### PR TITLE
Swift protocols

### DIFF
--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -24,7 +24,6 @@
 
 import UIKit
 
-@objc
 protocol OTPHeaderViewDelegate: class {
     func headerViewButtonWasPressed(headerView: OTPHeaderView)
 }

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -34,7 +34,6 @@ protocol TextFieldRowModel {
     var returnKeyType: UIReturnKeyType { get }
 }
 
-@objc
 protocol OTPTextFieldCellDelegate: class {
     func textFieldCellDidChange(textFieldCell: OTPTextFieldCell)
     func textFieldCellDidReturn(textFieldCell: OTPTextFieldCell)

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -39,7 +39,7 @@ class TokenEditForm: NSObject, TokenForm {
         OTPTextFieldCell.nameCellWithDelegate(self, returnKeyType: .Done)
     }()
 
-    private var sections: [Section] {
+    var sections: [Section] {
         return [
             [
                 issuerCell,
@@ -67,31 +67,6 @@ class TokenEditForm: NSObject, TokenForm {
     func unfocus() {
         issuerCell.textField.resignFirstResponder()
         accountNameCell.textField.resignFirstResponder()
-    }
-
-    var numberOfSections: Int {
-        return sections.count
-    }
-
-    func numberOfRowsInSection(section: Int) -> Int {
-        guard sections.indices.contains(section)
-            else { return 0 }
-        return sections[section].rows.count
-    }
-
-    func cellForRowAtIndexPath(indexPath: NSIndexPath) -> UITableViewCell? {
-        guard sections.indices.contains(indexPath.section)
-            else { return nil }
-        let section = sections[indexPath.section]
-        guard section.rows.indices.contains(indexPath.row)
-            else { return nil }
-        return section.rows[indexPath.row]
-    }
-
-    func viewForHeaderInSection(section: Int) -> UIView? {
-        guard sections.indices.contains(section)
-            else { return nil }
-        return sections[section].header
     }
 
     private var issuer: String {

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -60,7 +60,7 @@ class TokenEntryForm: NSObject, TokenForm {
         self.delegate = delegate
     }
 
-    private var sections: [Section] {
+    var sections: [Section] {
         return [
             [ self.issuerCell, self.accountNameCell , self.secretKeyCell ],
             showsAdvancedOptions
@@ -89,31 +89,6 @@ class TokenEntryForm: NSObject, TokenForm {
     }
 
     let title = "Add Token"
-
-    var numberOfSections: Int {
-        return sections.count
-    }
-
-    func numberOfRowsInSection(section: Int) -> Int {
-        guard sections.indices.contains(section)
-            else { return 0 }
-        return sections[section].rows.count
-    }
-
-    func cellForRowAtIndexPath(indexPath: NSIndexPath) -> UITableViewCell? {
-        guard sections.indices.contains(indexPath.section)
-            else { return nil }
-        let section = sections[indexPath.section]
-        guard section.rows.indices.contains(indexPath.row)
-            else { return nil }
-        return section.rows[indexPath.row]
-    }
-
-    func viewForHeaderInSection(section: Int) -> UIView? {
-        guard sections.indices.contains(section)
-            else { return nil }
-        return sections[section].header
-    }
 
     func focusFirstField() {
         issuerCell.textField.becomeFirstResponder()

--- a/Authenticator/Classes/TokenForm.swift
+++ b/Authenticator/Classes/TokenForm.swift
@@ -24,17 +24,10 @@
 
 import OneTimePasswordLegacy
 
-protocol TableViewModel {
+protocol TokenForm {
     var title: String { get }
     var sections: [Section] { get }
 
-    var numberOfSections: Int { get }
-    func numberOfRowsInSection(section: Int) -> Int
-    func cellForRowAtIndexPath(indexPath: NSIndexPath) -> UITableViewCell?
-    func viewForHeaderInSection(section:Int) -> UIView?
-}
-
-protocol TokenForm: TableViewModel {
     weak var presenter: TokenFormPresenter? { get set }
 
     func focusFirstField()
@@ -51,7 +44,7 @@ protocol TokenFormPresenter: class {
 }
 
 
-extension TableViewModel {
+extension TokenForm {
     var numberOfSections: Int {
         return sections.count
     }

--- a/Authenticator/Classes/TokenForm.swift
+++ b/Authenticator/Classes/TokenForm.swift
@@ -24,7 +24,6 @@
 
 import OneTimePasswordLegacy
 
-@objc
 protocol TableViewModel {
     var title: String { get }
     var numberOfSections: Int { get }
@@ -33,7 +32,6 @@ protocol TableViewModel {
     func viewForHeaderInSection(section:Int) -> UIView?
 }
 
-@objc
 protocol TokenForm: TableViewModel {
     weak var presenter: TokenFormPresenter? { get set }
 
@@ -44,7 +42,6 @@ protocol TokenForm: TableViewModel {
     func submit()
 }
 
-@objc
 protocol TokenFormPresenter: class {
     func formValuesDidChange(form: TokenForm)
     func form(form: TokenForm, didFailWithErrorMessage errorMessage: String)

--- a/Authenticator/Classes/TokenForm.swift
+++ b/Authenticator/Classes/TokenForm.swift
@@ -26,6 +26,8 @@ import OneTimePasswordLegacy
 
 protocol TableViewModel {
     var title: String { get }
+    var sections: [Section] { get }
+
     var numberOfSections: Int { get }
     func numberOfRowsInSection(section: Int) -> Int
     func cellForRowAtIndexPath(indexPath: NSIndexPath) -> UITableViewCell?
@@ -46,4 +48,32 @@ protocol TokenFormPresenter: class {
     func formValuesDidChange(form: TokenForm)
     func form(form: TokenForm, didFailWithErrorMessage errorMessage: String)
     func form(form: TokenForm, didReloadSection section: Int)
+}
+
+
+extension TableViewModel {
+    var numberOfSections: Int {
+        return sections.count
+    }
+
+    func numberOfRowsInSection(section: Int) -> Int {
+        guard sections.indices.contains(section)
+            else { return 0 }
+        return sections[section].rows.count
+    }
+
+    func cellForRowAtIndexPath(indexPath: NSIndexPath) -> UITableViewCell? {
+        guard sections.indices.contains(indexPath.section)
+            else { return nil }
+        let section = sections[indexPath.section]
+        guard section.rows.indices.contains(indexPath.row)
+            else { return nil }
+        return section.rows[indexPath.row]
+    }
+
+    func viewForHeaderInSection(section: Int) -> UIView? {
+        guard sections.indices.contains(section)
+            else { return nil }
+        return sections[section].header
+    }
 }

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -28,8 +28,9 @@ class TokenFormViewController: UITableViewController {
 
     init(form: TokenForm) {
         super.init(style: .Grouped)
-        self.form = form
-        form.presenter = self
+        var presentedForm = form
+        presentedForm.presenter = self
+        self.form = presentedForm
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Remove `objc` specifier from protocols, and consolidate table view support methods into an extension on the `TokenForm` protocol.