### PR TITLE
Text field row models

### DIFF
--- a/Authenticator/Classes/OTPTextFieldCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPTextFieldCell+TokenForm.swift
@@ -30,6 +30,12 @@ struct IssuerRowModel: TextFieldRowModel {
     let autocorrectionType: UITextAutocorrectionType = .Default
     let keyboardType: UIKeyboardType = .Default
     let returnKeyType: UIReturnKeyType = .Next
+
+    let changeAction: (String) -> ()
+
+    init(changeAction: (String) -> ()) {
+        self.changeAction = changeAction
+    }
 }
 
 struct NameRowModel: TextFieldRowModel {
@@ -41,8 +47,11 @@ struct NameRowModel: TextFieldRowModel {
     let keyboardType: UIKeyboardType = .EmailAddress
     let returnKeyType: UIReturnKeyType
 
-    init(returnKeyType: UIReturnKeyType) {
+    let changeAction: (String) -> ()
+
+    init(returnKeyType: UIReturnKeyType, changeAction: (String) -> ()) {
         self.returnKeyType = returnKeyType
+        self.changeAction = changeAction
     }
 }
 
@@ -54,4 +63,10 @@ struct SecretRowModel: TextFieldRowModel {
     let autocorrectionType: UITextAutocorrectionType = .No
     let keyboardType: UIKeyboardType = .Default
     let returnKeyType: UIReturnKeyType = .Done
+
+    let changeAction: (String) -> ()
+
+    init(changeAction: (String) -> ()) {
+        self.changeAction = changeAction
+    }
 }

--- a/Authenticator/Classes/OTPTextFieldCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPTextFieldCell+TokenForm.swift
@@ -55,25 +55,3 @@ struct SecretRowModel: TextFieldRowModel {
     let keyboardType: UIKeyboardType = .Default
     let returnKeyType: UIReturnKeyType = .Done
 }
-
-
-extension OTPTextFieldCell {
-    static func issuerCellWithDelegate(delegate: OTPTextFieldCellDelegate) -> OTPTextFieldCell {
-        return cellWithRowModel(IssuerRowModel(), delegate: delegate)
-    }
-
-    static func nameCellWithDelegate(delegate: OTPTextFieldCellDelegate, returnKeyType: UIReturnKeyType) -> OTPTextFieldCell {
-        return cellWithRowModel(NameRowModel(returnKeyType: returnKeyType), delegate: delegate)
-    }
-
-    static func secretCellWithDelegate(delegate: OTPTextFieldCellDelegate) -> OTPTextFieldCell {
-        return cellWithRowModel(SecretRowModel(), delegate: delegate)
-    }
-
-    static func cellWithRowModel(rowModel: TextFieldRowModel, delegate: OTPTextFieldCellDelegate) -> OTPTextFieldCell {
-        let cell = OTPTextFieldCell()
-        cell.updateWithRowModel(rowModel)
-        cell.delegate = delegate
-        return cell
-    }
-}

--- a/Authenticator/Classes/OTPTextFieldCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPTextFieldCell+TokenForm.swift
@@ -25,6 +25,7 @@
 struct IssuerRowModel: TextFieldRowModel {
     let label = "Issuer"
     let placeholder = "Some Website"
+    let initialValue: String
 
     let autocapitalizationType: UITextAutocapitalizationType = .Words
     let autocorrectionType: UITextAutocorrectionType = .Default
@@ -33,7 +34,8 @@ struct IssuerRowModel: TextFieldRowModel {
 
     let changeAction: (String) -> ()
 
-    init(changeAction: (String) -> ()) {
+    init(initialValue: String = "", changeAction: (String) -> ()) {
+        self.initialValue = initialValue
         self.changeAction = changeAction
     }
 }
@@ -41,6 +43,7 @@ struct IssuerRowModel: TextFieldRowModel {
 struct NameRowModel: TextFieldRowModel {
     let label = "Account Name"
     let placeholder = "user@example.com"
+    let initialValue: String
 
     let autocapitalizationType: UITextAutocapitalizationType = .None
     let autocorrectionType: UITextAutocorrectionType = .No
@@ -49,7 +52,8 @@ struct NameRowModel: TextFieldRowModel {
 
     let changeAction: (String) -> ()
 
-    init(returnKeyType: UIReturnKeyType, changeAction: (String) -> ()) {
+    init(initialValue: String = "", returnKeyType: UIReturnKeyType, changeAction: (String) -> ()) {
+        self.initialValue = initialValue
         self.returnKeyType = returnKeyType
         self.changeAction = changeAction
     }
@@ -58,6 +62,7 @@ struct NameRowModel: TextFieldRowModel {
 struct SecretRowModel: TextFieldRowModel {
     let label = "Secret Key"
     let placeholder = "•••• •••• •••• ••••"
+    let initialValue: String
 
     let autocapitalizationType: UITextAutocapitalizationType = .None
     let autocorrectionType: UITextAutocorrectionType = .No
@@ -66,7 +71,8 @@ struct SecretRowModel: TextFieldRowModel {
 
     let changeAction: (String) -> ()
 
-    init(changeAction: (String) -> ()) {
+    init(initialValue: String = "", changeAction: (String) -> ()) {
+        self.initialValue = initialValue
         self.changeAction = changeAction
     }
 }

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -96,7 +96,8 @@ class OTPTextFieldCell: UITableViewCell, OTPCell {
     // MARK: - Target Action
 
     func textFieldValueChanged() {
-        changeAction?(textField.text ?? "")
+        let newText = textField.text ?? ""
+        changeAction?(newText)
     }
 }
 

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -27,6 +27,7 @@ import UIKit
 protocol TextFieldRowModel {
     var label: String { get }
     var placeholder: String { get }
+    var initialValue: String { get }
 
     var autocapitalizationType: UITextAutocapitalizationType { get }
     var autocorrectionType: UITextAutocorrectionType { get }
@@ -84,6 +85,7 @@ class OTPTextFieldCell: UITableViewCell, OTPCell {
     func updateWithRowModel(rowModel: TextFieldRowModel) {
         textLabel?.text = rowModel.label
         textField.placeholder = rowModel.placeholder
+        textField.text = rowModel.initialValue
 
         textField.autocapitalizationType = rowModel.autocapitalizationType
         textField.autocorrectionType = rowModel.autocorrectionType

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -32,10 +32,11 @@ protocol TextFieldRowModel {
     var autocorrectionType: UITextAutocorrectionType { get }
     var keyboardType: UIKeyboardType { get }
     var returnKeyType: UIReturnKeyType { get }
+
+    var changeAction: (String) -> () { get }
 }
 
 protocol OTPTextFieldCellDelegate: class {
-    func textFieldCellDidChange(textFieldCell: OTPTextFieldCell)
     func textFieldCellDidReturn(textFieldCell: OTPTextFieldCell)
 }
 
@@ -44,6 +45,8 @@ class OTPTextFieldCell: UITableViewCell, OTPCell {
 
     let textField = UITextField()
     weak var delegate: OTPTextFieldCellDelegate?
+    var changeAction: ((String) -> ())?
+
 
     // MARK: - Init
 
@@ -86,12 +89,14 @@ class OTPTextFieldCell: UITableViewCell, OTPCell {
         textField.autocorrectionType = rowModel.autocorrectionType
         textField.keyboardType = rowModel.keyboardType
         textField.returnKeyType = rowModel.returnKeyType
+
+        changeAction = rowModel.changeAction
     }
 
     // MARK: - Target Action
 
     func textFieldValueChanged() {
-        delegate?.textFieldCellDidChange(self)
+        changeAction?(textField.text ?? "")
     }
 }
 

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -55,15 +55,22 @@ class TokenEditForm: NSObject, TokenForm {
     }
 
     private var issuerRowModel: TextFieldRowModel {
-        return IssuerRowModel(changeAction: { [weak self] (newIssuer) -> () in
-            self?.issuerDidChange(newIssuer)
-        })
+        return IssuerRowModel(
+            initialValue: token.issuer,
+            changeAction: { [weak self] (newIssuer) -> () in
+                self?.issuerDidChange(newIssuer)
+            }
+        )
     }
 
     private var nameRowModel: TextFieldRowModel {
-        return NameRowModel(returnKeyType: .Done, changeAction: { [weak self] (newAccountName) -> () in
-            self?.accountNameDidChange(newAccountName)
-        })
+        return NameRowModel(
+            initialValue: token.name,
+            returnKeyType: .Done,
+            changeAction: { [weak self] (newAccountName) -> () in
+                self?.accountNameDidChange(newAccountName)
+            }
+        )
     }
 
     let token: OTPToken
@@ -78,9 +85,6 @@ class TokenEditForm: NSObject, TokenForm {
 
         issuerCell.delegate = self
         accountNameCell.delegate = self
-
-        issuerCell.textField.text = token.issuer;
-        accountNameCell.textField.text = token.name;
     }
 
     func focusFirstField() {

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -66,7 +66,7 @@ class TokenEditForm: NSObject, TokenForm {
 
         issuerCell.delegate = self
         accountNameCell.delegate = self
-        
+
         issuerCell.textField.text = token.issuer;
         accountNameCell.textField.text = token.name;
     }

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -55,11 +55,15 @@ class TokenEditForm: NSObject, TokenForm {
     }
 
     private var issuerRowModel: TextFieldRowModel {
-        return IssuerRowModel()
+        return IssuerRowModel(changeAction: { [weak self] (newIssuer) -> () in
+            self?.issuerDidChange(newIssuer)
+        })
     }
 
     private var nameRowModel: TextFieldRowModel {
-        return NameRowModel(returnKeyType: .Done)
+        return NameRowModel(returnKeyType: .Done, changeAction: { [weak self] (newAccountName) -> () in
+            self?.accountNameDidChange(newAccountName)
+        })
     }
 
     let token: OTPToken
@@ -118,11 +122,17 @@ class TokenEditForm: NSObject, TokenForm {
     }
 }
 
-extension TokenEditForm: OTPTextFieldCellDelegate {
-    func textFieldCellDidChange(textFieldCell: OTPTextFieldCell) {
+extension TokenEditForm {
+    func issuerDidChange(newIssuer: String) {
         presenter?.formValuesDidChange(self)
     }
 
+    func accountNameDidChange(newAccountName: String) {
+        presenter?.formValuesDidChange(self)
+    }
+}
+
+extension TokenEditForm: OTPTextFieldCellDelegate {
     func textFieldCellDidReturn(textFieldCell: OTPTextFieldCell) {
         if textFieldCell == issuerCell {
             accountNameCell.textField.becomeFirstResponder()

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -54,6 +54,14 @@ class TokenEditForm: NSObject, TokenForm {
         )
     }
 
+    private var issuerRowModel: TextFieldRowModel {
+        return IssuerRowModel()
+    }
+
+    private var nameRowModel: TextFieldRowModel {
+        return NameRowModel(returnKeyType: .Done)
+    }
+
     let token: OTPToken
 
     init(token: OTPToken, delegate: TokenEditFormDelegate) {
@@ -61,8 +69,8 @@ class TokenEditForm: NSObject, TokenForm {
         self.delegate = delegate
         super.init()
         // Configure cells
-        issuerCell.updateWithRowModel(IssuerRowModel())
-        accountNameCell.updateWithRowModel(NameRowModel(returnKeyType: .Done))
+        issuerCell.updateWithRowModel(issuerRowModel)
+        accountNameCell.updateWithRowModel(nameRowModel)
 
         issuerCell.delegate = self
         accountNameCell.delegate = self

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -33,12 +33,8 @@ class TokenEditForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEditFormDelegate?
 
-    private lazy var issuerCell: OTPTextFieldCell = {
-        OTPTextFieldCell.issuerCellWithDelegate(self)
-    }()
-    private lazy var accountNameCell: OTPTextFieldCell = {
-        OTPTextFieldCell.nameCellWithDelegate(self, returnKeyType: .Done)
-    }()
+    private let issuerCell = OTPTextFieldCell()
+    private let accountNameCell = OTPTextFieldCell()
 
     var viewModel: TableViewModel {
         return TableViewModel(
@@ -64,6 +60,13 @@ class TokenEditForm: NSObject, TokenForm {
         self.token = token
         self.delegate = delegate
         super.init()
+        // Configure cells
+        issuerCell.updateWithRowModel(IssuerRowModel())
+        accountNameCell.updateWithRowModel(NameRowModel(returnKeyType: .Done))
+
+        issuerCell.delegate = self
+        accountNameCell.delegate = self
+        
         issuerCell.textField.text = token.issuer;
         accountNameCell.textField.text = token.name;
     }

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -52,9 +52,9 @@ class TokenEntryForm: NSObject, TokenForm {
         self.delegate = delegate
         super.init()
 
-        issuerCell.updateWithRowModel(IssuerRowModel())
-        accountNameCell.updateWithRowModel(NameRowModel(returnKeyType: .Next))
-        secretKeyCell.updateWithRowModel(SecretRowModel())
+        issuerCell.updateWithRowModel(issuerRowModel)
+        accountNameCell.updateWithRowModel(nameRowModel)
+        secretKeyCell.updateWithRowModel(secretRowModel)
 
         issuerCell.delegate = self
         accountNameCell.delegate = self
@@ -85,19 +85,31 @@ class TokenEntryForm: NSObject, TokenForm {
 
     // Mark: Row Models
 
-    var tokenTypeRowModel: TokenTypeRowModel {
+    private var issuerRowModel: TextFieldRowModel {
+        return IssuerRowModel()
+    }
+
+    private var nameRowModel: TextFieldRowModel {
+        return NameRowModel(returnKeyType: .Next)
+    }
+
+    private var secretRowModel: TextFieldRowModel {
+        return SecretRowModel()
+    }
+
+    private var tokenTypeRowModel: TokenTypeRowModel {
         return TokenTypeRowModel(valueChangedAction: { [weak self] (newTokenType) -> () in
             self?.tokenTypeDidChange(tokenType)
         })
     }
 
-    var digitCountRowModel: DigitCountRowModel {
+    private var digitCountRowModel: DigitCountRowModel {
         return DigitCountRowModel(valueChangedAction: { [weak self] (newDigitCount) -> () in
             self?.digitCountDidChange(newDigitCount)
         })
     }
 
-    var algorithmRowModel: AlgorithmRowModel {
+    private var algorithmRowModel: AlgorithmRowModel {
         return AlgorithmRowModel(valueChangedAction: { [weak self] (newAlgorithm) -> () in
             self?.algorithmDidChange(newAlgorithm)
         })

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -34,15 +34,9 @@ class TokenEntryForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEntryFormDelegate?
 
-    private lazy var issuerCell: OTPTextFieldCell = {
-        OTPTextFieldCell.issuerCellWithDelegate(self)
-    }()
-    private lazy var accountNameCell: OTPTextFieldCell = {
-        OTPTextFieldCell.nameCellWithDelegate(self, returnKeyType: .Next)
-    }()
-    private lazy var secretKeyCell: OTPTextFieldCell = {
-        OTPTextFieldCell.secretCellWithDelegate(self)
-    }()
+    private let issuerCell = OTPTextFieldCell()
+    private let accountNameCell = OTPTextFieldCell()
+    private let secretKeyCell = OTPTextFieldCell()
     private let tokenTypeCell = OTPSegmentedControlCell<OTPTokenType>()
     private let digitCountCell = OTPSegmentedControlCell<Int>()
     private let algorithmCell = OTPSegmentedControlCell<OTPAlgorithm>()
@@ -57,6 +51,15 @@ class TokenEntryForm: NSObject, TokenForm {
     init(delegate: TokenEntryFormDelegate) {
         self.delegate = delegate
         super.init()
+
+        issuerCell.updateWithRowModel(IssuerRowModel())
+        accountNameCell.updateWithRowModel(NameRowModel(returnKeyType: .Next))
+        secretKeyCell.updateWithRowModel(SecretRowModel())
+
+        issuerCell.delegate = self
+        accountNameCell.delegate = self
+        secretKeyCell.delegate = self
+
         tokenTypeCell.updateWithRowModel(tokenTypeRowModel)
         digitCountCell.updateWithRowModel(digitCountRowModel)
         algorithmCell.updateWithRowModel(algorithmRowModel)

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -86,15 +86,21 @@ class TokenEntryForm: NSObject, TokenForm {
     // Mark: Row Models
 
     private var issuerRowModel: TextFieldRowModel {
-        return IssuerRowModel()
+        return IssuerRowModel(changeAction: { [weak self] (newIssuer) -> () in
+            self?.issuerDidChange(newIssuer)
+        })
     }
 
     private var nameRowModel: TextFieldRowModel {
-        return NameRowModel(returnKeyType: .Next)
+        return NameRowModel(returnKeyType: .Next, changeAction: { [weak self] (newAccountName) -> () in
+            self?.accountNameDidChange(newAccountName)
+        })
     }
 
     private var secretRowModel: TextFieldRowModel {
-        return SecretRowModel()
+        return SecretRowModel(changeAction: { [weak self] (newSecret) -> () in
+            self?.secretDidChange(newSecret)
+        })
     }
 
     private var tokenTypeRowModel: TokenTypeRowModel {
@@ -180,6 +186,18 @@ class TokenEntryForm: NSObject, TokenForm {
 }
 
 extension TokenEntryForm {
+    func issuerDidChange(newIssuer: String) {
+        presenter?.formValuesDidChange(self)
+    }
+
+    func accountNameDidChange(newAccountName: String) {
+        presenter?.formValuesDidChange(self)
+    }
+
+    func secretDidChange(newSecret: String) {
+        presenter?.formValuesDidChange(self)
+    }
+
     func tokenTypeDidChange(newTokenType: OTPTokenType) {
         presenter?.formValuesDidChange(self)
     }
@@ -194,10 +212,6 @@ extension TokenEntryForm {
 }
 
 extension TokenEntryForm: OTPTextFieldCellDelegate {
-    func textFieldCellDidChange(textFieldCell: OTPTextFieldCell) {
-        presenter?.formValuesDidChange(self)
-    }
-
     func textFieldCellDidReturn(textFieldCell: OTPTextFieldCell) {
         if textFieldCell == issuerCell {
             accountNameCell.textField.becomeFirstResponder()


### PR DESCRIPTION
Refactor the configuration of text field cells in the forms, and replace the `textFieldCellDidChange` delegate method with a `changeAction` closure.