### PR TITLE
Header view models

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C944A5571A7ECB0800E08B1E /* OneTimePassword.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C944A5561A7ECB0800E08B1E /* OneTimePassword.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C944A5591A7ECB3100E08B1E /* Base32.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C944A5581A7ECB3100E08B1E /* Base32.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C97B68C717D9226D005D1FE0 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = C97B68C617D9226D005D1FE0 /* Settings.bundle */; };
+		C9800C491BCAA81D00CCB9B7 /* HeaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9800C481BCAA81D00CCB9B7 /* HeaderViewModel.swift */; settings = {ASSET_TAGS = (); }; };
 		C983AB74197F98FC00975003 /* OTPAuthenticatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C983AB73197F98FC00975003 /* OTPAuthenticatorTests.m */; };
 		C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1EC91AB2CEC300C59E53 /* TokenRowModel.swift */; };
 		C98B1ECC1AB3CF0700C59E53 /* TokenRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */; };
@@ -99,6 +100,7 @@
 		C959A63E190A69E60042DEC0 /* GenerateIcons.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = GenerateIcons.sh; sourceTree = "<group>"; };
 		C9776E3318518801003D53CB /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		C97B68C617D9226D005D1FE0 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		C9800C481BCAA81D00CCB9B7 /* HeaderViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderViewModel.swift; sourceTree = "<group>"; };
 		C983AB73197F98FC00975003 /* OTPAuthenticatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTPAuthenticatorTests.m; sourceTree = "<group>"; };
 		C98B1EC91AB2CEC300C59E53 /* TokenRowModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenRowModel.swift; sourceTree = "<group>"; };
 		C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenRowCell.swift; sourceTree = "<group>"; };
@@ -351,6 +353,7 @@
 				C9CC09541BA91D1C008C54FE /* TableViewModel.swift */,
 				C99B85241BC9AB7100A6C75D /* BarButtonViewModel.swift */,
 				C9919CE11BA733FD006237C1 /* Section.swift */,
+				C9800C481BCAA81D00CCB9B7 /* HeaderViewModel.swift */,
 			);
 			name = "View Models";
 			sourceTree = "<group>";
@@ -544,6 +547,7 @@
 				C9919CE01BA721A1006237C1 /* OTPHeaderView.swift in Sources */,
 				C9AAB0811B9187F8000CE547 /* TokenForm.swift in Sources */,
 				C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */,
+				C9800C491BCAA81D00CCB9B7 /* HeaderViewModel.swift in Sources */,
 				C99B85251BC9AB7100A6C75D /* BarButtonViewModel.swift in Sources */,
 				C9AAB0791B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift in Sources */,
 				1D3623260D0F684500981E51 /* OTPAppDelegate.swift in Sources */,

--- a/Authenticator/Classes/HeaderViewModel.swift
+++ b/Authenticator/Classes/HeaderViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  OTPHeaderView.swift
+//  HeaderViewModel.swift
 //  Authenticator
 //
 //  Copyright (c) 2015 Matt Rubin
@@ -22,49 +22,12 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import UIKit
+struct HeaderViewModel {
+    let title: String
+    let action: (() -> ())?
 
-class OTPHeaderView: UIButton {
-    private static let preferredHeight: CGFloat = 54
-
-    private var buttonAction: (() -> ())?
-
-    // MARK: - Init
-
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-        configureSubviews()
-    }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        configureSubviews()
-    }
-
-    // MARK: - Subviews
-
-    private func configureSubviews() {
-        titleLabel?.textAlignment = .Center
-        titleLabel?.textColor = UIColor.otpForegroundColor
-        titleLabel?.font = UIFont(name: "HelveticaNeue-Light", size: 16)
-
-        addTarget(self, action: Selector("buttonWasPressed"), forControlEvents: .TouchUpInside)
-    }
-
-    // MARK: - Update
-
-    func updateWithViewModel(viewModel: HeaderViewModel) {
-        setTitle(viewModel.title, forState: .Normal)
-        buttonAction = viewModel.action
-    }
-
-    static func heightWithViewModel(viewModel: HeaderViewModel) -> CGFloat {
-        return preferredHeight
-    }
-
-    // MARK: - Target Action
-
-    func buttonWasPressed() {
-        buttonAction?()
+    init(title: String, action: (() -> ())? = nil) {
+        self.title = title
+        self.action = action
     }
 }

--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -51,7 +51,12 @@ class OTPHeaderView: UIButton {
         addTarget(self, action: Selector("buttonWasPressed"), forControlEvents: .TouchUpInside)
     }
 
-    // MARK: - Update
+    // MARK: - View Model
+
+    convenience init(viewModel: HeaderViewModel) {
+        self.init()
+        updateWithViewModel(viewModel)
+    }
 
     func updateWithViewModel(viewModel: HeaderViewModel) {
         setTitle(viewModel.title, forState: .Normal)

--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -57,8 +57,8 @@ class OTPHeaderView: UIButton {
 
     // MARK: - Update
 
-    func updateWithTitle(title: String) {
-        setTitle("Advanced Options", forState: .Normal)
+    func updateWithViewModel(viewModel: Section.Header) {
+        setTitle(viewModel.title, forState: .Normal)
     }
 
     // MARK: - Target Action

--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -25,7 +25,7 @@
 import UIKit
 
 class OTPHeaderView: UIButton {
-    static let preferredHeight: CGFloat = 54
+    private static let preferredHeight: CGFloat = 54
 
     private var buttonAction: (() -> ())?
 
@@ -56,6 +56,10 @@ class OTPHeaderView: UIButton {
     func updateWithViewModel(viewModel: Section.Header) {
         setTitle(viewModel.title, forState: .Normal)
         buttonAction = viewModel.action
+    }
+
+    static func heightWithViewModel(viewModel: Section.Header) -> CGFloat {
+        return preferredHeight
     }
 
     // MARK: - Target Action

--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -28,8 +28,8 @@ protocol OTPHeaderViewDelegate: class {
     func headerViewButtonWasPressed(headerView: OTPHeaderView)
 }
 
-class OTPHeaderView: UIButton, OTPCell {
-    let preferredHeight: CGFloat = 54
+class OTPHeaderView: UIButton {
+    static let preferredHeight: CGFloat = 54
 
     weak var delegate: OTPHeaderViewDelegate?
 

--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -24,14 +24,10 @@
 
 import UIKit
 
-protocol OTPHeaderViewDelegate: class {
-    func headerViewButtonWasPressed(headerView: OTPHeaderView)
-}
-
 class OTPHeaderView: UIButton {
     static let preferredHeight: CGFloat = 54
 
-    weak var delegate: OTPHeaderViewDelegate?
+    private var buttonAction: (() -> ())?
 
     // MARK: - Init
 
@@ -59,11 +55,12 @@ class OTPHeaderView: UIButton {
 
     func updateWithViewModel(viewModel: Section.Header) {
         setTitle(viewModel.title, forState: .Normal)
+        buttonAction = viewModel.action
     }
 
     // MARK: - Target Action
 
     func buttonWasPressed() {
-        delegate?.headerViewButtonWasPressed(self)
+        buttonAction?()
     }
 }

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -27,6 +27,12 @@ import UIKit
 struct Section {
     struct Header {
         let title: String
+        let action: (() -> ())?
+
+        init(title: String, action: (() -> ())? = nil) {
+            self.title = title
+            self.action = action
+        }
     }
 
     typealias Row = UITableViewCell

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -25,7 +25,10 @@
 import UIKit
 
 struct Section {
-    typealias Header = UIView
+    struct Header {
+        let title: String
+    }
+
     typealias Row = UITableViewCell
 
     let header: Header?

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -25,7 +25,6 @@
 import UIKit
 
 struct Section {
-
     typealias Row = UITableViewCell
 
     let header: HeaderViewModel?

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -25,22 +25,13 @@
 import UIKit
 
 struct Section {
-    struct Header {
-        let title: String
-        let action: (() -> ())?
-
-        init(title: String, action: (() -> ())? = nil) {
-            self.title = title
-            self.action = action
-        }
-    }
 
     typealias Row = UITableViewCell
 
-    let header: Header?
+    let header: HeaderViewModel?
     let rows: [Row]
 
-    init(header: Header? = nil, rows: [Row] = []) {
+    init(header: HeaderViewModel? = nil, rows: [Row] = []) {
         self.header = header
         self.rows = rows
     }

--- a/Authenticator/Classes/TableViewModel.swift
+++ b/Authenticator/Classes/TableViewModel.swift
@@ -60,7 +60,7 @@ extension TableViewModel {
         return section.rows[indexPath.row]
     }
 
-    func headerForSection(section: Int) -> Section.Header? {
+    func headerForSection(section: Int) -> HeaderViewModel? {
         guard sections.indices.contains(section)
             else { return nil }
         return sections[section].header

--- a/Authenticator/Classes/TableViewModel.swift
+++ b/Authenticator/Classes/TableViewModel.swift
@@ -48,7 +48,7 @@ extension TableViewModel {
         return section.rows[indexPath.row]
     }
 
-    func viewForHeaderInSection(section: Int) -> UIView? {
+    func headerForSection(section: Int) -> Section.Header? {
         guard sections.indices.contains(section)
             else { return nil }
         return sections[section].header

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -47,7 +47,11 @@ class TokenEntryForm: NSObject, TokenForm {
     private var tokenTypeCell = OTPSegmentedControlCell<OTPTokenType>(rowModel: TokenTypeRowModel())
     private var digitCountCell = OTPSegmentedControlCell<Int>(rowModel: DigitCountRowModel())
     private var algorithmCell = OTPSegmentedControlCell<OTPAlgorithm>(rowModel: AlgorithmRowModel())
-    private let advancedSectionHeader = Section.Header(title: "Advanced Options")
+    private var advancedSectionHeader: Section.Header {
+        return Section.Header(title: "Advanced Options") { [weak self] in
+            self?.toggleAdvancedOptions()
+        }
+    }
 
     var showsAdvancedOptions = false
 
@@ -143,8 +147,8 @@ extension TokenEntryForm: OTPTextFieldCellDelegate {
     }
 }
 
-extension TokenEntryForm: OTPHeaderViewDelegate {
-    func headerViewButtonWasPressed(headerView: OTPHeaderView) {
+extension TokenEntryForm {
+    func toggleAdvancedOptions() {
         if (!showsAdvancedOptions) {
             showsAdvancedOptions = true
             // TODO: Don't hard-code this index

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -47,12 +47,7 @@ class TokenEntryForm: NSObject, TokenForm {
     private var tokenTypeCell = OTPSegmentedControlCell<OTPTokenType>(rowModel: TokenTypeRowModel())
     private var digitCountCell = OTPSegmentedControlCell<Int>(rowModel: DigitCountRowModel())
     private var algorithmCell = OTPSegmentedControlCell<OTPAlgorithm>(rowModel: AlgorithmRowModel())
-    private lazy var advancedSectionHeaderView: OTPHeaderView = {
-        let headerView = OTPHeaderView()
-        headerView.updateWithTitle("Advanced Options")
-        headerView.delegate = self
-        return headerView
-    }()
+    private let advancedSectionHeader = Section.Header(title: "Advanced Options")
 
     var showsAdvancedOptions = false
 
@@ -66,8 +61,8 @@ class TokenEntryForm: NSObject, TokenForm {
             sections: [
                 [ self.issuerCell, self.accountNameCell , self.secretKeyCell ],
                 showsAdvancedOptions
-                    ? Section(header: advancedSectionHeaderView, rows: [ self.tokenTypeCell, self.digitCountCell, self.algorithmCell ])
-                    : Section(header: advancedSectionHeaderView),
+                    ? Section(header: advancedSectionHeader, rows: [ self.tokenTypeCell, self.digitCountCell, self.algorithmCell ])
+                    : Section(header: advancedSectionHeader),
             ],
             doneButtonEnabled: isValid
         )

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -48,8 +48,8 @@ class TokenEntryForm: NSObject, TokenForm {
     private var tokenTypeCell = OTPSegmentedControlCell<OTPTokenType>(rowModel: TokenTypeRowModel())
     private var digitCountCell = OTPSegmentedControlCell<Int>(rowModel: DigitCountRowModel())
     private var algorithmCell = OTPSegmentedControlCell<OTPAlgorithm>(rowModel: AlgorithmRowModel())
-    private var advancedSectionHeader: Section.Header {
-        return Section.Header(title: "Advanced Options") { [weak self] in
+    private var advancedSectionHeader: HeaderViewModel {
+        return HeaderViewModel(title: "Advanced Options") { [weak self] in
             self?.toggleAdvancedOptions()
         }
     }

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -124,7 +124,7 @@ class TokenFormViewController: UITableViewController {
         guard let header = viewModel.headerForSection(section)
             else { return nil }
         let headerView = OTPHeaderView()
-        headerView.updateWithTitle(header.title)
+        headerView.updateWithViewModel(header)
         headerView.delegate = self
         return headerView
     }

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -115,9 +115,9 @@ class TokenFormViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard viewModel.headerForSection(section) != nil
+        guard let header = viewModel.headerForSection(section)
             else { return CGFloat(FLT_EPSILON) }
-        return OTPHeaderView.preferredHeight
+        return OTPHeaderView.heightWithViewModel(header)
     }
 
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -114,9 +114,7 @@ class TokenFormViewController: UITableViewController {
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerViewModel = viewModel.headerForSection(section)
             else { return nil }
-        let headerView = OTPHeaderView()
-        headerView.updateWithViewModel(headerViewModel)
-        return headerView
+        return OTPHeaderView(viewModel: headerViewModel)
     }
 
     // MARK: - Update

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -106,16 +106,16 @@ class TokenFormViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let header = viewModel.headerForSection(section)
+        guard let headerViewModel = viewModel.headerForSection(section)
             else { return CGFloat(FLT_EPSILON) }
-        return OTPHeaderView.heightWithViewModel(header)
+        return OTPHeaderView.heightWithViewModel(headerViewModel)
     }
 
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let header = viewModel.headerForSection(section)
+        guard let headerViewModel = viewModel.headerForSection(section)
             else { return nil }
         let headerView = OTPHeaderView()
-        headerView.updateWithViewModel(header)
+        headerView.updateWithViewModel(headerViewModel)
         return headerView
     }
 

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -125,7 +125,6 @@ class TokenFormViewController: UITableViewController {
             else { return nil }
         let headerView = OTPHeaderView()
         headerView.updateWithViewModel(header)
-        headerView.delegate = self
         return headerView
     }
 
@@ -153,14 +152,6 @@ extension TokenFormViewController: TokenFormPresenter {
         tableView.scrollToRowAtIndexPath(NSIndexPath(forRow: 0, inSection: section),
             atScrollPosition: .Top,
             animated: true)
-    }
-}
-
-extension TokenFormViewController: OTPHeaderViewDelegate {
-    func headerViewButtonWasPressed(headerView: OTPHeaderView) {
-        if let form = form as? OTPHeaderViewDelegate {
-            form.headerViewButtonWasPressed(headerView)
-        }
     }
 }
 

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -115,13 +115,18 @@ class TokenFormViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let headerView = viewModel.viewForHeaderInSection(section) as? OTPCell
+        guard viewModel.headerForSection(section) != nil
             else { return CGFloat(FLT_EPSILON) }
-        return headerView.preferredHeight
+        return OTPHeaderView.preferredHeight
     }
 
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        return viewModel.viewForHeaderInSection(section)
+        guard let header = viewModel.headerForSection(section)
+            else { return nil }
+        let headerView = OTPHeaderView()
+        headerView.updateWithTitle(header.title)
+        headerView.delegate = self
+        return headerView
     }
 
     // MARK: - Validation
@@ -148,6 +153,14 @@ extension TokenFormViewController: TokenFormPresenter {
         tableView.scrollToRowAtIndexPath(NSIndexPath(forRow: 0, inSection: section),
             atScrollPosition: .Top,
             animated: true)
+    }
+}
+
+extension TokenFormViewController: OTPHeaderViewDelegate {
+    func headerViewButtonWasPressed(headerView: OTPHeaderView) {
+        if let form = form as? OTPHeaderViewDelegate {
+            form.headerViewButtonWasPressed(headerView)
+        }
     }
 }
 


### PR DESCRIPTION
Add `HeaderViewModel` and use it to configure `OTPHeaderView`. `OTPHeaderViewDelegate` is replaced by an action closure.