### PR TITLE
Row models to cells

### DIFF
--- a/Authenticator/Classes/OTPCell.swift
+++ b/Authenticator/Classes/OTPCell.swift
@@ -22,14 +22,6 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-protocol ViewModelBasedView {
-    typealias ViewModel
-
-    init(viewModel: ViewModel)
-    func updateWithViewModel(viewModel: ViewModel)
-    static func heightWithViewModel(viewModel: ViewModel) -> CGFloat
-}
-
 protocol FocusCell {
     func focus() -> Bool
     func unfocus() -> Bool

--- a/Authenticator/Classes/OTPCell.swift
+++ b/Authenticator/Classes/OTPCell.swift
@@ -22,8 +22,12 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-protocol OTPCell {
-    var preferredHeight: CGFloat { get }
+protocol ViewModelBasedView {
+    typealias ViewModel
+
+    init(viewModel: ViewModel)
+    func updateWithViewModel(viewModel: ViewModel)
+    static func heightWithViewModel(viewModel: ViewModel) -> CGFloat
 }
 
 protocol FocusCell {

--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-class OTPHeaderView: UIButton, ViewModelBasedView {
+class OTPHeaderView: UIButton {
     private static let preferredHeight: CGFloat = 54
 
     private var buttonAction: (() -> ())?

--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-class OTPHeaderView: UIButton {
+class OTPHeaderView: UIButton, ViewModelBasedView {
     private static let preferredHeight: CGFloat = 54
 
     private var buttonAction: (() -> ())?
@@ -53,7 +53,7 @@ class OTPHeaderView: UIButton {
 
     // MARK: - View Model
 
-    convenience init(viewModel: HeaderViewModel) {
+    required convenience init(viewModel: HeaderViewModel) {
         self.init()
         updateWithViewModel(viewModel)
     }

--- a/Authenticator/Classes/OTPHeaderView.swift
+++ b/Authenticator/Classes/OTPHeaderView.swift
@@ -53,7 +53,7 @@ class OTPHeaderView: UIButton {
 
     // MARK: - View Model
 
-    required convenience init(viewModel: HeaderViewModel) {
+    convenience init(viewModel: HeaderViewModel) {
         self.init()
         updateWithViewModel(viewModel)
     }

--- a/Authenticator/Classes/OTPSegmentedControlCell.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell.swift
@@ -31,6 +31,7 @@ protocol SegmentedControlRowModel {
     var valueChangedAction: (Value) -> () { get }
 }
 
+// "static stored properties not yet supported in generic types"
 private let preferredHeight: CGFloat = 54
 
 class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {

--- a/Authenticator/Classes/OTPSegmentedControlCell.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell.swift
@@ -33,7 +33,7 @@ protocol SegmentedControlRowModel {
 
 private let preferredHeight: CGFloat = 54
 
-class OTPSegmentedControlCell<Value: Equatable, ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>: UITableViewCell, ViewModelBasedView {
+class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []
     private var valueChangedAction: ((Value) -> ())?
@@ -68,12 +68,12 @@ class OTPSegmentedControlCell<Value: Equatable, ViewModel: SegmentedControlRowMo
 
     // MARK: - View Model
 
-    required convenience init(viewModel: ViewModel) {
+    required convenience init<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>(viewModel: ViewModel) {
         self.init()
         updateWithViewModel(viewModel)
     }
 
-    func updateWithViewModel(viewModel: ViewModel) {
+    func updateWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>(viewModel: ViewModel) {
         valueChangedAction = viewModel.valueChangedAction
         // Remove any old segments
         segmentedControl.removeAllSegments()
@@ -88,7 +88,7 @@ class OTPSegmentedControlCell<Value: Equatable, ViewModel: SegmentedControlRowMo
         segmentedControl.selectedSegmentIndex = values.indexOf(viewModel.initialValue) ?? 0
     }
 
-    static func heightWithViewModel(viewModel: ViewModel) -> CGFloat {
+    static func heightWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>(viewModel: ViewModel) -> CGFloat {
         return preferredHeight
     }
 

--- a/Authenticator/Classes/OTPSegmentedControlCell.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell.swift
@@ -68,7 +68,7 @@ class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
 
     // MARK: - View Model
 
-    required convenience init<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>(viewModel: ViewModel) {
+    convenience init<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>(viewModel: ViewModel) {
         self.init()
         updateWithViewModel(viewModel)
     }

--- a/Authenticator/Classes/OTPSegmentedControlCell.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell.swift
@@ -31,9 +31,9 @@ protocol SegmentedControlRowModel {
     var valueChangedAction: (Value) -> () { get }
 }
 
-class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell, OTPCell {
-    let preferredHeight: CGFloat = 54
+private let preferredHeight: CGFloat = 54
 
+class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []
     private var valueChangedAction: ((Value) -> ())?
@@ -86,6 +86,10 @@ class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell, OTPCell {
         values = rowModel.segments.map { $0.value }
         // Select the initial value
         segmentedControl.selectedSegmentIndex = values.indexOf(rowModel.initialValue) ?? 0
+    }
+
+    static func heightWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>(viewModel: ViewModel) -> CGFloat {
+        return preferredHeight
     }
 
     // MARK: - Target Action

--- a/Authenticator/Classes/OTPSegmentedControlCell.swift
+++ b/Authenticator/Classes/OTPSegmentedControlCell.swift
@@ -33,7 +33,7 @@ protocol SegmentedControlRowModel {
 
 private let preferredHeight: CGFloat = 54
 
-class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
+class OTPSegmentedControlCell<Value: Equatable, ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>: UITableViewCell, ViewModelBasedView {
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []
     private var valueChangedAction: ((Value) -> ())?
@@ -54,11 +54,6 @@ class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
         configureSubviews()
     }
 
-    convenience init<RowModel: SegmentedControlRowModel where RowModel.Value == Value>(rowModel: RowModel) {
-        self.init()
-        updateWithRowModel(rowModel)
-    }
-
     // MARK: - Subviews
 
     private func configureSubviews() {
@@ -71,24 +66,29 @@ class OTPSegmentedControlCell<Value: Equatable>: UITableViewCell {
         segmentedControl.frame = CGRectMake(20, 15, CGRectGetWidth(contentView.bounds) - 40, 29)
     }
 
-    // MARK: - Update
+    // MARK: - View Model
 
-    func updateWithRowModel<RowModel: SegmentedControlRowModel where RowModel.Value == Value>(rowModel: RowModel) {
-        valueChangedAction = rowModel.valueChangedAction
+    required convenience init(viewModel: ViewModel) {
+        self.init()
+        updateWithViewModel(viewModel)
+    }
+
+    func updateWithViewModel(viewModel: ViewModel) {
+        valueChangedAction = viewModel.valueChangedAction
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments
-        for i in rowModel.segments.startIndex ..< rowModel.segments.endIndex {
-            let segment = rowModel.segments[i]
+        for i in viewModel.segments.startIndex ..< viewModel.segments.endIndex {
+            let segment = viewModel.segments[i]
             segmentedControl.insertSegmentWithTitle(segment.title, atIndex: i, animated: false)
         }
         // Store values
-        values = rowModel.segments.map { $0.value }
+        values = viewModel.segments.map { $0.value }
         // Select the initial value
-        segmentedControl.selectedSegmentIndex = values.indexOf(rowModel.initialValue) ?? 0
+        segmentedControl.selectedSegmentIndex = values.indexOf(viewModel.initialValue) ?? 0
     }
 
-    static func heightWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value>(viewModel: ViewModel) -> CGFloat {
+    static func heightWithViewModel(viewModel: ViewModel) -> CGFloat {
         return preferredHeight
     }
 

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -82,7 +82,7 @@ class OTPTextFieldCell: UITableViewCell {
 
     // MARK: - View Model
 
-    required convenience init(viewModel: TextFieldRowModel) {
+    convenience init(viewModel: TextFieldRowModel) {
         self.init()
         updateWithViewModel(viewModel)
     }

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -41,8 +41,8 @@ protocol OTPTextFieldCellDelegate: class {
     func textFieldCellDidReturn(textFieldCell: OTPTextFieldCell)
 }
 
-class OTPTextFieldCell: UITableViewCell, OTPCell {
-    let preferredHeight: CGFloat = 74
+class OTPTextFieldCell: UITableViewCell {
+    private static let preferredHeight: CGFloat = 74
 
     let textField = UITextField()
     weak var delegate: OTPTextFieldCellDelegate?
@@ -93,6 +93,10 @@ class OTPTextFieldCell: UITableViewCell, OTPCell {
         textField.returnKeyType = rowModel.returnKeyType
 
         changeAction = rowModel.changeAction
+    }
+
+    static func heightWithViewModel(viewModel: TextFieldRowModel) -> CGFloat {
+        return preferredHeight
     }
 
     // MARK: - Target Action

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -41,7 +41,7 @@ protocol OTPTextFieldCellDelegate: class {
     func textFieldCellDidReturn(textFieldCell: OTPTextFieldCell)
 }
 
-class OTPTextFieldCell: UITableViewCell, ViewModelBasedView {
+class OTPTextFieldCell: UITableViewCell {
     private static let preferredHeight: CGFloat = 74
 
     let textField = UITextField()

--- a/Authenticator/Classes/OTPTextFieldCell.swift
+++ b/Authenticator/Classes/OTPTextFieldCell.swift
@@ -41,7 +41,7 @@ protocol OTPTextFieldCellDelegate: class {
     func textFieldCellDidReturn(textFieldCell: OTPTextFieldCell)
 }
 
-class OTPTextFieldCell: UITableViewCell {
+class OTPTextFieldCell: UITableViewCell, ViewModelBasedView {
     private static let preferredHeight: CGFloat = 74
 
     let textField = UITextField()
@@ -80,19 +80,24 @@ class OTPTextFieldCell: UITableViewCell {
         textField.frame = CGRectMake(20, 44, CGRectGetWidth(contentView.bounds) - 40, 30)
     }
 
-    // MARK: - Update
+    // MARK: - View Model
 
-    func updateWithRowModel(rowModel: TextFieldRowModel) {
-        textLabel?.text = rowModel.label
-        textField.placeholder = rowModel.placeholder
-        textField.text = rowModel.initialValue
+    required convenience init(viewModel: TextFieldRowModel) {
+        self.init()
+        updateWithViewModel(viewModel)
+    }
 
-        textField.autocapitalizationType = rowModel.autocapitalizationType
-        textField.autocorrectionType = rowModel.autocorrectionType
-        textField.keyboardType = rowModel.keyboardType
-        textField.returnKeyType = rowModel.returnKeyType
+    func updateWithViewModel(viewModel: TextFieldRowModel) {
+        textLabel?.text = viewModel.label
+        textField.placeholder = viewModel.placeholder
+        textField.text = viewModel.initialValue
 
-        changeAction = rowModel.changeAction
+        textField.autocapitalizationType = viewModel.autocapitalizationType
+        textField.autocorrectionType = viewModel.autocorrectionType
+        textField.keyboardType = viewModel.keyboardType
+        textField.returnKeyType = viewModel.returnKeyType
+
+        changeAction = viewModel.changeAction
     }
 
     static func heightWithViewModel(viewModel: TextFieldRowModel) -> CGFloat {

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -45,4 +45,7 @@ extension Section: ArrayLiteralConvertible {
 
 enum RowModel {
     case TextFieldRow(TextFieldRowModel)
+    case TokenTypeRow(TokenTypeRowModel)
+    case DigitCountRow(DigitCountRowModel)
+    case AlgorithmRow(AlgorithmRowModel)
 }

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -25,7 +25,7 @@
 import UIKit
 
 struct Section {
-    typealias Row = RowModel
+    typealias Row = FormRowModel
 
     let header: HeaderViewModel?
     let rows: [Row]
@@ -43,7 +43,7 @@ extension Section: ArrayLiteralConvertible {
 }
 
 
-enum RowModel {
+enum FormRowModel {
     case TextFieldRow(TextFieldRowModel)
     case TokenTypeRow(TokenTypeRowModel)
     case DigitCountRow(DigitCountRowModel)

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -25,7 +25,7 @@
 import UIKit
 
 struct Section {
-    typealias Row = UITableViewCell
+    typealias Row = RowModel
 
     let header: HeaderViewModel?
     let rows: [Row]
@@ -40,4 +40,9 @@ extension Section: ArrayLiteralConvertible {
     init(arrayLiteral elements: Row...) {
         self.init(rows: elements)
     }
+}
+
+
+enum RowModel {
+    case TextFieldRow(TextFieldRowModel)
 }

--- a/Authenticator/Classes/TableViewModel.swift
+++ b/Authenticator/Classes/TableViewModel.swift
@@ -54,7 +54,7 @@ extension TableViewModel {
         return sections[section].rows.count
     }
 
-    func cellForRowAtIndexPath(indexPath: NSIndexPath) -> UITableViewCell? {
+    func modelForRowAtIndexPath(indexPath: NSIndexPath) -> Section.Row? {
         guard sections.indices.contains(indexPath.section)
             else { return nil }
         let section = sections[indexPath.section]

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -73,7 +73,7 @@ class TokenEditForm: NSObject, TokenForm {
         )
     }
 
-    private var issuerRowModel: RowModel {
+    private var issuerRowModel: FormRowModel {
         let model = IssuerRowModel(
             initialValue: state.issuer,
             changeAction: { [weak self] (newIssuer) -> () in
@@ -83,7 +83,7 @@ class TokenEditForm: NSObject, TokenForm {
         return .TextFieldRow(model)
     }
 
-    private var nameRowModel: RowModel {
+    private var nameRowModel: FormRowModel {
         let model = NameRowModel(
             initialValue: state.name,
             returnKeyType: .Done,

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -50,11 +50,6 @@ class TokenEditForm: NSObject, TokenForm {
         }
     }
 
-    // MARK: Cells
-
-    private let issuerCell = OTPTextFieldCell()
-    private let accountNameCell = OTPTextFieldCell()
-
     // MARK: View Model
 
     var viewModel: TableViewModel {
@@ -68,8 +63,8 @@ class TokenEditForm: NSObject, TokenForm {
             },
             sections: [
                 [
-                    issuerCell,
-                    accountNameCell,
+                    issuerRowModel,
+                    nameRowModel,
                 ]
             ],
             doneKeyAction: { [weak self] in
@@ -78,23 +73,25 @@ class TokenEditForm: NSObject, TokenForm {
         )
     }
 
-    private var issuerRowModel: TextFieldRowModel {
-        return IssuerRowModel(
+    private var issuerRowModel: RowModel {
+        let model = IssuerRowModel(
             initialValue: state.issuer,
             changeAction: { [weak self] (newIssuer) -> () in
                 self?.state.issuer = newIssuer
             }
         )
+        return .TextFieldRow(model)
     }
 
-    private var nameRowModel: TextFieldRowModel {
-        return NameRowModel(
+    private var nameRowModel: RowModel {
+        let model = NameRowModel(
             initialValue: state.name,
             returnKeyType: .Done,
             changeAction: { [weak self] (newName) -> () in
                 self?.state.name = newName
             }
         )
+        return .TextFieldRow(model)
     }
 
     // MARK: Initialization
@@ -105,11 +102,6 @@ class TokenEditForm: NSObject, TokenForm {
         self.token = token
         self.delegate = delegate
         state = State(issuer: token.issuer, name: token.name)
-
-        super.init()
-        // Configure cells
-        issuerCell.updateWithRowModel(issuerRowModel)
-        accountNameCell.updateWithRowModel(nameRowModel)
     }
 
     // MARK: Actions

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -33,6 +33,8 @@ class TokenEditForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEditFormDelegate?
 
+    // MARK: State
+
     private struct State {
         var issuer: String
         var name: String
@@ -48,8 +50,12 @@ class TokenEditForm: NSObject, TokenForm {
         }
     }
 
+    // MARK: Cells
+
     private let issuerCell = OTPTextFieldCell()
     private let accountNameCell = OTPTextFieldCell()
+
+    // MARK: View Model
 
     var viewModel: TableViewModel {
         return TableViewModel(
@@ -91,6 +97,8 @@ class TokenEditForm: NSObject, TokenForm {
         )
     }
 
+    // MARK: Initialization
+
     let token: OTPToken
 
     init(token: OTPToken, delegate: TokenEditFormDelegate) {
@@ -103,6 +111,8 @@ class TokenEditForm: NSObject, TokenForm {
         issuerCell.updateWithRowModel(issuerRowModel)
         accountNameCell.updateWithRowModel(nameRowModel)
     }
+
+    // MARK: Actions
 
     func cancel() {
         delegate?.editFormDidCancel(self)

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -91,12 +91,12 @@ class TokenEntryForm: NSObject, TokenForm {
                 ],
                 Section(
                     header: advancedSectionHeader,
-                    rows: showsAdvancedOptions
-                        ? [
+                    rows: showsAdvancedOptions ?
+                        [
                             tokenTypeRowModel,
                             digitCountRowModel,
                             algorithmRowModel,
-                            ]
+                        ]
                         : []
                 ),
             ],

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -34,6 +34,8 @@ class TokenEntryForm: NSObject, TokenForm {
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEntryFormDelegate?
 
+    // MARK: State
+    
     private struct State {
         var issuer: String
         var name: String
@@ -53,6 +55,8 @@ class TokenEntryForm: NSObject, TokenForm {
         }
     }
 
+    // MARK: Cells
+
     private let issuerCell = OTPTextFieldCell()
     private let accountNameCell = OTPTextFieldCell()
     private let secretKeyCell = OTPTextFieldCell()
@@ -60,11 +64,7 @@ class TokenEntryForm: NSObject, TokenForm {
     private let digitCountCell = OTPSegmentedControlCell<Int>()
     private let algorithmCell = OTPSegmentedControlCell<OTPAlgorithm>()
 
-    private var advancedSectionHeader: HeaderViewModel {
-        return HeaderViewModel(title: "Advanced Options") { [weak self] in
-            self?.toggleAdvancedOptions()
-        }
-    }
+    // MARK: Initialization
 
     var showsAdvancedOptions = false
 
@@ -89,6 +89,8 @@ class TokenEntryForm: NSObject, TokenForm {
         digitCountCell.updateWithRowModel(digitCountRowModel)
         algorithmCell.updateWithRowModel(algorithmRowModel)
     }
+
+    // MARK: View Model
 
     var viewModel: TableViewModel {
         return TableViewModel(
@@ -121,7 +123,11 @@ class TokenEntryForm: NSObject, TokenForm {
         )
     }
 
-    // Mark: Row Models
+    private var advancedSectionHeader: HeaderViewModel {
+        return HeaderViewModel(title: "Advanced Options") { [weak self] in
+            self?.toggleAdvancedOptions()
+        }
+    }
 
     private var issuerRowModel: TextFieldRowModel {
         return IssuerRowModel(
@@ -178,7 +184,7 @@ class TokenEntryForm: NSObject, TokenForm {
         )
     }
 
-    // Mark: TokenForm
+    // MARK: Actions
 
     func cancel() {
         delegate?.entryFormDidCancel(self)
@@ -207,9 +213,7 @@ class TokenEntryForm: NSObject, TokenForm {
         // If the method hasn't returned by this point, token creation failed
         presenter?.form(self, didFailWithErrorMessage: "Invalid Token")
     }
-}
 
-extension TokenEntryForm {
     func toggleAdvancedOptions() {
         if (!showsAdvancedOptions) {
             showsAdvancedOptions = true

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -102,20 +102,20 @@ class TokenEntryForm: NSObject, TokenForm {
                 self?.submit()
             },
             sections: [
-                [
-                    self.issuerCell,
-                    self.accountNameCell,
-                    self.secretKeyCell,
-                ],
-                Section(
-                    header: advancedSectionHeader,
-                    rows: showsAdvancedOptions
-                        ? [
-                            self.tokenTypeCell,
-                            self.digitCountCell,
-                            self.algorithmCell ]
-                        : []
-                ),
+//                [
+//                    self.issuerCell,
+//                    self.accountNameCell,
+//                    self.secretKeyCell,
+//                ],
+//                Section(
+//                    header: advancedSectionHeader,
+//                    rows: showsAdvancedOptions
+//                        ? [
+//                            self.tokenTypeCell,
+//                            self.digitCountCell,
+//                            self.algorithmCell ]
+//                        : []
+//                ),
             ],
             doneKeyAction: { [weak self] in
                 self?.submit()

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -112,7 +112,7 @@ class TokenEntryForm: NSObject, TokenForm {
         }
     }
 
-    private var issuerRowModel: RowModel {
+    private var issuerRowModel: FormRowModel {
         let model = IssuerRowModel(
             initialValue: state.issuer,
             changeAction: { [weak self] (newIssuer) -> () in
@@ -122,7 +122,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .TextFieldRow(model)
     }
 
-    private var nameRowModel: RowModel {
+    private var nameRowModel: FormRowModel {
         let model = NameRowModel(
             initialValue: state.name,
             returnKeyType: .Next,
@@ -133,7 +133,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .TextFieldRow(model)
     }
 
-    private var secretRowModel: RowModel {
+    private var secretRowModel: FormRowModel {
         let model = SecretRowModel(
             initialValue: state.secret,
             changeAction: { [weak self] (newSecret) -> () in
@@ -143,7 +143,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .TextFieldRow(model)
     }
 
-    private var tokenTypeRowModel: RowModel {
+    private var tokenTypeRowModel: FormRowModel {
         let model = TokenTypeRowModel(
             initialValue: state.tokenType,
             valueChangedAction: { [weak self] (newTokenType) -> () in
@@ -153,7 +153,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .TokenTypeRow(model)
     }
 
-    private var digitCountRowModel: RowModel {
+    private var digitCountRowModel: FormRowModel {
         let model = DigitCountRowModel(
             initialValue: state.digitCount,
             valueChangedAction: { [weak self] (newDigitCount) -> () in
@@ -163,7 +163,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .DigitCountRow(model)
     }
 
-    private var algorithmRowModel: RowModel {
+    private var algorithmRowModel: FormRowModel {
         let model = AlgorithmRowModel(
             initialValue: state.algorithm,
             valueChangedAction: { [weak self] (newAlgorithm) -> () in

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -91,13 +91,12 @@ class TokenEntryForm: NSObject, TokenForm {
                 ],
                 Section(
                     header: advancedSectionHeader,
-                    rows: showsAdvancedOptions ?
+                    rows: !showsAdvancedOptions ? [] :
                         [
                             tokenTypeRowModel,
                             digitCountRowModel,
                             algorithmRowModel,
                         ]
-                        : []
                 ),
             ],
             doneKeyAction: { [weak self] in

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -100,10 +100,20 @@ class TokenEntryForm: NSObject, TokenForm {
                 self?.submit()
             },
             sections: [
-                [ self.issuerCell, self.accountNameCell , self.secretKeyCell ],
-                showsAdvancedOptions
-                    ? Section(header: advancedSectionHeader, rows: [ self.tokenTypeCell, self.digitCountCell, self.algorithmCell ])
-                    : Section(header: advancedSectionHeader),
+                [
+                    self.issuerCell,
+                    self.accountNameCell,
+                    self.secretKeyCell,
+                ],
+                Section(
+                    header: advancedSectionHeader,
+                    rows: showsAdvancedOptions
+                        ? [
+                            self.tokenTypeCell,
+                            self.digitCountCell,
+                            self.algorithmCell ]
+                        : []
+                ),
             ],
             doneKeyAction: { [weak self] in
                 self?.submit()

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -55,18 +55,9 @@ class TokenEntryForm: NSObject, TokenForm {
         }
     }
 
-    // MARK: Cells
-
-    private let issuerCell = OTPTextFieldCell()
-    private let accountNameCell = OTPTextFieldCell()
-    private let secretKeyCell = OTPTextFieldCell()
-    private let tokenTypeCell = OTPSegmentedControlCell<OTPTokenType>()
-    private let digitCountCell = OTPSegmentedControlCell<Int>()
-    private let algorithmCell = OTPSegmentedControlCell<OTPAlgorithm>()
+    var showsAdvancedOptions = false
 
     // MARK: Initialization
-
-    var showsAdvancedOptions = false
 
     init(delegate: TokenEntryFormDelegate) {
         self.delegate = delegate
@@ -79,15 +70,6 @@ class TokenEntryForm: NSObject, TokenForm {
             digitCount: 6,
             algorithm: .SHA1
         )
-
-        super.init()
-
-        issuerCell.updateWithRowModel(issuerRowModel)
-        accountNameCell.updateWithRowModel(nameRowModel)
-        secretKeyCell.updateWithRowModel(secretRowModel)
-        tokenTypeCell.updateWithRowModel(tokenTypeRowModel)
-        digitCountCell.updateWithRowModel(digitCountRowModel)
-        algorithmCell.updateWithRowModel(algorithmRowModel)
     }
 
     // MARK: View Model
@@ -102,20 +84,21 @@ class TokenEntryForm: NSObject, TokenForm {
                 self?.submit()
             },
             sections: [
-//                [
-//                    self.issuerCell,
-//                    self.accountNameCell,
-//                    self.secretKeyCell,
-//                ],
-//                Section(
-//                    header: advancedSectionHeader,
-//                    rows: showsAdvancedOptions
-//                        ? [
-//                            self.tokenTypeCell,
-//                            self.digitCountCell,
-//                            self.algorithmCell ]
-//                        : []
-//                ),
+                [
+                    issuerRowModel,
+                    nameRowModel,
+                    secretRowModel,
+                ],
+                Section(
+                    header: advancedSectionHeader,
+                    rows: showsAdvancedOptions
+                        ? [
+                            tokenTypeRowModel,
+                            digitCountRowModel,
+                            algorithmRowModel,
+                            ]
+                        : []
+                ),
             ],
             doneKeyAction: { [weak self] in
                 self?.submit()
@@ -129,59 +112,65 @@ class TokenEntryForm: NSObject, TokenForm {
         }
     }
 
-    private var issuerRowModel: TextFieldRowModel {
-        return IssuerRowModel(
+    private var issuerRowModel: RowModel {
+        let model = IssuerRowModel(
             initialValue: state.issuer,
             changeAction: { [weak self] (newIssuer) -> () in
                 self?.state.issuer = newIssuer
             }
         )
+        return .TextFieldRow(model)
     }
 
-    private var nameRowModel: TextFieldRowModel {
-        return NameRowModel(
+    private var nameRowModel: RowModel {
+        let model = NameRowModel(
             initialValue: state.name,
             returnKeyType: .Next,
             changeAction: { [weak self] (newName) -> () in
                 self?.state.name = newName
             }
         )
+        return .TextFieldRow(model)
     }
 
-    private var secretRowModel: TextFieldRowModel {
-        return SecretRowModel(
+    private var secretRowModel: RowModel {
+        let model = SecretRowModel(
             initialValue: state.secret,
             changeAction: { [weak self] (newSecret) -> () in
                 self?.state.secret = newSecret
             }
         )
+        return .TextFieldRow(model)
     }
 
-    private var tokenTypeRowModel: TokenTypeRowModel {
-        return TokenTypeRowModel(
+    private var tokenTypeRowModel: RowModel {
+        let model = TokenTypeRowModel(
             initialValue: state.tokenType,
             valueChangedAction: { [weak self] (newTokenType) -> () in
                 self?.state.tokenType = newTokenType
             }
         )
+        return .TokenTypeRow(model)
     }
 
-    private var digitCountRowModel: DigitCountRowModel {
-        return DigitCountRowModel(
+    private var digitCountRowModel: RowModel {
+        let model = DigitCountRowModel(
             initialValue: state.digitCount,
             valueChangedAction: { [weak self] (newDigitCount) -> () in
                 self?.state.digitCount = newDigitCount
             }
         )
+        return .DigitCountRow(model)
     }
 
-    private var algorithmRowModel: AlgorithmRowModel {
-        return AlgorithmRowModel(
+    private var algorithmRowModel: RowModel {
+        let model = AlgorithmRowModel(
             initialValue: state.algorithm,
             valueChangedAction: { [weak self] (newAlgorithm) -> () in
                 self?.state.algorithm = newAlgorithm
             }
         )
+        return .AlgorithmRow(model)
     }
 
     // MARK: Actions

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -181,15 +181,13 @@ class TokenFormViewController: UITableViewController {
     func cellForRowModel(rowModel: RowModel) -> UITableViewCell {
         switch rowModel {
         case .TextFieldRow(let textFieldViewModel):
-            let cell = OTPTextFieldCell()
-            cell.updateWithRowModel(textFieldViewModel)
-            return cell
+            return OTPTextFieldCell(viewModel: textFieldViewModel)
         case .TokenTypeRow(let segmentedControlViewModel):
-            return OTPSegmentedControlCell(rowModel: segmentedControlViewModel)
+            return OTPSegmentedControlCell(viewModel: segmentedControlViewModel)
         case .DigitCountRow(let segmentedControlViewModel):
-            return OTPSegmentedControlCell(rowModel: segmentedControlViewModel)
+            return OTPSegmentedControlCell(viewModel: segmentedControlViewModel)
         case .AlgorithmRow(let segmentedControlViewModel):
-            return OTPSegmentedControlCell(rowModel: segmentedControlViewModel)
+            return OTPSegmentedControlCell(viewModel: segmentedControlViewModel)
         }
     }
 

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -184,6 +184,12 @@ class TokenFormViewController: UITableViewController {
             let cell = OTPTextFieldCell()
             cell.updateWithRowModel(textFieldViewModel)
             return cell
+        case .TokenTypeRow(let segmentedControlViewModel):
+            return OTPSegmentedControlCell(rowModel: segmentedControlViewModel)
+        case .DigitCountRow(let segmentedControlViewModel):
+            return OTPSegmentedControlCell(rowModel: segmentedControlViewModel)
+        case .AlgorithmRow(let segmentedControlViewModel):
+            return OTPSegmentedControlCell(rowModel: segmentedControlViewModel)
         }
     }
 
@@ -191,6 +197,12 @@ class TokenFormViewController: UITableViewController {
         switch rowModel {
         case .TextFieldRow(let textFieldViewModel):
             return OTPTextFieldCell.heightWithViewModel(textFieldViewModel)
+        case .TokenTypeRow(let segmentedControlViewModel):
+            return OTPSegmentedControlCell.heightWithViewModel(segmentedControlViewModel)
+        case .DigitCountRow(let segmentedControlViewModel):
+            return OTPSegmentedControlCell.heightWithViewModel(segmentedControlViewModel)
+        case .AlgorithmRow(let segmentedControlViewModel):
+            return OTPSegmentedControlCell.heightWithViewModel(segmentedControlViewModel)
         }
     }
 }

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -178,7 +178,7 @@ class TokenFormViewController: UITableViewController {
 
     // MARK: Row Model Helpers
 
-    func cellForRowModel(rowModel: RowModel) -> UITableViewCell {
+    func cellForRowModel(rowModel: FormRowModel) -> UITableViewCell {
         switch rowModel {
         case .TextFieldRow(let textFieldViewModel):
             return OTPTextFieldCell(viewModel: textFieldViewModel)
@@ -191,7 +191,7 @@ class TokenFormViewController: UITableViewController {
         }
     }
 
-    func heightForRowModel(rowModel: RowModel) -> CGFloat {
+    func heightForRowModel(rowModel: FormRowModel) -> CGFloat {
         switch rowModel {
         case .TextFieldRow(let textFieldViewModel):
             return OTPTextFieldCell.heightWithViewModel(textFieldViewModel)

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -111,7 +111,9 @@ class TokenFormViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
-        return viewModel.cellForRowAtIndexPath(indexPath) ?? UITableViewCell()
+        guard let rowModel = viewModel.modelForRowAtIndexPath(indexPath)
+            else { return UITableViewCell() }
+        return cellForRowModel(rowModel)
     }
 
     // MARK: - UITableViewDelegate
@@ -129,9 +131,9 @@ class TokenFormViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-        guard let cell = viewModel.cellForRowAtIndexPath(indexPath) as? OTPCell
+        guard let rowModel = viewModel.modelForRowAtIndexPath(indexPath)
             else { return 0 }
-        return cell.preferredHeight
+        return heightForRowModel(rowModel)
     }
 
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -171,6 +173,24 @@ class TokenFormViewController: UITableViewController {
         }
         navigationItem.rightBarButtonItem = viewModel.rightBarButton.map { (viewModel) in
             barButtomItemForViewModel(viewModel, target: self, action: Selector("rightBarButtonAction"))
+        }
+    }
+
+    // MARK: Row Model Helpers
+
+    func cellForRowModel(rowModel: RowModel) -> UITableViewCell {
+        switch rowModel {
+        case .TextFieldRow(let textFieldViewModel):
+            let cell = OTPTextFieldCell()
+            cell.updateWithRowModel(textFieldViewModel)
+            return cell
+        }
+    }
+
+    func heightForRowModel(rowModel: RowModel) -> CGFloat {
+        switch rowModel {
+        case .TextFieldRow(let textFieldViewModel):
+            return OTPTextFieldCell.heightWithViewModel(textFieldViewModel)
         }
     }
 }


### PR DESCRIPTION
Populate `TableViewModel` `Section`s with `FormRowModel`s instead of `UITableViewCell`s. The `FormRowModel` enables a mapping from row view models to row cells. Construct cells on demand in the view controller rather than pre-building them in the forms.