### PR TITLE
Form state

### DIFF
--- a/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell+TokenForm.swift
@@ -29,10 +29,11 @@ struct TokenTypeRowModel: SegmentedControlRowModel {
         (title: "Time Based", value: OTPTokenType.Timer),
         (title: "Counter Based", value: OTPTokenType.Counter),
     ]
-    let initialValue = OTPTokenType.Timer
-
+    let initialValue: OTPTokenType
     let valueChangedAction: (OTPTokenType) -> ()
-    init(valueChangedAction: (OTPTokenType) -> ()) {
+
+    init(initialValue: OTPTokenType, valueChangedAction: (OTPTokenType) -> ()) {
+        self.initialValue = initialValue
         self.valueChangedAction = valueChangedAction
     }
 }
@@ -43,10 +44,11 @@ struct DigitCountRowModel: SegmentedControlRowModel {
         (title: "7 Digits", value: 7),
         (title: "8 Digits", value: 8),
     ]
-    let initialValue = 6
-
+    let initialValue: Int
     let valueChangedAction: (Int) -> ()
-    init(valueChangedAction: (Int) -> ()) {
+
+    init(initialValue: Int, valueChangedAction: (Int) -> ()) {
+        self.initialValue = initialValue
         self.valueChangedAction = valueChangedAction
     }
 }
@@ -57,10 +59,11 @@ struct AlgorithmRowModel: SegmentedControlRowModel {
         (title: "SHA-256", value: OTPAlgorithm.SHA256),
         (title: "SHA-512", value: OTPAlgorithm.SHA512),
     ]
-    let initialValue = OTPAlgorithm.SHA1
-
+    let initialValue: OTPAlgorithm
     let valueChangedAction: (OTPAlgorithm) -> ()
-    init(valueChangedAction: (OTPAlgorithm) -> ()) {
+
+    init(initialValue: OTPAlgorithm, valueChangedAction: (OTPAlgorithm) -> ()) {
+        self.initialValue = initialValue
         self.valueChangedAction = valueChangedAction
     }
 }

--- a/Authenticator/Classes/OTPTextFieldCell+TokenForm.swift
+++ b/Authenticator/Classes/OTPTextFieldCell+TokenForm.swift
@@ -34,7 +34,7 @@ struct IssuerRowModel: TextFieldRowModel {
 
     let changeAction: (String) -> ()
 
-    init(initialValue: String = "", changeAction: (String) -> ()) {
+    init(initialValue: String, changeAction: (String) -> ()) {
         self.initialValue = initialValue
         self.changeAction = changeAction
     }
@@ -52,7 +52,7 @@ struct NameRowModel: TextFieldRowModel {
 
     let changeAction: (String) -> ()
 
-    init(initialValue: String = "", returnKeyType: UIReturnKeyType, changeAction: (String) -> ()) {
+    init(initialValue: String, returnKeyType: UIReturnKeyType, changeAction: (String) -> ()) {
         self.initialValue = initialValue
         self.returnKeyType = returnKeyType
         self.changeAction = changeAction
@@ -71,7 +71,7 @@ struct SecretRowModel: TextFieldRowModel {
 
     let changeAction: (String) -> ()
 
-    init(initialValue: String = "", changeAction: (String) -> ()) {
+    init(initialValue: String, changeAction: (String) -> ()) {
         self.initialValue = initialValue
         self.changeAction = changeAction
     }

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -33,8 +33,16 @@ class TokenEditForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEditFormDelegate?
 
-    private var issuer: String
-    private var name: String
+    private var issuer: String {
+        didSet {
+            presenter?.formValuesDidChange(self)
+        }
+    }
+    private var name: String {
+        didSet {
+            presenter?.formValuesDidChange(self)
+        }
+    }
 
     private let issuerCell = OTPTextFieldCell()
     private let accountNameCell = OTPTextFieldCell()
@@ -61,7 +69,7 @@ class TokenEditForm: NSObject, TokenForm {
         return IssuerRowModel(
             initialValue: issuer,
             changeAction: { [weak self] (newIssuer) -> () in
-                self?.issuerDidChange(newIssuer)
+                self?.issuer = newIssuer
             }
         )
     }
@@ -71,7 +79,7 @@ class TokenEditForm: NSObject, TokenForm {
             initialValue: name,
             returnKeyType: .Done,
             changeAction: { [weak self] (newName) -> () in
-                self?.nameDidChange(newName)
+                self?.name = newName
             }
         )
     }
@@ -122,18 +130,6 @@ class TokenEditForm: NSObject, TokenForm {
         }
 
         delegate?.form(self, didEditToken: token)
-    }
-}
-
-extension TokenEditForm {
-    func issuerDidChange(newIssuer: String) {
-        issuer = newIssuer
-        presenter?.formValuesDidChange(self)
-    }
-
-    func nameDidChange(newName: String) {
-        name = newName
-        presenter?.formValuesDidChange(self)
     }
 }
 

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -36,6 +36,10 @@ class TokenEditForm: NSObject, TokenForm {
     private struct State {
         var issuer: String
         var name: String
+
+        var isValid: Bool {
+            return !(issuer.isEmpty && name.isEmpty)
+        }
     }
 
     private var state: State {
@@ -53,7 +57,7 @@ class TokenEditForm: NSObject, TokenForm {
             leftBarButton: BarButtonViewModel(style: .Cancel) { [weak self] in
                 self?.cancel()
             },
-            rightBarButton: BarButtonViewModel(style: .Done, enabled: isValid) { [weak self] in
+            rightBarButton: BarButtonViewModel(style: .Done, enabled: state.isValid) { [weak self] in
                 self?.submit()
             },
             sections: [
@@ -109,16 +113,12 @@ class TokenEditForm: NSObject, TokenForm {
         accountNameCell.textField.resignFirstResponder()
     }
 
-    var isValid: Bool {
-        return !(state.issuer.isEmpty && state.name.isEmpty)
-    }
-
     func cancel() {
         delegate?.editFormDidCancel(self)
     }
 
     func submit() {
-        if (!isValid) { return }
+        if (!state.isValid) { return }
 
         if (token.name != state.name ||
             token.issuer != state.issuer) {

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -33,6 +33,9 @@ class TokenEditForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEditFormDelegate?
 
+    private var issuer: String
+    private var name: String
+
     private let issuerCell = OTPTextFieldCell()
     private let accountNameCell = OTPTextFieldCell()
 
@@ -56,7 +59,7 @@ class TokenEditForm: NSObject, TokenForm {
 
     private var issuerRowModel: TextFieldRowModel {
         return IssuerRowModel(
-            initialValue: token.issuer,
+            initialValue: issuer,
             changeAction: { [weak self] (newIssuer) -> () in
                 self?.issuerDidChange(newIssuer)
             }
@@ -65,10 +68,10 @@ class TokenEditForm: NSObject, TokenForm {
 
     private var nameRowModel: TextFieldRowModel {
         return NameRowModel(
-            initialValue: token.name,
+            initialValue: name,
             returnKeyType: .Done,
-            changeAction: { [weak self] (newAccountName) -> () in
-                self?.accountNameDidChange(newAccountName)
+            changeAction: { [weak self] (newName) -> () in
+                self?.nameDidChange(newName)
             }
         )
     }
@@ -78,6 +81,10 @@ class TokenEditForm: NSObject, TokenForm {
     init(token: OTPToken, delegate: TokenEditFormDelegate) {
         self.token = token
         self.delegate = delegate
+
+        issuer = token.issuer
+        name = token.name
+
         super.init()
         // Configure cells
         issuerCell.updateWithRowModel(issuerRowModel)
@@ -96,16 +103,8 @@ class TokenEditForm: NSObject, TokenForm {
         accountNameCell.textField.resignFirstResponder()
     }
 
-    private var issuer: String {
-        return issuerCell.textField.text ?? ""
-    }
-
-    private var accountName: String {
-        return accountNameCell.textField.text ?? ""
-    }
-
     var isValid: Bool {
-        return !(issuer.isEmpty && accountName.isEmpty)
+        return !(issuer.isEmpty && name.isEmpty)
     }
 
     func cancel() {
@@ -115,9 +114,9 @@ class TokenEditForm: NSObject, TokenForm {
     func submit() {
         if (!isValid) { return }
 
-        if (token.name != accountName ||
+        if (token.name != name ||
             token.issuer != issuer) {
-                self.token.name = accountName
+                self.token.name = name
                 self.token.issuer = issuer
                 self.token.saveToKeychain()
         }
@@ -128,10 +127,12 @@ class TokenEditForm: NSObject, TokenForm {
 
 extension TokenEditForm {
     func issuerDidChange(newIssuer: String) {
+        issuer = newIssuer
         presenter?.formValuesDidChange(self)
     }
 
-    func accountNameDidChange(newAccountName: String) {
+    func nameDidChange(newName: String) {
+        name = newName
         presenter?.formValuesDidChange(self)
     }
 }

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -33,12 +33,12 @@ class TokenEditForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEditFormDelegate?
 
-    private var issuer: String {
-        didSet {
-            presenter?.formValuesDidChange(self)
-        }
+    private struct State {
+        var issuer: String
+        var name: String
     }
-    private var name: String {
+
+    private var state: State {
         didSet {
             presenter?.formValuesDidChange(self)
         }
@@ -67,19 +67,19 @@ class TokenEditForm: NSObject, TokenForm {
 
     private var issuerRowModel: TextFieldRowModel {
         return IssuerRowModel(
-            initialValue: issuer,
+            initialValue: state.issuer,
             changeAction: { [weak self] (newIssuer) -> () in
-                self?.issuer = newIssuer
+                self?.state.issuer = newIssuer
             }
         )
     }
 
     private var nameRowModel: TextFieldRowModel {
         return NameRowModel(
-            initialValue: name,
+            initialValue: state.name,
             returnKeyType: .Done,
             changeAction: { [weak self] (newName) -> () in
-                self?.name = newName
+                self?.state.name = newName
             }
         )
     }
@@ -89,9 +89,7 @@ class TokenEditForm: NSObject, TokenForm {
     init(token: OTPToken, delegate: TokenEditFormDelegate) {
         self.token = token
         self.delegate = delegate
-
-        issuer = token.issuer
-        name = token.name
+        state = State(issuer: token.issuer, name: token.name)
 
         super.init()
         // Configure cells
@@ -112,7 +110,7 @@ class TokenEditForm: NSObject, TokenForm {
     }
 
     var isValid: Bool {
-        return !(issuer.isEmpty && name.isEmpty)
+        return !(state.issuer.isEmpty && state.name.isEmpty)
     }
 
     func cancel() {
@@ -122,10 +120,10 @@ class TokenEditForm: NSObject, TokenForm {
     func submit() {
         if (!isValid) { return }
 
-        if (token.name != name ||
-            token.issuer != issuer) {
-                self.token.name = name
-                self.token.issuer = issuer
+        if (token.name != state.name ||
+            token.issuer != state.issuer) {
+                self.token.name = state.name
+                self.token.issuer = state.issuer
                 self.token.saveToKeychain()
         }
 

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -34,12 +34,36 @@ class TokenEntryForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEntryFormDelegate?
 
-    private var issuer: String
-    private var name: String
-    private var secretKey: String
-    private var tokenType: OTPTokenType
-    private var digitCount: Int
-    private var algorithm: OTPAlgorithm
+    private var issuer: String {
+        didSet {
+            presenter?.formValuesDidChange(self)
+        }
+    }
+    private var name: String {
+        didSet {
+            presenter?.formValuesDidChange(self)
+        }
+    }
+    private var secretKey: String {
+        didSet {
+            presenter?.formValuesDidChange(self)
+        }
+    }
+    private var tokenType: OTPTokenType {
+        didSet {
+            presenter?.formValuesDidChange(self)
+        }
+    }
+    private var digitCount: Int {
+        didSet {
+            presenter?.formValuesDidChange(self)
+        }
+    }
+    private var algorithm: OTPAlgorithm {
+        didSet {
+            presenter?.formValuesDidChange(self)
+        }
+    }
 
     private let issuerCell = OTPTextFieldCell()
     private let accountNameCell = OTPTextFieldCell()
@@ -104,7 +128,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return IssuerRowModel(
             initialValue: issuer,
             changeAction: { [weak self] (newIssuer) -> () in
-                self?.issuerDidChange(newIssuer)
+                self?.issuer = newIssuer
             }
         )
     }
@@ -114,7 +138,7 @@ class TokenEntryForm: NSObject, TokenForm {
             initialValue: name,
             returnKeyType: .Next,
             changeAction: { [weak self] (newName) -> () in
-                self?.nameDidChange(newName)
+                self?.name = newName
             }
         )
     }
@@ -123,7 +147,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return SecretRowModel(
             initialValue: secretKey,
             changeAction: { [weak self] (newSecret) -> () in
-                self?.secretDidChange(newSecret)
+                self?.secretKey = newSecret
             }
         )
     }
@@ -132,7 +156,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return TokenTypeRowModel(
             initialValue: tokenType,
             valueChangedAction: { [weak self] (newTokenType) -> () in
-                self?.tokenTypeDidChange(tokenType)
+                self?.tokenType = tokenType
             }
         )
     }
@@ -141,7 +165,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return DigitCountRowModel(
             initialValue: digitCount,
             valueChangedAction: { [weak self] (newDigitCount) -> () in
-                self?.digitCountDidChange(newDigitCount)
+                self?.digitCount = newDigitCount
             }
         )
     }
@@ -150,7 +174,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return AlgorithmRowModel(
             initialValue: algorithm,
             valueChangedAction: { [weak self] (newAlgorithm) -> () in
-                self?.algorithmDidChange(newAlgorithm)
+                self?.algorithm = newAlgorithm
             }
         )
     }
@@ -197,38 +221,6 @@ class TokenEntryForm: NSObject, TokenForm {
 
         // If the method hasn't returned by this point, token creation failed
         presenter?.form(self, didFailWithErrorMessage: "Invalid Token")
-    }
-}
-
-extension TokenEntryForm {
-    func issuerDidChange(newIssuer: String) {
-        issuer = newIssuer
-        presenter?.formValuesDidChange(self)
-    }
-
-    func nameDidChange(newName: String) {
-        name = newName
-        presenter?.formValuesDidChange(self)
-    }
-
-    func secretDidChange(newSecret: String) {
-        secretKey = newSecret
-        presenter?.formValuesDidChange(self)
-    }
-
-    func tokenTypeDidChange(newTokenType: OTPTokenType) {
-        tokenType = newTokenType
-        presenter?.formValuesDidChange(self)
-    }
-
-    func digitCountDidChange(newDigitCount: Int) {
-        digitCount = newDigitCount
-        presenter?.formValuesDidChange(self)
-    }
-
-    func algorithmDidChange(newAlgorithm: OTPAlgorithm) {
-        algorithm = newAlgorithm
-        presenter?.formValuesDidChange(self)
     }
 }
 

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -41,6 +41,10 @@ class TokenEntryForm: NSObject, TokenForm {
         var tokenType: OTPTokenType
         var digitCount: Int
         var algorithm: OTPAlgorithm
+
+        var isValid: Bool {
+            return !secret.isEmpty && !(issuer.isEmpty && name.isEmpty)
+        }
     }
 
     private var state: State {
@@ -96,7 +100,7 @@ class TokenEntryForm: NSObject, TokenForm {
             leftBarButton: BarButtonViewModel(style: .Cancel) { [weak self] in
                 self?.cancel()
             },
-            rightBarButton: BarButtonViewModel(style: .Done, enabled: isValid) { [weak self] in
+            rightBarButton: BarButtonViewModel(style: .Done, enabled: state.isValid) { [weak self] in
                 self?.submit()
             },
             sections: [
@@ -177,16 +181,12 @@ class TokenEntryForm: NSObject, TokenForm {
         secretKeyCell.textField.resignFirstResponder()
     }
 
-    var isValid: Bool {
-        return !state.secret.isEmpty && !(state.issuer.isEmpty && state.name.isEmpty)
-    }
-
     func cancel() {
         delegate?.entryFormDidCancel(self)
     }
 
     func submit() {
-        if !isValid { return }
+        if !state.isValid { return }
 
         if let secret = NSData(base32String: state.secret) {
             if secret.length > 0 {

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -34,6 +34,10 @@ class TokenEntryForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEntryFormDelegate?
 
+    private var issuer: String
+    private var name: String
+    private var secretKey: String
+
     private let issuerCell = OTPTextFieldCell()
     private let accountNameCell = OTPTextFieldCell()
     private let secretKeyCell = OTPTextFieldCell()
@@ -50,6 +54,11 @@ class TokenEntryForm: NSObject, TokenForm {
 
     init(delegate: TokenEntryFormDelegate) {
         self.delegate = delegate
+
+        issuer = "!"
+        name = "!"
+        secretKey = "!"
+
         super.init()
 
         issuerCell.updateWithRowModel(issuerRowModel)
@@ -86,21 +95,31 @@ class TokenEntryForm: NSObject, TokenForm {
     // Mark: Row Models
 
     private var issuerRowModel: TextFieldRowModel {
-        return IssuerRowModel(changeAction: { [weak self] (newIssuer) -> () in
-            self?.issuerDidChange(newIssuer)
-        })
+        return IssuerRowModel(
+            initialValue: issuer,
+            changeAction: { [weak self] (newIssuer) -> () in
+                self?.issuerDidChange(newIssuer)
+            }
+        )
     }
 
     private var nameRowModel: TextFieldRowModel {
-        return NameRowModel(returnKeyType: .Next, changeAction: { [weak self] (newAccountName) -> () in
-            self?.accountNameDidChange(newAccountName)
-        })
+        return NameRowModel(
+            initialValue: name,
+            returnKeyType: .Next,
+            changeAction: { [weak self] (newName) -> () in
+                self?.nameDidChange(newName)
+            }
+        )
     }
 
     private var secretRowModel: TextFieldRowModel {
-        return SecretRowModel(changeAction: { [weak self] (newSecret) -> () in
-            self?.secretDidChange(newSecret)
-        })
+        return SecretRowModel(
+            initialValue: secretKey,
+            changeAction: { [weak self] (newSecret) -> () in
+                self?.secretDidChange(newSecret)
+            }
+        )
     }
 
     private var tokenTypeRowModel: TokenTypeRowModel {
@@ -123,15 +142,6 @@ class TokenEntryForm: NSObject, TokenForm {
 
     // Mark: Values
 
-    var issuer: String {
-        return issuerCell.textField.text ?? ""
-    }
-    var accountName: String {
-        return accountNameCell.textField.text ?? ""
-    }
-    var secretKey: String {
-        return secretKeyCell.textField.text ?? ""
-    }
     var tokenType: OTPTokenType {
         return tokenTypeCell.value
     }
@@ -153,7 +163,7 @@ class TokenEntryForm: NSObject, TokenForm {
     }
 
     var isValid: Bool {
-        return !secretKey.isEmpty && !(issuer.isEmpty && accountName.isEmpty)
+        return !secretKey.isEmpty && !(issuer.isEmpty && name.isEmpty)
     }
 
     func cancel() {
@@ -168,7 +178,7 @@ class TokenEntryForm: NSObject, TokenForm {
                 let token = OTPToken()
                 token.type = tokenType;
                 token.secret = secret;
-                token.name = accountName;
+                token.name = name;
                 token.issuer = issuer;
                 token.digits = digitCount;
                 token.algorithm = algorithm;
@@ -187,14 +197,17 @@ class TokenEntryForm: NSObject, TokenForm {
 
 extension TokenEntryForm {
     func issuerDidChange(newIssuer: String) {
+        issuer = newIssuer
         presenter?.formValuesDidChange(self)
     }
 
-    func accountNameDidChange(newAccountName: String) {
+    func nameDidChange(newName: String) {
+        name = newName
         presenter?.formValuesDidChange(self)
     }
 
     func secretDidChange(newSecret: String) {
+        secretKey = newSecret
         presenter?.formValuesDidChange(self)
     }
 

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -37,6 +37,9 @@ class TokenEntryForm: NSObject, TokenForm {
     private var issuer: String
     private var name: String
     private var secretKey: String
+    private var tokenType: OTPTokenType
+    private var digitCount: Int
+    private var algorithm: OTPAlgorithm
 
     private let issuerCell = OTPTextFieldCell()
     private let accountNameCell = OTPTextFieldCell()
@@ -58,6 +61,9 @@ class TokenEntryForm: NSObject, TokenForm {
         issuer = "!"
         name = "!"
         secretKey = "!"
+        tokenType = .Timer
+        digitCount = 6
+        algorithm = .SHA1
 
         super.init()
 
@@ -123,34 +129,33 @@ class TokenEntryForm: NSObject, TokenForm {
     }
 
     private var tokenTypeRowModel: TokenTypeRowModel {
-        return TokenTypeRowModel(valueChangedAction: { [weak self] (newTokenType) -> () in
-            self?.tokenTypeDidChange(tokenType)
-        })
+        return TokenTypeRowModel(
+            initialValue: tokenType,
+            valueChangedAction: { [weak self] (newTokenType) -> () in
+                self?.tokenTypeDidChange(tokenType)
+            }
+        )
     }
 
     private var digitCountRowModel: DigitCountRowModel {
-        return DigitCountRowModel(valueChangedAction: { [weak self] (newDigitCount) -> () in
-            self?.digitCountDidChange(newDigitCount)
-        })
+        return DigitCountRowModel(
+            initialValue: digitCount,
+            valueChangedAction: { [weak self] (newDigitCount) -> () in
+                self?.digitCountDidChange(newDigitCount)
+            }
+        )
     }
 
     private var algorithmRowModel: AlgorithmRowModel {
-        return AlgorithmRowModel(valueChangedAction: { [weak self] (newAlgorithm) -> () in
-            self?.algorithmDidChange(newAlgorithm)
-        })
+        return AlgorithmRowModel(
+            initialValue: algorithm,
+            valueChangedAction: { [weak self] (newAlgorithm) -> () in
+                self?.algorithmDidChange(newAlgorithm)
+            }
+        )
     }
 
-    // Mark: Values
-
-    var tokenType: OTPTokenType {
-        return tokenTypeCell.value
-    }
-    var digitCount: UInt {
-        return UInt(digitCountCell.value)
-    }
-    var algorithm: OTPAlgorithm {
-        return algorithmCell.value
-    }
+    // Mark: TokenForm
 
     func focusFirstField() {
         issuerCell.textField.becomeFirstResponder()
@@ -180,7 +185,7 @@ class TokenEntryForm: NSObject, TokenForm {
                 token.secret = secret;
                 token.name = name;
                 token.issuer = issuer;
-                token.digits = digitCount;
+                token.digits = UInt(digitCount);
                 token.algorithm = algorithm;
 
                 if token.password != nil {
@@ -212,14 +217,17 @@ extension TokenEntryForm {
     }
 
     func tokenTypeDidChange(newTokenType: OTPTokenType) {
+        tokenType = newTokenType
         presenter?.formValuesDidChange(self)
     }
 
     func digitCountDidChange(newDigitCount: Int) {
+        digitCount = newDigitCount
         presenter?.formValuesDidChange(self)
     }
 
     func algorithmDidChange(newAlgorithm: OTPAlgorithm) {
+        algorithm = newAlgorithm
         presenter?.formValuesDidChange(self)
     }
 }


### PR DESCRIPTION
Wrap form state in a private internal `State` struct, instead of using the table view cells to store the state.
Replace `...DidChange` methods with `didSet` observation on the `state`. Specify the initial values for all cells explicitly from the form state.