### PR TITLE
Replace TokenEditFormDelegate with Event callback

### DIFF
--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -206,11 +206,10 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
     }
 
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        let keychainItem = self.tokenManager.keychainItemAtIndex(indexPath.row)
         if self.editing {
-            let keychainItem = self.tokenManager.keychainItemAtIndex(indexPath.row)
             editKeychainItem(keychainItem)
         } else {
-            let keychainItem = self.tokenManager.keychainItemAtIndex(indexPath.row)
             if let password = keychainItem.token.currentPassword {
                 UIPasteboard.generalPasteboard().setValue(password, forPasteboardType: kUTTypeUTF8PlainText as String)
                 SVProgressHUD.showSuccessWithStatus("Copied")

--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -220,13 +220,11 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
     private func editKeychainItem(keychainItem: Token.KeychainItem) {
         let form = TokenEditForm(token: keychainItem.token) { [weak self] (event) in
             switch event {
-            case .Cancel:
-                self?.dismissViewControllerAnimated(true, completion: nil)
-
+            case .Cancel: break
             case .Save(let token):
-                self?.dismissViewControllerAnimated(true, completion: nil)
                 self?.saveToken(token, toKeychainItem: keychainItem)
             }
+            self?.dismissViewControllerAnimated(true, completion: nil)
         }
 
         let editController = TokenFormViewController(form: form)

--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -226,6 +226,15 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
 }
 
 extension OTPTokenListViewController: TokenEditFormDelegate {
+    func tokenEditForm(form: TokenEditForm, didSendEvent event: TokenEditForm.Event) {
+        switch event {
+        case .Cancel:
+            self.editFormDidCancel(form)
+        case .Save(let token):
+            self.form(form, didEditToken: token)
+        }
+    }
+
     func editFormDidCancel(form: TokenEditForm) {
         dismissViewControllerAnimated(true, completion: nil)
     }

--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -222,9 +222,11 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
         let form = TokenEditForm(keychainItem: keychainItem) { [weak self] (form, event) in
             switch event {
             case .Cancel:
-                self?.editFormDidCancel(form)
+                self?.dismissViewControllerAnimated(true, completion: nil)
+
             case .Save(let token):
-                self?.form(form, didEditToken: token)
+                self?.dismissViewControllerAnimated(true, completion: nil)
+                self?.saveToken(token, toKeychainItem: form.keychainItem)
             }
         }
 
@@ -234,20 +236,12 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
 
         self.presentViewController(navController, animated: true, completion: nil)
     }
-}
 
-extension OTPTokenListViewController {
-    func editFormDidCancel(form: TokenEditForm) {
-        dismissViewControllerAnimated(true, completion: nil)
-    }
-
-    func form(form: TokenEditForm, didEditToken token: Token) {
-        self.dismissViewControllerAnimated(true, completion: nil)
-        if tokenManager.saveToken(token, toKeychainItem: form.keychainItem) {
+    private func saveToken(token: Token, toKeychainItem keychainItem: Token.KeychainItem) {
+        if tokenManager.saveToken(token, toKeychainItem: keychainItem) {
             tableView.reloadData()
         }
     }
-
 }
 
 extension OTPTokenListViewController: TokenEntryFormDelegate {

--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -219,14 +219,14 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
     }
 
     private func editKeychainItem(keychainItem: Token.KeychainItem) {
-        let form = TokenEditForm(keychainItem: keychainItem) { [weak self] (form, event) in
+        let form = TokenEditForm(token: keychainItem.token) { [weak self] (form, event) in
             switch event {
             case .Cancel:
                 self?.dismissViewControllerAnimated(true, completion: nil)
 
             case .Save(let token):
                 self?.dismissViewControllerAnimated(true, completion: nil)
-                self?.saveToken(token, toKeychainItem: form.keychainItem)
+                self?.saveToken(token, toKeychainItem: keychainItem)
             }
         }
 

--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -219,7 +219,7 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
     }
 
     private func editKeychainItem(keychainItem: Token.KeychainItem) {
-        let form = TokenEditForm(token: keychainItem.token) { [weak self] (form, event) in
+        let form = TokenEditForm(token: keychainItem.token) { [weak self] (event) in
             switch event {
             case .Cancel:
                 self?.dismissViewControllerAnimated(true, completion: nil)

--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -219,7 +219,14 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
     }
 
     private func editKeychainItem(keychainItem: Token.KeychainItem) {
-        let form = TokenEditForm(keychainItem: keychainItem, delegate: self)
+        let form = TokenEditForm(keychainItem: keychainItem) { (form, event) in
+            switch event {
+            case .Cancel:
+                self.editFormDidCancel(form)
+            case .Save(let token):
+                self.form(form, didEditToken: token)
+            }
+        }
         let editController = TokenFormViewController(form: form)
         let navController = UINavigationController(rootViewController: editController)
         navController.navigationBar.translucent = false
@@ -228,16 +235,7 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
     }
 }
 
-extension OTPTokenListViewController: TokenEditFormDelegate {
-    func tokenEditForm(form: TokenEditForm, didSendEvent event: TokenEditForm.Event) {
-        switch event {
-        case .Cancel:
-            self.editFormDidCancel(form)
-        case .Save(let token):
-            self.form(form, didEditToken: token)
-        }
-    }
-
+extension OTPTokenListViewController {
     func editFormDidCancel(form: TokenEditForm) {
         dismissViewControllerAnimated(true, completion: nil)
     }

--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -208,12 +208,7 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         if self.editing {
             let keychainItem = self.tokenManager.keychainItemAtIndex(indexPath.row)
-            let form = TokenEditForm(keychainItem: keychainItem, delegate: self)
-            let editController = TokenFormViewController(form: form)
-            let navController = UINavigationController(rootViewController: editController)
-            navController.navigationBar.translucent = false
-
-            self.presentViewController(navController, animated: true, completion: nil)
+            editKeychainItem(keychainItem)
         } else {
             let keychainItem = self.tokenManager.keychainItemAtIndex(indexPath.row)
             if let password = keychainItem.token.currentPassword {
@@ -223,6 +218,14 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
         }
     }
 
+    private func editKeychainItem(keychainItem: Token.KeychainItem) {
+        let form = TokenEditForm(keychainItem: keychainItem, delegate: self)
+        let editController = TokenFormViewController(form: form)
+        let navController = UINavigationController(rootViewController: editController)
+        navController.navigationBar.translucent = false
+
+        self.presentViewController(navController, animated: true, completion: nil)
+    }
 }
 
 extension OTPTokenListViewController: TokenEditFormDelegate {

--- a/Authenticator/Classes/OTPTokenListViewController.swift
+++ b/Authenticator/Classes/OTPTokenListViewController.swift
@@ -219,14 +219,15 @@ extension OTPTokenListViewController /* UITableViewDelegate */ {
     }
 
     private func editKeychainItem(keychainItem: Token.KeychainItem) {
-        let form = TokenEditForm(keychainItem: keychainItem) { (form, event) in
+        let form = TokenEditForm(keychainItem: keychainItem) { [weak self] (form, event) in
             switch event {
             case .Cancel:
-                self.editFormDidCancel(form)
+                self?.editFormDidCancel(form)
             case .Save(let token):
-                self.form(form, didEditToken: token)
+                self?.form(form, didEditToken: token)
             }
         }
+
         let editController = TokenFormViewController(form: form)
         let navController = UINavigationController(rootViewController: editController)
         navController.navigationBar.translucent = false

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -96,14 +96,14 @@ class TokenEditForm: TokenForm {
 
     // MARK: Initialization
 
-    let keychainItem: Token.KeychainItem
+    private let token: Token
 
-    init(keychainItem: Token.KeychainItem, callback: (TokenEditForm, Event) -> ()) {
-        self.keychainItem = keychainItem
+    init(token: Token, callback: (TokenEditForm, Event) -> ()) {
+        self.token = token
         self.callback = callback
         state = State(
-            issuer: keychainItem.token.issuer,
-            name: keychainItem.token.name
+            issuer: token.issuer,
+            name: token.name
         )
     }
 
@@ -119,7 +119,7 @@ class TokenEditForm: TokenForm {
         let editedToken = Token(
             name: state.name,
             issuer: state.issuer,
-            generator: keychainItem.token.generator
+            generator: token.generator
         )
         callback(self, .Save(editedToken))
     }

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -31,7 +31,7 @@ class TokenEditForm: TokenForm {
     }
 
     weak var presenter: TokenFormPresenter?
-    private let callback: (TokenEditForm, Event) -> ()
+    private let callback: (Event) -> ()
 
     // MARK: State
 
@@ -98,7 +98,7 @@ class TokenEditForm: TokenForm {
 
     private let token: Token
 
-    init(token: Token, callback: (TokenEditForm, Event) -> ()) {
+    init(token: Token, callback: (Event) -> ()) {
         self.token = token
         self.callback = callback
         state = State(
@@ -110,7 +110,7 @@ class TokenEditForm: TokenForm {
     // MARK: Actions
 
     func cancel() {
-        callback(self, .Cancel)
+        callback(.Cancel)
     }
 
     func submit() {
@@ -121,6 +121,6 @@ class TokenEditForm: TokenForm {
             issuer: state.issuer,
             generator: token.generator
         )
-        callback(self, .Save(editedToken))
+        callback(.Save(editedToken))
     }
 }

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -25,11 +25,15 @@
 import OneTimePassword
 
 protocol TokenEditFormDelegate: class {
-    func editFormDidCancel(form: TokenEditForm)
-    func form(form: TokenEditForm, didEditToken token: Token)
+    func tokenEditForm(form: TokenEditForm, didSendEvent event: TokenEditForm.Event)
 }
 
 class TokenEditForm: TokenForm {
+    enum Event {
+        case Cancel
+        case Save(Token)
+    }
+
     weak var presenter: TokenFormPresenter?
     private weak var delegate: TokenEditFormDelegate?
 
@@ -110,7 +114,7 @@ class TokenEditForm: TokenForm {
     // MARK: Actions
 
     func cancel() {
-        delegate?.editFormDidCancel(self)
+        delegate?.tokenEditForm(self, didSendEvent: .Cancel)
     }
 
     func submit() {
@@ -121,6 +125,6 @@ class TokenEditForm: TokenForm {
             issuer: state.issuer,
             generator: keychainItem.token.generator
         )
-        delegate?.form(self, didEditToken: editedToken)
+        delegate?.tokenEditForm(self, didSendEvent: .Save(editedToken))
     }
 }

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -38,6 +38,7 @@ class TokenEditForm: TokenForm {
     private struct State {
         var issuer: String
         var name: String
+        let generator: Generator
 
         var isValid: Bool {
             return !(issuer.isEmpty && name.isEmpty)
@@ -96,14 +97,12 @@ class TokenEditForm: TokenForm {
 
     // MARK: Initialization
 
-    private let token: Token
-
     init(token: Token, callback: (Event) -> ()) {
-        self.token = token
         self.callback = callback
         state = State(
             issuer: token.issuer,
-            name: token.name
+            name: token.name,
+            generator: token.generator
         )
     }
 
@@ -119,7 +118,7 @@ class TokenEditForm: TokenForm {
         let editedToken = Token(
             name: state.name,
             issuer: state.issuer,
-            generator: token.generator
+            generator: state.generator
         )
         callback(.Save(editedToken))
     }

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -25,12 +25,15 @@
 import OneTimePassword
 
 class TokenEditForm: TokenForm {
+    weak var presenter: TokenFormPresenter?
+
+    // MARK: Events
+
     enum Event {
         case Cancel
         case Save(Token)
     }
 
-    weak var presenter: TokenFormPresenter?
     private let callback: (Event) -> ()
 
     // MARK: State
@@ -113,13 +116,13 @@ class TokenEditForm: TokenForm {
     }
 
     func submit() {
-        if !state.isValid { return }
+        guard state.isValid else { return }
 
-        let editedToken = Token(
+        let token = Token(
             name: state.name,
             issuer: state.issuer,
             generator: state.generator
         )
-        callback(.Save(editedToken))
+        callback(.Save(token))
     }
 }

--- a/Authenticator/Classes/TokenEditForm.swift
+++ b/Authenticator/Classes/TokenEditForm.swift
@@ -24,10 +24,6 @@
 
 import OneTimePassword
 
-protocol TokenEditFormDelegate: class {
-    func tokenEditForm(form: TokenEditForm, didSendEvent event: TokenEditForm.Event)
-}
-
 class TokenEditForm: TokenForm {
     enum Event {
         case Cancel
@@ -35,7 +31,7 @@ class TokenEditForm: TokenForm {
     }
 
     weak var presenter: TokenFormPresenter?
-    private weak var delegate: TokenEditFormDelegate?
+    private let callback: (TokenEditForm, Event) -> ()
 
     // MARK: State
 
@@ -102,9 +98,9 @@ class TokenEditForm: TokenForm {
 
     let keychainItem: Token.KeychainItem
 
-    init(keychainItem: Token.KeychainItem, delegate: TokenEditFormDelegate) {
+    init(keychainItem: Token.KeychainItem, callback: (TokenEditForm, Event) -> ()) {
         self.keychainItem = keychainItem
-        self.delegate = delegate
+        self.callback = callback
         state = State(
             issuer: keychainItem.token.issuer,
             name: keychainItem.token.name
@@ -114,7 +110,7 @@ class TokenEditForm: TokenForm {
     // MARK: Actions
 
     func cancel() {
-        delegate?.tokenEditForm(self, didSendEvent: .Cancel)
+        callback(self, .Cancel)
     }
 
     func submit() {
@@ -125,6 +121,6 @@ class TokenEditForm: TokenForm {
             issuer: state.issuer,
             generator: keychainItem.token.generator
         )
-        delegate?.tokenEditForm(self, didSendEvent: .Save(editedToken))
+        callback(self, .Save(editedToken))
     }
 }


### PR DESCRIPTION
Replace the multiple methods of `TokenEditFormDelegate` with a single callback closure that takes an `TokenEditForm.Event` enum value. This allows information associated with the editing of a token (the keychain item) to be captured by the callback closure when the form is created, instead of being manually retained in the form only to be read out by the delegate later.