### PR TITLE
Header models

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		C944A5571A7ECB0800E08B1E /* OneTimePassword.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C944A5561A7ECB0800E08B1E /* OneTimePassword.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C944A5591A7ECB3100E08B1E /* Base32.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C944A5581A7ECB3100E08B1E /* Base32.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C97B68C717D9226D005D1FE0 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = C97B68C617D9226D005D1FE0 /* Settings.bundle */; };
-		C9800C491BCAA81D00CCB9B7 /* HeaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9800C481BCAA81D00CCB9B7 /* HeaderViewModel.swift */; settings = {ASSET_TAGS = (); }; };
+		C9800C491BCAA81D00CCB9B7 /* FormModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9800C481BCAA81D00CCB9B7 /* FormModels.swift */; settings = {ASSET_TAGS = (); }; };
 		C983AB74197F98FC00975003 /* OTPAuthenticatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C983AB73197F98FC00975003 /* OTPAuthenticatorTests.m */; };
 		C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1EC91AB2CEC300C59E53 /* TokenRowModel.swift */; };
 		C98B1ECC1AB3CF0700C59E53 /* TokenRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */; };
@@ -100,7 +100,7 @@
 		C959A63E190A69E60042DEC0 /* GenerateIcons.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = GenerateIcons.sh; sourceTree = "<group>"; };
 		C9776E3318518801003D53CB /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		C97B68C617D9226D005D1FE0 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
-		C9800C481BCAA81D00CCB9B7 /* HeaderViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderViewModel.swift; sourceTree = "<group>"; };
+		C9800C481BCAA81D00CCB9B7 /* FormModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormModels.swift; sourceTree = "<group>"; };
 		C983AB73197F98FC00975003 /* OTPAuthenticatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OTPAuthenticatorTests.m; sourceTree = "<group>"; };
 		C98B1EC91AB2CEC300C59E53 /* TokenRowModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenRowModel.swift; sourceTree = "<group>"; };
 		C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenRowCell.swift; sourceTree = "<group>"; };
@@ -353,7 +353,7 @@
 				C9CC09541BA91D1C008C54FE /* TableViewModel.swift */,
 				C99B85241BC9AB7100A6C75D /* BarButtonViewModel.swift */,
 				C9919CE11BA733FD006237C1 /* Section.swift */,
-				C9800C481BCAA81D00CCB9B7 /* HeaderViewModel.swift */,
+				C9800C481BCAA81D00CCB9B7 /* FormModels.swift */,
 			);
 			name = "View Models";
 			sourceTree = "<group>";
@@ -547,7 +547,7 @@
 				C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */,
 				C9AAB0811B9187F8000CE547 /* TokenForm.swift in Sources */,
 				C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */,
-				C9800C491BCAA81D00CCB9B7 /* HeaderViewModel.swift in Sources */,
+				C9800C491BCAA81D00CCB9B7 /* FormModels.swift in Sources */,
 				C99B85251BC9AB7100A6C75D /* BarButtonViewModel.swift in Sources */,
 				C9AAB0791B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift in Sources */,
 				1D3623260D0F684500981E51 /* OTPAppDelegate.swift in Sources */,

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		C98B1ECC1AB3CF0700C59E53 /* TokenRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */; };
 		C99069D1180CBAC900BAEF53 /* OTPScannerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C99069D0180CBAC900BAEF53 /* OTPScannerViewController.m */; };
 		C9919CDD1BA64EED006237C1 /* TokenEntryForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */; };
-		C9919CE01BA721A1006237C1 /* OTPHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDF1BA721A1006237C1 /* OTPHeaderView.swift */; };
+		C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */; };
 		C9919CE21BA733FD006237C1 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CE11BA733FD006237C1 /* Section.swift */; };
 		C99B85251BC9AB7100A6C75D /* BarButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99B85241BC9AB7100A6C75D /* BarButtonViewModel.swift */; settings = {ASSET_TAGS = (); }; };
 		C9AAB0791B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB0781B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift */; };
@@ -109,7 +109,7 @@
 		C99069D5180E09D700BAEF53 /* OTPTokenSourceDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OTPTokenSourceDelegate.h; sourceTree = "<group>"; };
 		C9906A2E1812522100BAEF53 /* AuthenticatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AuthenticatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenEntryForm.swift; sourceTree = "<group>"; };
-		C9919CDF1BA721A1006237C1 /* OTPHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTPHeaderView.swift; sourceTree = "<group>"; };
+		C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonHeaderView.swift; sourceTree = "<group>"; };
 		C9919CE11BA733FD006237C1 /* Section.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
 		C99B85241BC9AB7100A6C75D /* BarButtonViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarButtonViewModel.swift; sourceTree = "<group>"; };
 		C9A4FA1317CF9D3100CD5EDC /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
@@ -376,7 +376,7 @@
 				C9AAB0781B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift */,
 				C9D6C8451906CD54004F0E08 /* OTPTextFieldCell.swift */,
 				C9078D171AB7E90A0068A11D /* OTPTextFieldCell+TokenForm.swift */,
-				C9919CDF1BA721A1006237C1 /* OTPHeaderView.swift */,
+				C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */,
 			);
 			name = Cells;
 			sourceTree = "<group>";
@@ -544,7 +544,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C93AD15219CD51BE007480E9 /* Colors.swift in Sources */,
-				C9919CE01BA721A1006237C1 /* OTPHeaderView.swift in Sources */,
+				C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */,
 				C9AAB0811B9187F8000CE547 /* TokenForm.swift in Sources */,
 				C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */,
 				C9800C491BCAA81D00CCB9B7 /* HeaderViewModel.swift in Sources */,

--- a/Authenticator/Classes/ButtonHeaderView.swift
+++ b/Authenticator/Classes/ButtonHeaderView.swift
@@ -24,6 +24,16 @@
 
 import UIKit
 
+struct ButtonHeaderViewModel {
+    let title: String
+    let action: (() -> ())?
+
+    init(title: String, action: (() -> ())? = nil) {
+        self.title = title
+        self.action = action
+    }
+}
+
 class ButtonHeaderView: UIButton {
     private static let preferredHeight: CGFloat = 54
 
@@ -53,17 +63,17 @@ class ButtonHeaderView: UIButton {
 
     // MARK: - View Model
 
-    convenience init(viewModel: HeaderViewModel) {
+    convenience init(viewModel: ButtonHeaderViewModel) {
         self.init()
         updateWithViewModel(viewModel)
     }
 
-    func updateWithViewModel(viewModel: HeaderViewModel) {
+    func updateWithViewModel(viewModel: ButtonHeaderViewModel) {
         setTitle(viewModel.title, forState: .Normal)
         buttonAction = viewModel.action
     }
 
-    static func heightWithViewModel(viewModel: HeaderViewModel) -> CGFloat {
+    static func heightWithViewModel(viewModel: ButtonHeaderViewModel) -> CGFloat {
         return preferredHeight
     }
 

--- a/Authenticator/Classes/ButtonHeaderView.swift
+++ b/Authenticator/Classes/ButtonHeaderView.swift
@@ -1,5 +1,5 @@
 //
-//  OTPHeaderView.swift
+//  ButtonHeaderView.swift
 //  Authenticator
 //
 //  Copyright (c) 2015 Matt Rubin
@@ -24,7 +24,7 @@
 
 import UIKit
 
-class OTPHeaderView: UIButton {
+class ButtonHeaderView: UIButton {
     private static let preferredHeight: CGFloat = 54
 
     private var buttonAction: (() -> ())?

--- a/Authenticator/Classes/FormModels.swift
+++ b/Authenticator/Classes/FormModels.swift
@@ -26,4 +26,11 @@ enum Form {
     enum HeaderModel {
         case ButtonHeader(ButtonHeaderViewModel)
     }
+
+    enum RowModel {
+        case TextFieldRow(TextFieldRowModel)
+        case TokenTypeRow(TokenTypeRowModel)
+        case DigitCountRow(DigitCountRowModel)
+        case AlgorithmRow(AlgorithmRowModel)
+    }
 }

--- a/Authenticator/Classes/FormModels.swift
+++ b/Authenticator/Classes/FormModels.swift
@@ -1,5 +1,5 @@
 //
-//  HeaderViewModel.swift
+//  FormModels.swift
 //  Authenticator
 //
 //  Copyright (c) 2015 Matt Rubin
@@ -21,3 +21,9 @@
 //  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+
+enum Form {
+    enum HeaderModel {
+        case ButtonHeader(ButtonHeaderViewModel)
+    }
+}

--- a/Authenticator/Classes/HeaderViewModel.swift
+++ b/Authenticator/Classes/HeaderViewModel.swift
@@ -21,13 +21,3 @@
 //  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
-
-struct HeaderViewModel {
-    let title: String
-    let action: (() -> ())?
-
-    init(title: String, action: (() -> ())? = nil) {
-        self.title = title
-        self.action = action
-    }
-}

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -27,10 +27,10 @@ import UIKit
 struct Section {
     typealias Row = FormRowModel
 
-    let header: HeaderViewModel?
+    let header: ButtonHeaderViewModel?
     let rows: [Row]
 
-    init(header: HeaderViewModel? = nil, rows: [Row] = []) {
+    init(header: ButtonHeaderViewModel? = nil, rows: [Row] = []) {
         self.header = header
         self.rows = rows
     }

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -26,7 +26,7 @@ import UIKit
 
 struct Section {
     typealias HeaderModel = Form.HeaderModel
-    typealias Row = FormRowModel
+    typealias Row = Form.RowModel
 
     let header: HeaderModel?
     let rows: [Row]
@@ -41,12 +41,4 @@ extension Section: ArrayLiteralConvertible {
     init(arrayLiteral elements: Row...) {
         self.init(rows: elements)
     }
-}
-
-
-enum FormRowModel {
-    case TextFieldRow(TextFieldRowModel)
-    case TokenTypeRow(TokenTypeRowModel)
-    case DigitCountRow(DigitCountRowModel)
-    case AlgorithmRow(AlgorithmRowModel)
 }

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -26,19 +26,19 @@ import UIKit
 
 struct Section {
     typealias HeaderModel = Form.HeaderModel
-    typealias Row = Form.RowModel
+    typealias RowModel = Form.RowModel
 
     let header: HeaderModel?
-    let rows: [Row]
+    let rows: [RowModel]
 
-    init(header: HeaderModel? = nil, rows: [Row] = []) {
+    init(header: HeaderModel? = nil, rows: [RowModel] = []) {
         self.header = header
         self.rows = rows
     }
 }
 
 extension Section: ArrayLiteralConvertible {
-    init(arrayLiteral elements: Row...) {
+    init(arrayLiteral elements: RowModel...) {
         self.init(rows: elements)
     }
 }

--- a/Authenticator/Classes/Section.swift
+++ b/Authenticator/Classes/Section.swift
@@ -25,12 +25,13 @@
 import UIKit
 
 struct Section {
+    typealias HeaderModel = Form.HeaderModel
     typealias Row = FormRowModel
 
-    let header: ButtonHeaderViewModel?
+    let header: HeaderModel?
     let rows: [Row]
 
-    init(header: ButtonHeaderViewModel? = nil, rows: [Row] = []) {
+    init(header: HeaderModel? = nil, rows: [Row] = []) {
         self.header = header
         self.rows = rows
     }

--- a/Authenticator/Classes/TableViewModel.swift
+++ b/Authenticator/Classes/TableViewModel.swift
@@ -63,7 +63,7 @@ extension TableViewModel {
         return section.rows[indexPath.row]
     }
 
-    func headerForSection(section: Int) -> HeaderViewModel? {
+    func headerForSection(section: Int) -> ButtonHeaderViewModel? {
         guard sections.indices.contains(section)
             else { return nil }
         return sections[section].header

--- a/Authenticator/Classes/TableViewModel.swift
+++ b/Authenticator/Classes/TableViewModel.swift
@@ -63,7 +63,7 @@ extension TableViewModel {
         return section.rows[indexPath.row]
     }
 
-    func headerForSection(section: Int) -> ButtonHeaderViewModel? {
+    func modelForHeaderInSection(section: Int) -> ButtonHeaderViewModel? {
         guard sections.indices.contains(section)
             else { return nil }
         return sections[section].header

--- a/Authenticator/Classes/TableViewModel.swift
+++ b/Authenticator/Classes/TableViewModel.swift
@@ -54,7 +54,7 @@ extension TableViewModel {
         return sections[section].rows.count
     }
 
-    func modelForRowAtIndexPath(indexPath: NSIndexPath) -> Section.Row? {
+    func modelForRowAtIndexPath(indexPath: NSIndexPath) -> Section.RowModel? {
         guard sections.indices.contains(indexPath.section)
             else { return nil }
         let section = sections[indexPath.section]

--- a/Authenticator/Classes/TableViewModel.swift
+++ b/Authenticator/Classes/TableViewModel.swift
@@ -63,7 +63,7 @@ extension TableViewModel {
         return section.rows[indexPath.row]
     }
 
-    func modelForHeaderInSection(section: Int) -> ButtonHeaderViewModel? {
+    func modelForHeaderInSection(section: Int) -> Section.HeaderModel? {
         guard sections.indices.contains(section)
             else { return nil }
         return sections[section].header

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -73,7 +73,7 @@ class TokenEditForm: NSObject, TokenForm {
         )
     }
 
-    private var issuerRowModel: FormRowModel {
+    private var issuerRowModel: Form.RowModel {
         let model = IssuerRowModel(
             initialValue: state.issuer,
             changeAction: { [weak self] (newIssuer) -> () in
@@ -83,7 +83,7 @@ class TokenEditForm: NSObject, TokenForm {
         return .TextFieldRow(model)
     }
 
-    private var nameRowModel: FormRowModel {
+    private var nameRowModel: Form.RowModel {
         let model = NameRowModel(
             initialValue: state.name,
             returnKeyType: .Done,

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -112,7 +112,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .ButtonHeader(model)
     }
 
-    private var issuerRowModel: FormRowModel {
+    private var issuerRowModel: Form.RowModel {
         let model = IssuerRowModel(
             initialValue: state.issuer,
             changeAction: { [weak self] (newIssuer) -> () in
@@ -122,7 +122,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .TextFieldRow(model)
     }
 
-    private var nameRowModel: FormRowModel {
+    private var nameRowModel: Form.RowModel {
         let model = NameRowModel(
             initialValue: state.name,
             returnKeyType: .Next,
@@ -133,7 +133,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .TextFieldRow(model)
     }
 
-    private var secretRowModel: FormRowModel {
+    private var secretRowModel: Form.RowModel {
         let model = SecretRowModel(
             initialValue: state.secret,
             changeAction: { [weak self] (newSecret) -> () in
@@ -143,7 +143,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .TextFieldRow(model)
     }
 
-    private var tokenTypeRowModel: FormRowModel {
+    private var tokenTypeRowModel: Form.RowModel {
         let model = TokenTypeRowModel(
             initialValue: state.tokenType,
             valueChangedAction: { [weak self] (newTokenType) -> () in
@@ -153,7 +153,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .TokenTypeRow(model)
     }
 
-    private var digitCountRowModel: FormRowModel {
+    private var digitCountRowModel: Form.RowModel {
         let model = DigitCountRowModel(
             initialValue: state.digitCount,
             valueChangedAction: { [weak self] (newDigitCount) -> () in
@@ -163,7 +163,7 @@ class TokenEntryForm: NSObject, TokenForm {
         return .DigitCountRow(model)
     }
 
-    private var algorithmRowModel: FormRowModel {
+    private var algorithmRowModel: Form.RowModel {
         let model = AlgorithmRowModel(
             initialValue: state.algorithm,
             valueChangedAction: { [weak self] (newAlgorithm) -> () in

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -105,8 +105,8 @@ class TokenEntryForm: NSObject, TokenForm {
         )
     }
 
-    private var advancedSectionHeader: HeaderViewModel {
-        return HeaderViewModel(title: "Advanced Options") { [weak self] in
+    private var advancedSectionHeader: ButtonHeaderViewModel {
+        return ButtonHeaderViewModel(title: "Advanced Options") { [weak self] in
             self?.toggleAdvancedOptions()
         }
     }

--- a/Authenticator/Classes/TokenEntryForm.swift
+++ b/Authenticator/Classes/TokenEntryForm.swift
@@ -105,10 +105,11 @@ class TokenEntryForm: NSObject, TokenForm {
         )
     }
 
-    private var advancedSectionHeader: ButtonHeaderViewModel {
-        return ButtonHeaderViewModel(title: "Advanced Options") { [weak self] in
+    private var advancedSectionHeader: Form.HeaderModel {
+        let model = ButtonHeaderViewModel(title: "Advanced Options") { [weak self] in
             self?.toggleAdvancedOptions()
         }
+        return .ButtonHeader(model)
     }
 
     private var issuerRowModel: FormRowModel {

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -178,7 +178,7 @@ class TokenFormViewController: UITableViewController {
 
     // MARK: Row Model Helpers
 
-    func cellForRowModel(rowModel: FormRowModel) -> UITableViewCell {
+    func cellForRowModel(rowModel: Form.RowModel) -> UITableViewCell {
         switch rowModel {
         case .TextFieldRow(let textFieldViewModel):
             return OTPTextFieldCell(viewModel: textFieldViewModel)
@@ -191,7 +191,7 @@ class TokenFormViewController: UITableViewController {
         }
     }
 
-    func heightForRowModel(rowModel: FormRowModel) -> CGFloat {
+    func heightForRowModel(rowModel: Form.RowModel) -> CGFloat {
         switch rowModel {
         case .TextFieldRow(let textFieldViewModel):
             return OTPTextFieldCell.heightWithViewModel(textFieldViewModel)

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -137,13 +137,13 @@ class TokenFormViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let headerViewModel = viewModel.headerForSection(section)
+        guard let headerViewModel = viewModel.modelForHeaderInSection(section)
             else { return CGFloat(FLT_EPSILON) }
         return ButtonHeaderView.heightWithViewModel(headerViewModel)
     }
 
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let headerViewModel = viewModel.headerForSection(section)
+        guard let headerViewModel = viewModel.modelForHeaderInSection(section)
             else { return nil }
         return ButtonHeaderView(viewModel: headerViewModel)
     }

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -139,13 +139,13 @@ class TokenFormViewController: UITableViewController {
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         guard let headerViewModel = viewModel.headerForSection(section)
             else { return CGFloat(FLT_EPSILON) }
-        return OTPHeaderView.heightWithViewModel(headerViewModel)
+        return ButtonHeaderView.heightWithViewModel(headerViewModel)
     }
 
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let headerViewModel = viewModel.headerForSection(section)
             else { return nil }
-        return OTPHeaderView(viewModel: headerViewModel)
+        return ButtonHeaderView(viewModel: headerViewModel)
     }
 
     // MARK: - Update

--- a/Authenticator/Classes/TokenFormViewController.swift
+++ b/Authenticator/Classes/TokenFormViewController.swift
@@ -137,15 +137,15 @@ class TokenFormViewController: UITableViewController {
     }
 
     override func tableView(tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        guard let headerViewModel = viewModel.modelForHeaderInSection(section)
+        guard let headerModel = viewModel.modelForHeaderInSection(section)
             else { return CGFloat(FLT_EPSILON) }
-        return ButtonHeaderView.heightWithViewModel(headerViewModel)
+        return heightForHeaderModel(headerModel)
     }
 
     override func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let headerViewModel = viewModel.modelForHeaderInSection(section)
+        guard let headerModel = viewModel.modelForHeaderInSection(section)
             else { return nil }
-        return ButtonHeaderView(viewModel: headerViewModel)
+        return viewForHeaderModel(headerModel)
     }
 
     // MARK: - Update
@@ -201,6 +201,22 @@ class TokenFormViewController: UITableViewController {
             return OTPSegmentedControlCell.heightWithViewModel(segmentedControlViewModel)
         case .AlgorithmRow(let segmentedControlViewModel):
             return OTPSegmentedControlCell.heightWithViewModel(segmentedControlViewModel)
+        }
+    }
+
+    // MARK: Header Model Helpers
+
+    func viewForHeaderModel(headerModel: Form.HeaderModel) -> UIView {
+        switch headerModel {
+        case .ButtonHeader(let viewModel):
+            return ButtonHeaderView(viewModel: viewModel)
+        }
+    }
+
+    func heightForHeaderModel(headerModel: Form.HeaderModel) -> CGFloat {
+        switch headerModel {
+        case .ButtonHeader(let viewModel):
+            return ButtonHeaderView.heightWithViewModel(viewModel)
         }
     }
 }


### PR DESCRIPTION
Rename `OTPHeaderView` to `ButtonHeaderView` and `HeaderViewModel` to `ButtonHeaderViewModel`. Rename `FormRowModel` to `Form.RowModel` and create a similar `Form.HeaderModel` enum for specifying and constructing section headers.