### PR TITLE
Configure Travis to build with Xcode 6.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: objective-c
 xcode_workspace: Authenticator.xcworkspace
 xcode_scheme: Authenticator
 
-osx_image: xcode611
+osx_image: xcode6.4
 xcode_sdk:
-  - iphonesimulator8.1
+  - iphoneos8.4
+  - iphonesimulator8.4
 
 before_install:
   - export LANG=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ xcode_sdk:
 before_install:
   - export LANG=en_US.UTF-8
   - gem update cocoapods --no-document
-  - brew update
+  - brew update; brew update
   - brew upgrade xctool
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ xcode_sdk:
   - iphonesimulator8.4
 
 before_install:
-  - export LANG=en_US.UTF-8
+#  - export LANG=en_US.UTF-8
   - gem update cocoapods --no-document
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ xcode_scheme: Authenticator
 
 osx_image: xcode6.4
 xcode_sdk:
-  - iphoneos8.4
   - iphonesimulator8.4
 
 before_install:
   - export LANG=en_US.UTF-8
   - gem update cocoapods --no-document
-#  - brew update; brew update
-#  - brew upgrade xctool
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ xcode_sdk:
 before_install:
   - export LANG=en_US.UTF-8
   - gem update cocoapods --no-document
-  - brew update; brew update
-  - brew upgrade xctool
+#  - brew update; brew update
+#  - brew upgrade xctool
   - git submodule update --init --recursive

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ xcode_workspace: Authenticator.xcworkspace
 xcode_scheme: Authenticator
 
 osx_image: xcode6.4
-xcode_sdk:
-  - iphonesimulator8.4
+xcode_sdk: iphonesimulator8.4
 
 before_install:
-#  - export LANG=en_US.UTF-8
   - gem update cocoapods --no-document
   - git submodule update --init --recursive


### PR DESCRIPTION
Updated arguments from the [Travis Objective-C docs](http://docs.travis-ci.com/user/languages/objective-c/#Xcode-6.4) to build with Xcode 6.4 for the simulator running iOS 8.4. Also removed a few `before_install` commands which are no longer necessary on the new image.