### PR TITLE
Generic segmented control cell

### DIFF
--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -14,7 +14,7 @@ protocol OTPHeaderViewDelegate: class {
 }
 
 class OTPHeaderView: UIButton {
-    static let preferredHeight: CGFloat = 54
+    let preferredHeight: CGFloat = 54
 
     weak var delegate: OTPHeaderViewDelegate?
 

--- a/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
@@ -69,20 +69,20 @@ struct AlgorithmRowModel: SegmentedControlRowModel {
 }
 
 extension OTPSegmentedControlCell {
-    static func tokenTypeCell() -> Self {
-        let cell = self.init()
+    static func tokenTypeCell() -> OTPSegmentedControlCell<Int> {
+        let cell = OTPSegmentedControlCell<Int>.init()
         cell.updateWithRowModel(TokenTypeRowModel())
         return cell
     }
 
-    static func digitCountCell() -> Self {
-        let cell = self.init()
+    static func digitCountCell() -> OTPSegmentedControlCell<Int> {
+        let cell = OTPSegmentedControlCell<Int>.init()
         cell.updateWithRowModel(DigitCountRowModel())
         return cell
     }
 
-    static func algorithmCell() -> Self {
-        let cell = self.init()
+    static func algorithmCell() -> OTPSegmentedControlCell<Int> {
+        let cell = OTPSegmentedControlCell<Int>.init()
         cell.updateWithRowModel(AlgorithmRowModel())
         return cell
     }

--- a/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
@@ -22,25 +22,14 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-@objc
-enum OTPTokenTypeOption: Int {
-    case Timer
-    case Counter
-}
-
-@objc
-enum OTPTokenAlgorithmOption: Int {
-    case SHA1
-    case SHA256
-    case SHA512
-}
+import OneTimePasswordLegacy
 
 struct TokenTypeRowModel: SegmentedControlRowModel {
     let segments = [
-        (title: "Time Based", value: OTPTokenTypeOption.Timer.rawValue),
-        (title: "Counter Based", value: OTPTokenTypeOption.Counter.rawValue),
+        (title: "Time Based", value: OTPTokenType.Timer),
+        (title: "Counter Based", value: OTPTokenType.Counter),
     ]
-    let initialValue = OTPTokenTypeOption.Timer.rawValue
+    let initialValue = OTPTokenType.Timer
 }
 
 struct DigitCountRowModel: SegmentedControlRowModel {
@@ -54,16 +43,16 @@ struct DigitCountRowModel: SegmentedControlRowModel {
 
 struct AlgorithmRowModel: SegmentedControlRowModel {
     let segments = [
-        (title: "SHA-1", value: OTPTokenAlgorithmOption.SHA1.rawValue),
-        (title: "SHA-256", value: OTPTokenAlgorithmOption.SHA256.rawValue),
-        (title: "SHA-512", value: OTPTokenAlgorithmOption.SHA512.rawValue),
+        (title: "SHA-1", value: OTPAlgorithm.SHA1),
+        (title: "SHA-256", value: OTPAlgorithm.SHA256),
+        (title: "SHA-512", value: OTPAlgorithm.SHA512),
     ]
-    let initialValue = OTPTokenAlgorithmOption.SHA1.rawValue
+    let initialValue = OTPAlgorithm.SHA1
 }
 
 extension OTPSegmentedControlCell {
-    static func tokenTypeCell() -> OTPSegmentedControlCell<Int> {
-        let cell = OTPSegmentedControlCell<Int>.init()
+    static func tokenTypeCell() -> OTPSegmentedControlCell<OTPTokenType> {
+        let cell = OTPSegmentedControlCell<OTPTokenType>.init()
         cell.updateWithRowModel(TokenTypeRowModel())
         return cell
     }
@@ -74,8 +63,8 @@ extension OTPSegmentedControlCell {
         return cell
     }
 
-    static func algorithmCell() -> OTPSegmentedControlCell<Int> {
-        let cell = OTPSegmentedControlCell<Int>.init()
+    static func algorithmCell() -> OTPSegmentedControlCell<OTPAlgorithm> {
+        let cell = OTPSegmentedControlCell<OTPAlgorithm>.init()
         cell.updateWithRowModel(AlgorithmRowModel())
         return cell
     }

--- a/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
@@ -29,13 +29,6 @@ enum OTPTokenTypeOption: Int {
 }
 
 @objc
-enum OTPTokenDigitsOption: Int {
-    case Six
-    case Seven
-    case Eight
-}
-
-@objc
 enum OTPTokenAlgorithmOption: Int {
     case SHA1
     case SHA256
@@ -52,11 +45,11 @@ struct TokenTypeRowModel: SegmentedControlRowModel {
 
 struct DigitCountRowModel: SegmentedControlRowModel {
     let segments = [
-        (title: "6 Digits", value: OTPTokenDigitsOption.Six.rawValue),
-        (title: "7 Digits", value: OTPTokenDigitsOption.Seven.rawValue),
-        (title: "8 Digits", value: OTPTokenDigitsOption.Eight.rawValue),
+        (title: "6 Digits", value: 6),
+        (title: "7 Digits", value: 7),
+        (title: "8 Digits", value: 8),
     ]
-    let initialValue = OTPTokenDigitsOption.Six.rawValue
+    let initialValue = 6
 }
 
 struct AlgorithmRowModel: SegmentedControlRowModel {

--- a/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
@@ -52,20 +52,14 @@ struct AlgorithmRowModel: SegmentedControlRowModel {
 
 extension OTPSegmentedControlCell {
     static func tokenTypeCell() -> OTPSegmentedControlCell<OTPTokenType> {
-        let cell = OTPSegmentedControlCell<OTPTokenType>.init()
-        cell.updateWithRowModel(TokenTypeRowModel())
-        return cell
+        return OTPSegmentedControlCell<OTPTokenType>(rowModel: TokenTypeRowModel())
     }
 
     static func digitCountCell() -> OTPSegmentedControlCell<Int> {
-        let cell = OTPSegmentedControlCell<Int>.init()
-        cell.updateWithRowModel(DigitCountRowModel())
-        return cell
+        return OTPSegmentedControlCell<Int>(rowModel: DigitCountRowModel())
     }
 
     static func algorithmCell() -> OTPSegmentedControlCell<OTPAlgorithm> {
-        let cell = OTPSegmentedControlCell<OTPAlgorithm>.init()
-        cell.updateWithRowModel(AlgorithmRowModel())
-        return cell
+        return OTPSegmentedControlCell<OTPAlgorithm>(rowModel: AlgorithmRowModel())
     }
 }

--- a/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
@@ -49,17 +49,3 @@ struct AlgorithmRowModel: SegmentedControlRowModel {
     ]
     let initialValue = OTPAlgorithm.SHA1
 }
-
-extension OTPSegmentedControlCell {
-    static func tokenTypeCell() -> OTPSegmentedControlCell<OTPTokenType> {
-        return OTPSegmentedControlCell<OTPTokenType>(rowModel: TokenTypeRowModel())
-    }
-
-    static func digitCountCell() -> OTPSegmentedControlCell<Int> {
-        return OTPSegmentedControlCell<Int>(rowModel: DigitCountRowModel())
-    }
-
-    static func algorithmCell() -> OTPSegmentedControlCell<OTPAlgorithm> {
-        return OTPSegmentedControlCell<OTPAlgorithm>(rowModel: AlgorithmRowModel())
-    }
-}

--- a/Authenticator/Classes/OTPSegmentedControlCell.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell.swift
@@ -30,13 +30,13 @@ protocol SegmentedControlRowModel {
     var initialValue: Value { get }
 }
 
-class OTPSegmentedControlCell: UITableViewCell {
-    static let preferredHeight: CGFloat = 54
+class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
+    let preferredHeight: CGFloat = 54
 
     private let segmentedControl = UISegmentedControl()
-    private var values: [Int] = []
+    private var values: [Value] = []
 
-    var value: Int {
+    var value: Value {
         return values[segmentedControl.selectedSegmentIndex]
     }
 
@@ -65,7 +65,7 @@ class OTPSegmentedControlCell: UITableViewCell {
 
     // MARK: - Update
 
-    func updateWithRowModel<M: SegmentedControlRowModel where M.Value == Int>(rowModel: M) {
+    func updateWithRowModel<M: SegmentedControlRowModel where M.Value == Value>(rowModel: M) {
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments
@@ -77,6 +77,5 @@ class OTPSegmentedControlCell: UITableViewCell {
         values = rowModel.segments.map { $0.value }
         // Select the initial value
         segmentedControl.selectedSegmentIndex = values.indexOf(rowModel.initialValue) ?? 0
-
     }
 }

--- a/Authenticator/Classes/OTPSegmentedControlCell.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell.swift
@@ -25,8 +25,9 @@
 import UIKit
 
 protocol SegmentedControlRowModel {
-    var segments: [(title: String, value: Int)] { get }
-    var initialValue: Int { get }
+    typealias Value
+    var segments: [(title: String, value: Value)] { get }
+    var initialValue: Value { get }
 }
 
 class OTPSegmentedControlCell: UITableViewCell {
@@ -64,7 +65,7 @@ class OTPSegmentedControlCell: UITableViewCell {
 
     // MARK: - Update
 
-    func updateWithRowModel(rowModel: SegmentedControlRowModel) {
+    func updateWithRowModel<M: SegmentedControlRowModel where M.Value == Int>(rowModel: M) {
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments

--- a/Authenticator/Classes/OTPSegmentedControlCell.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell.swift
@@ -52,6 +52,11 @@ class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
         configureSubviews()
     }
 
+    convenience init<RowModel: SegmentedControlRowModel where RowModel.Value == Value>(rowModel: RowModel) {
+        self.init()
+        updateWithRowModel(rowModel)
+    }
+
     // MARK: - Subviews
 
     private func configureSubviews() {
@@ -65,7 +70,7 @@ class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
 
     // MARK: - Update
 
-    func updateWithRowModel<M: SegmentedControlRowModel where M.Value == Value>(rowModel: M) {
+    func updateWithRowModel<RowModel: SegmentedControlRowModel where RowModel.Value == Value>(rowModel: RowModel) {
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -41,7 +41,7 @@ protocol OTPTextFieldCellDelegate: class {
 }
 
 class OTPTextFieldCell: UITableViewCell {
-    static let preferredHeight: CGFloat = 74
+    let preferredHeight: CGFloat = 74
 
     let textField = UITextField()
     weak var delegate: OTPTextFieldCellDelegate?

--- a/Authenticator/Classes/OTPTokenFormViewController.m
+++ b/Authenticator/Classes/OTPTokenFormViewController.m
@@ -136,8 +136,8 @@
 - (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell = [self.form cellForRowAtIndexPath:indexPath];
-    if ([[cell class] respondsToSelector:@selector(preferredHeight)]) {
-        return [[cell class] preferredHeight];
+    if ([cell respondsToSelector:@selector(preferredHeight)]) {
+        return [(id)cell preferredHeight];
     }
     return 0;
 }
@@ -145,8 +145,8 @@
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     UIView *headerView = [self.form viewForHeaderInSection:section];
-    if (headerView && [[headerView class] respondsToSelector:@selector(preferredHeight)]) {
-        return [[headerView class] preferredHeight];
+    if (headerView && [headerView respondsToSelector:@selector(preferredHeight)]) {
+        return [(id)headerView preferredHeight];
     }
     return FLT_EPSILON;
 }

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -63,22 +63,13 @@ class TokenEntryForm: NSObject, TokenForm {
         return secretKeyCell.textField.text ?? ""
     }
     var tokenType: OTPTokenType {
-        return (tokenTypeCell.value == OTPTokenTypeOption.Timer.rawValue) ? .Timer : .Counter
+        return tokenTypeCell.value
     }
     var digitCount: UInt {
         return UInt(digitCountCell.value)
     }
     var algorithm: OTPAlgorithm {
-        switch algorithmCell.value {
-        case OTPTokenAlgorithmOption.SHA1.rawValue:
-            return .SHA1
-        case OTPTokenAlgorithmOption.SHA256.rawValue:
-            return .SHA256
-        case OTPTokenAlgorithmOption.SHA512.rawValue:
-            return .SHA512
-        default:
-            return .SHA1 // FIXME: this should never need a default
-        }
+        return algorithmCell.value
     }
 
     let title = "Add Token"

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -66,16 +66,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return (tokenTypeCell.value == OTPTokenTypeOption.Timer.rawValue) ? .Timer : .Counter
     }
     var digitCount: UInt {
-        switch digitCountCell.value {
-        case OTPTokenDigitsOption.Six.rawValue:
-            return 6
-        case OTPTokenDigitsOption.Seven.rawValue:
-            return 7
-        case OTPTokenDigitsOption.Eight.rawValue:
-            return 8
-        default:
-            return 6 // FIXME: this should never need a default
-        }
+        return UInt(digitCountCell.value)
     }
     var algorithm: OTPAlgorithm {
         switch algorithmCell.value {

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -28,9 +28,9 @@ class TokenEntryForm: NSObject, TokenForm {
     private lazy var secretKeyCell: OTPTextFieldCell = {
         OTPTextFieldCell.secretCellWithDelegate(self)
     }()
-    private var tokenTypeCell = OTPSegmentedControlCell<Int>.tokenTypeCell()
-    private var digitCountCell = OTPSegmentedControlCell<Int>.digitCountCell()
-    private var algorithmCell = OTPSegmentedControlCell<Int>.algorithmCell()
+    private var tokenTypeCell: OTPSegmentedControlCell<OTPTokenType> = .tokenTypeCell()
+    private var digitCountCell: OTPSegmentedControlCell<Int> = .digitCountCell()
+    private var algorithmCell: OTPSegmentedControlCell<OTPAlgorithm> = .algorithmCell()
     private lazy var advancedSectionHeaderView: OTPHeaderView = {
         let headerView = OTPHeaderView()
         headerView.updateWithTitle("Advanced Options")

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -28,15 +28,9 @@ class TokenEntryForm: NSObject, TokenForm {
     private lazy var secretKeyCell: OTPTextFieldCell = {
         OTPTextFieldCell.secretCellWithDelegate(self)
     }()
-    private lazy var tokenTypeCell: OTPSegmentedControlCell = {
-        OTPSegmentedControlCell.tokenTypeCell()
-    }()
-    private lazy var digitCountCell: OTPSegmentedControlCell = {
-        OTPSegmentedControlCell.digitCountCell()
-    }()
-    private lazy var algorithmCell: OTPSegmentedControlCell = {
-        OTPSegmentedControlCell.algorithmCell()
-    }()
+    private var tokenTypeCell = OTPSegmentedControlCell<Int>.tokenTypeCell()
+    private var digitCountCell = OTPSegmentedControlCell<Int>.digitCountCell()
+    private var algorithmCell = OTPSegmentedControlCell<Int>.algorithmCell()
     private lazy var advancedSectionHeaderView: OTPHeaderView = {
         let headerView = OTPHeaderView()
         headerView.updateWithTitle("Advanced Options")

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -28,9 +28,9 @@ class TokenEntryForm: NSObject, TokenForm {
     private lazy var secretKeyCell: OTPTextFieldCell = {
         OTPTextFieldCell.secretCellWithDelegate(self)
     }()
-    private var tokenTypeCell: OTPSegmentedControlCell<OTPTokenType> = .tokenTypeCell()
-    private var digitCountCell: OTPSegmentedControlCell<Int> = .digitCountCell()
-    private var algorithmCell: OTPSegmentedControlCell<OTPAlgorithm> = .algorithmCell()
+    private var tokenTypeCell = OTPSegmentedControlCell<OTPTokenType>(rowModel: TokenTypeRowModel())
+    private var digitCountCell = OTPSegmentedControlCell<Int>(rowModel: DigitCountRowModel())
+    private var algorithmCell = OTPSegmentedControlCell<OTPAlgorithm>(rowModel: AlgorithmRowModel())
     private lazy var advancedSectionHeaderView: OTPHeaderView = {
         let headerView = OTPHeaderView()
         headerView.updateWithTitle("Advanced Options")


### PR DESCRIPTION
Genericizes `OTPSegmentedControlCell` and `SegmentedControlRowModel` for an equatable `Value` type.
Also converts `preferredHeight` to a property on cell instances, since static stored properties aren't supported on generic types.