### PR TITLE
Automatic table view update animations

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		1D3623260D0F684500981E51 /* OTPAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* OTPAppDelegate.swift */; };
 		8B0028B511EB75920092DE18 /* ScannerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0028B411EB75920092DE18 /* ScannerOverlayView.swift */; };
 		C9078D181AB7E90A0068A11D /* OTPTextFieldCell+TokenForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9078D171AB7E90A0068A11D /* OTPTextFieldCell+TokenForm.swift */; };
-		C910ADC11BF0315A00C988F5 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C910ADC01BF0315A00C988F5 /* TokenManager.swift */; settings = {ASSET_TAGS = (); }; };
+		C910ADC11BF0315A00C988F5 /* TokenManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C910ADC01BF0315A00C988F5 /* TokenManager.swift */; };
 		C92708AC19CFB0750033128B /* OTPTokenListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92708AB19CFB0750033128B /* OTPTokenListViewController.swift */; };
 		C93AD15219CD51BE007480E9 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93AD15119CD51BE007480E9 /* Colors.swift */; };
 		C944A5571A7ECB0800E08B1E /* OneTimePassword.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C944A5561A7ECB0800E08B1E /* OneTimePassword.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -18,8 +18,8 @@
 		C97B68C717D9226D005D1FE0 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = C97B68C617D9226D005D1FE0 /* Settings.bundle */; };
 		C97CDF261BEEA66A00D64406 /* SVProgressHUD.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C97CDF241BEEA49300D64406 /* SVProgressHUD.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C97CDF291BEEA82B00D64406 /* CommonCrypto.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C97CDF271BEEA7DA00D64406 /* CommonCrypto.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C97CDF2C1BEEC90100D64406 /* QRScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97CDF2B1BEEC90100D64406 /* QRScanner.swift */; settings = {ASSET_TAGS = (); }; };
-		C9800C491BCAA81D00CCB9B7 /* FormModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9800C481BCAA81D00CCB9B7 /* FormModels.swift */; settings = {ASSET_TAGS = (); }; };
+		C97CDF2C1BEEC90100D64406 /* QRScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97CDF2B1BEEC90100D64406 /* QRScanner.swift */; };
+		C9800C491BCAA81D00CCB9B7 /* FormModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9800C481BCAA81D00CCB9B7 /* FormModels.swift */; };
 		C983AB74197F98FC00975003 /* OTPAuthenticatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C983AB73197F98FC00975003 /* OTPAuthenticatorTests.m */; };
 		C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1EC91AB2CEC300C59E53 /* TokenRowModel.swift */; };
 		C98B1ECC1AB3CF0700C59E53 /* TokenRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */; };
@@ -27,15 +27,16 @@
 		C9919CDD1BA64EED006237C1 /* TokenEntryForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */; };
 		C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */; };
 		C9919CE21BA733FD006237C1 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CE11BA733FD006237C1 /* Section.swift */; };
-		C99B85251BC9AB7100A6C75D /* BarButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99B85241BC9AB7100A6C75D /* BarButtonViewModel.swift */; settings = {ASSET_TAGS = (); }; };
+		C99B85251BC9AB7100A6C75D /* BarButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99B85241BC9AB7100A6C75D /* BarButtonViewModel.swift */; };
 		C9AAB0791B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB0781B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift */; };
 		C9AAB07F1B917EC3000CE547 /* TokenEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB07E1B917EC3000CE547 /* TokenEditForm.swift */; };
 		C9AAB0811B9187F8000CE547 /* TokenForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB0801B9187F8000CE547 /* TokenForm.swift */; };
+		C9B7328D1C09495D0076F77E /* TableDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B7328C1C09495D0076F77E /* TableDiff.swift */; };
 		C9BEAE6019C67FD800533385 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = C9BEAE5F19C67FD800533385 /* LaunchScreen.xib */; };
 		C9C6CCA21842E331000100C2 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C9C6CCA11842E331000100C2 /* Images.xcassets */; };
-		C9CC09511BA903B7008C54FE /* TokenFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09501BA903B7008C54FE /* TokenFormViewController.swift */; settings = {ASSET_TAGS = (); }; };
-		C9CC09531BA9133B008C54FE /* FocusCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09521BA9133B008C54FE /* FocusCell.swift */; settings = {ASSET_TAGS = (); }; };
-		C9CC09551BA91D1C008C54FE /* TableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09541BA91D1C008C54FE /* TableViewModel.swift */; settings = {ASSET_TAGS = (); }; };
+		C9CC09511BA903B7008C54FE /* TokenFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09501BA903B7008C54FE /* TokenFormViewController.swift */; };
+		C9CC09531BA9133B008C54FE /* FocusCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09521BA9133B008C54FE /* FocusCell.swift */; };
+		C9CC09551BA91D1C008C54FE /* TableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09541BA91D1C008C54FE /* TableViewModel.swift */; };
 		C9D6C83F1906BD68004F0E08 /* SegmentedControlRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C83E1906BD68004F0E08 /* SegmentedControlRowCell.swift */; };
 		C9D6C8461906CD54004F0E08 /* TextFieldRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C8451906CD54004F0E08 /* TextFieldRowCell.swift */; };
 		C9D6C84C19075044004F0E08 /* OTPProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C84B19075044004F0E08 /* OTPProgressRing.swift */; };
@@ -118,6 +119,7 @@
 		C9AAB0781B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OTPSegmentedControlCell+TokenForm.swift"; sourceTree = "<group>"; };
 		C9AAB07E1B917EC3000CE547 /* TokenEditForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenEditForm.swift; sourceTree = "<group>"; };
 		C9AAB0801B9187F8000CE547 /* TokenForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenForm.swift; sourceTree = "<group>"; };
+		C9B7328C1C09495D0076F77E /* TableDiff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableDiff.swift; sourceTree = "<group>"; };
 		C9BEAE5F19C67FD800533385 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		C9C6CCA11842E331000100C2 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		C9CC09501BA903B7008C54FE /* TokenFormViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenFormViewController.swift; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 			isa = PBXGroup;
 			children = (
 				C93AD15119CD51BE007480E9 /* Colors.swift */,
+				C9B7328C1C09495D0076F77E /* TableDiff.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -525,6 +528,7 @@
 				1D3623260D0F684500981E51 /* OTPAppDelegate.swift in Sources */,
 				C9919CE21BA733FD006237C1 /* Section.swift in Sources */,
 				C9D6C8461906CD54004F0E08 /* TextFieldRowCell.swift in Sources */,
+				C9B7328D1C09495D0076F77E /* TableDiff.swift in Sources */,
 				C97CDF2C1BEEC90100D64406 /* QRScanner.swift in Sources */,
 				C9AAB07F1B917EC3000CE547 /* TokenEditForm.swift in Sources */,
 				C9D6C84C19075044004F0E08 /* OTPProgressRing.swift in Sources */,

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -1,0 +1,70 @@
+//
+//  TableDiff.swift
+//  Authenticator
+//
+//  Copyright (c) 2015 Authenticator authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+enum Change {
+    case Insert(index: Int)
+    case Update(index: Int)
+    case Delete(index: Int)
+    case Move(fromIndex: Int, toIndex: Int)
+}
+
+func diff<Row>(from groupA: ArraySlice<Row>, to groupB: ArraySlice<Row>, comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
+    // Work from the end to preserve earlier indices when recursing
+    switch (groupA.last, groupB.last) {
+    case let (.Some(a), .Some(b)):
+        if isSameRow(a, b) {
+            // TODO: Don't update if the rows are truly equal
+            let update = Change.Update(index: groupB.endIndex.predecessor())
+            let remainingChanges = diff(from: groupA.dropLast(), to: groupB.dropLast(), comparator: isSameRow)
+            return [update] + remainingChanges
+        } else {
+            let insertion = Change.Insert(index: groupB.endIndex.predecessor())
+            let changesAfterInsertion = diff(from: groupA, to: groupB.dropLast(), comparator: isSameRow)
+            let changesWithInsertion = [insertion] + changesAfterInsertion
+
+            let deletion = Change.Delete(index: groupA.endIndex.predecessor())
+            let changesAfterDeletion = diff(from: groupA.dropLast(), to: groupB, comparator: isSameRow)
+            let changesWithDeletion = [deletion] + changesAfterDeletion
+
+            return changesWithInsertion.count < changesWithDeletion.count
+                ? changesWithInsertion
+                : changesWithDeletion
+        }
+    case (.Some, .None):
+        let deletion = Change.Delete(index: groupA.endIndex.predecessor())
+        let remainingChanges = diff(from: groupA.dropLast(), to: groupB, comparator: isSameRow)
+        return [deletion] + remainingChanges
+
+    case (.None, .Some):
+        let insertion = Change.Insert(index: groupB.endIndex.predecessor())
+        let remainingChanges = diff(from: groupA, to: groupB.dropLast(), comparator: isSameRow)
+        return [insertion] + remainingChanges
+
+    case (.None, .None):
+        return []
+    }
+}

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -29,13 +29,14 @@ enum Change {
     case Insert(index: Int)
     case Update(index: Int)
     case Delete(index: Int)
+    // TODO: Consolidate matching Inserts and Deletes into Moves
     case Move(fromIndex: Int, toIndex: Int)
 }
 
-func diff<Row>(from oldArray: [Row], to newArray: [Row], comparator isSameRow: (Row, Row) -> Bool)
+func diff<Row>(from oldRows: [Row], to newRows: [Row], comparator isSameRow: (Row, Row) -> Bool)
     -> [Change]
 {
-    return changes(from: ArraySlice(oldArray), to: ArraySlice(newArray), comparator: isSameRow)
+    return changes(from: ArraySlice(oldRows), to: ArraySlice(newRows), comparator: isSameRow)
 }
 
 private func changes<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -33,64 +33,69 @@ enum Change {
 }
 
 func diff<Row>(from oldArray: [Row], to newArray: [Row], comparator isSameRow: (Row, Row) -> Bool)
-    -> [Change] {
-        return changes(from: ArraySlice(oldArray), to: ArraySlice(newArray), comparator: isSameRow)
+    -> [Change]
+{
+    return changes(from: ArraySlice(oldArray), to: ArraySlice(newArray), comparator: isSameRow)
 }
 
 private func changes<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
-    comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
-        // Work from the end to preserve earlier indices when recursing
-        switch (oldRows.last, newRows.last) {
-        case let (.Some(oldRow), .Some(newRow)):
-            if isSameRow(oldRow, newRow) {
-                // The old and new rows are the same row, and can be represented by an Update
-                // TODO: Don't update if the rows are truly equal
-                return changesWithUpdate(from: oldRows, to: newRows, comparator: isSameRow)
-            } else {
-                // The old and new rows are different, so compute the two possible change sets:
-                // one where the old row is deleted, another where the new row is inserted
-                let changesA = changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
-                let changesB = changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
+    comparator isSameRow: (Row, Row) -> Bool) -> [Change]
+{
+    // Work from the end to preserve earlier indices when recursing
+    switch (oldRows.last, newRows.last) {
+    case let (.Some(oldRow), .Some(newRow)):
+        if isSameRow(oldRow, newRow) {
+            // The old and new rows are the same row, and can be represented by an Update
+            // TODO: Don't update if the rows are truly equal
+            return changesWithUpdate(from: oldRows, to: newRows, comparator: isSameRow)
+        } else {
+            // The old and new rows are different, so compute the two possible change sets:
+            // one where the old row is deleted, another where the new row is inserted
+            let changesA = changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
+            let changesB = changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
 
-                // Return the shorter of the two change sets
-                return changesA.count < changesB.count ? changesA : changesB
-            }
-
-        case (.Some, .None):
-            // Only old rows remain, which must be deleted
-            return changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
-
-        case (.None, .Some):
-            // Only new rows remain, which must be inserted
-            return changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
-
-        case (.None, .None):
-            // All rows are accounted for
-            return []
+            // Return the shorter of the two change sets
+            return changesA.count < changesB.count ? changesA : changesB
         }
+
+    case (.Some, .None):
+        // Only old rows remain, which must be deleted
+        return changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
+
+    case (.None, .Some):
+        // Only new rows remain, which must be inserted
+        return changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
+
+    case (.None, .None):
+        // All rows are accounted for
+        return []
+    }
 }
 
 private func changesWithInsertion<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
-    comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
-        let insertion = Change.Insert(index: newRows.endIndex.predecessor())
-        let changesAfterInsertion = changes(from: oldRows, to: newRows.dropLast(),
-            comparator: isSameRow)
-        return [insertion] + changesAfterInsertion
+    comparator isSameRow: (Row, Row) -> Bool) -> [Change]
+{
+    let insertion = Change.Insert(index: newRows.endIndex.predecessor())
+    let changesAfterInsertion = changes(from: oldRows, to: newRows.dropLast(),
+        comparator: isSameRow)
+    return [insertion] + changesAfterInsertion
 }
 
 private func changesWithUpdate<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
-    comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
-        // TODO: Test update indices
-        let update = Change.Update(index: newRows.endIndex.predecessor())
-        let changesAfterUpdate = changes(from: oldRows.dropLast(), to: newRows.dropLast(),
-            comparator: isSameRow)
-        return [update] + changesAfterUpdate
+    comparator isSameRow: (Row, Row) -> Bool) -> [Change]
+{
+    // TODO: Test update indices
+    let update = Change.Update(index: newRows.endIndex.predecessor())
+    let changesAfterUpdate = changes(from: oldRows.dropLast(), to: newRows.dropLast(),
+        comparator: isSameRow)
+    return [update] + changesAfterUpdate
 }
 
 private func changesWithDeletion<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
-    comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
-        let deletion = Change.Delete(index: oldRows.endIndex.predecessor())
-        let changesAfterDeletion = changes(from: oldRows.dropLast(), to: newRows,
-            comparator: isSameRow)
-        return [deletion] + changesAfterDeletion
+    comparator isSameRow: (Row, Row) -> Bool) -> [Change]
+{
+    let deletion = Change.Delete(index: oldRows.endIndex.predecessor())
+    let changesAfterDeletion = changes(from: oldRows.dropLast(), to: newRows,
+        comparator: isSameRow)
+    return [deletion] + changesAfterDeletion
 }

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -32,40 +32,42 @@ enum Change {
     case Move(fromIndex: Int, toIndex: Int)
 }
 
-func diff<Row>(from oldArray: [Row], to newArray: [Row], comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
-    return changes(from: ArraySlice(oldArray), to: ArraySlice(newArray), comparator: isSameRow)
+func diff<Row>(from oldArray: [Row], to newArray: [Row], comparator isSameRow: (Row, Row) -> Bool)
+    -> [Change] {
+        return changes(from: ArraySlice(oldArray), to: ArraySlice(newArray), comparator: isSameRow)
 }
 
-private func changes<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>, comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
-    // Work from the end to preserve earlier indices when recursing
-    switch (oldRows.last, newRows.last) {
-    case let (.Some(oldRow), .Some(newRow)):
-        if isSameRow(oldRow, newRow) {
-            // The old and new rows are the same row, and can be represented by an Update
-            // TODO: Don't update if the rows are truly equal
-            return changesWithUpdate(from: oldRows, to: newRows, comparator: isSameRow)
-        } else {
-            // The old and new rows are different, so compute the two possible change sets:
-            // one where the old row is deleted, another where the new row is inserted
-            let changesA = changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
-            let changesB = changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
+private func changes<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
+    comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
+        // Work from the end to preserve earlier indices when recursing
+        switch (oldRows.last, newRows.last) {
+        case let (.Some(oldRow), .Some(newRow)):
+            if isSameRow(oldRow, newRow) {
+                // The old and new rows are the same row, and can be represented by an Update
+                // TODO: Don't update if the rows are truly equal
+                return changesWithUpdate(from: oldRows, to: newRows, comparator: isSameRow)
+            } else {
+                // The old and new rows are different, so compute the two possible change sets:
+                // one where the old row is deleted, another where the new row is inserted
+                let changesA = changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
+                let changesB = changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
 
-            // Return the shorter of the two change sets
-            return changesA.count < changesB.count ? changesA : changesB
+                // Return the shorter of the two change sets
+                return changesA.count < changesB.count ? changesA : changesB
+            }
+
+        case (.Some, .None):
+            // Only old rows remain, which must be deleted
+            return changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
+
+        case (.None, .Some):
+            // Only new rows remain, which must be inserted
+            return changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
+
+        case (.None, .None):
+            // All rows are accounted for
+            return []
         }
-
-    case (.Some, .None):
-        // Only old rows remain, which must be deleted
-        return changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
-
-    case (.None, .Some):
-        // Only new rows remain, which must be inserted
-        return changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
-
-    case (.None, .None):
-        // All rows are accounted for
-        return []
-    }
 }
 
 private func changesWithInsertion<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -46,7 +46,7 @@ private func changes<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<
     case let (.Some(oldRow), .Some(newRow)):
         if isSameRow(oldRow, newRow) {
             // The old and new rows are the same row, and can be represented by an Update
-            // TODO: Don't update if the rows are truly equal
+            // TODO: Don't update if the rows are truly equal (requires Row to be Equatable)
             return changesWithUpdate(from: oldRows, to: newRows, comparator: isSameRow)
         } else {
             // The old and new rows are different, so compute the two possible change sets:
@@ -84,7 +84,7 @@ private func changesWithInsertion<Row>(from oldRows: ArraySlice<Row>, to newRows
 private func changesWithUpdate<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
     comparator isSameRow: (Row, Row) -> Bool) -> [Change]
 {
-    // TODO: Test update indices
+    // TODO: Test update indices (old index or new?)
     let update = Change.Update(index: newRows.endIndex.predecessor())
     let changesAfterUpdate = changes(from: oldRows.dropLast(), to: newRows.dropLast(),
         comparator: isSameRow)

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -43,18 +43,22 @@ private func changes<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<
         if isSameRow(oldRow, newRow) {
             // The old and new rows are the same row, and can be represented by an Update
             // TODO: Don't update if the rows are truly equal
+            // TODO: Test update indices
             let update = Change.Update(index: newRows.endIndex.predecessor())
-            let remainingChanges = changes(from: oldRows.dropLast(), to: newRows.dropLast(), comparator: isSameRow)
+            let remainingChanges = changes(from: oldRows.dropLast(), to: newRows.dropLast(),
+                comparator: isSameRow)
             return [update] + remainingChanges
         } else {
             // The old and new rows are different, so compute the two possible change sets:
             // one where the old row is deleted, another where the new row is inserted
             let insertion = Change.Insert(index: newRows.endIndex.predecessor())
-            let changesAfterInsertion = changes(from: oldRows, to: newRows.dropLast(), comparator: isSameRow)
+            let changesAfterInsertion = changes(from: oldRows, to: newRows.dropLast(),
+                comparator: isSameRow)
             let changesWithInsertion = [insertion] + changesAfterInsertion
 
             let deletion = Change.Delete(index: oldRows.endIndex.predecessor())
-            let changesAfterDeletion = changes(from: oldRows.dropLast(), to: newRows, comparator: isSameRow)
+            let changesAfterDeletion = changes(from: oldRows.dropLast(), to: newRows,
+                comparator: isSameRow)
             let changesWithDeletion = [deletion] + changesAfterDeletion
 
             // Return the shorter of the two change sets
@@ -66,14 +70,16 @@ private func changes<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<
     case (.Some, .None):
         // Only old rows remain, which must be deleted
         let deletion = Change.Delete(index: oldRows.endIndex.predecessor())
-        let remainingChanges = changes(from: oldRows.dropLast(), to: newRows, comparator: isSameRow)
-        return [deletion] + remainingChanges
+        let changesAfterDeletion = changes(from: oldRows.dropLast(), to: newRows,
+            comparator: isSameRow)
+        return [deletion] + changesAfterDeletion
 
     case (.None, .Some):
         // Only new rows remain, which must be inserted
         let insertion = Change.Insert(index: newRows.endIndex.predecessor())
-        let remainingChanges = changes(from: oldRows, to: newRows.dropLast(), comparator: isSameRow)
-        return [insertion] + remainingChanges
+        let changesAfterInsertion = changes(from: oldRows, to: newRows.dropLast(),
+            comparator: isSameRow)
+        return [insertion] + changesAfterInsertion
 
     case (.None, .None):
         // All rows are accounted for

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -36,22 +36,22 @@ func diff<Row>(from oldArray: [Row], to newArray: [Row], comparator isSameRow: (
     return changes(from: ArraySlice(oldArray), to: ArraySlice(newArray), comparator: isSameRow)
 }
 
-private func changes<Row>(from groupA: ArraySlice<Row>, to groupB: ArraySlice<Row>, comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
+private func changes<Row>(from oldSlice: ArraySlice<Row>, to newSlice: ArraySlice<Row>, comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
     // Work from the end to preserve earlier indices when recursing
-    switch (groupA.last, groupB.last) {
+    switch (oldSlice.last, newSlice.last) {
     case let (.Some(a), .Some(b)):
         if isSameRow(a, b) {
             // TODO: Don't update if the rows are truly equal
-            let update = Change.Update(index: groupB.endIndex.predecessor())
-            let remainingChanges = changes(from: groupA.dropLast(), to: groupB.dropLast(), comparator: isSameRow)
+            let update = Change.Update(index: newSlice.endIndex.predecessor())
+            let remainingChanges = changes(from: oldSlice.dropLast(), to: newSlice.dropLast(), comparator: isSameRow)
             return [update] + remainingChanges
         } else {
-            let insertion = Change.Insert(index: groupB.endIndex.predecessor())
-            let changesAfterInsertion = changes(from: groupA, to: groupB.dropLast(), comparator: isSameRow)
+            let insertion = Change.Insert(index: newSlice.endIndex.predecessor())
+            let changesAfterInsertion = changes(from: oldSlice, to: newSlice.dropLast(), comparator: isSameRow)
             let changesWithInsertion = [insertion] + changesAfterInsertion
 
-            let deletion = Change.Delete(index: groupA.endIndex.predecessor())
-            let changesAfterDeletion = changes(from: groupA.dropLast(), to: groupB, comparator: isSameRow)
+            let deletion = Change.Delete(index: oldSlice.endIndex.predecessor())
+            let changesAfterDeletion = changes(from: oldSlice.dropLast(), to: newSlice, comparator: isSameRow)
             let changesWithDeletion = [deletion] + changesAfterDeletion
 
             return changesWithInsertion.count < changesWithDeletion.count
@@ -59,13 +59,13 @@ private func changes<Row>(from groupA: ArraySlice<Row>, to groupB: ArraySlice<Ro
                 : changesWithDeletion
         }
     case (.Some, .None):
-        let deletion = Change.Delete(index: groupA.endIndex.predecessor())
-        let remainingChanges = changes(from: groupA.dropLast(), to: groupB, comparator: isSameRow)
+        let deletion = Change.Delete(index: oldSlice.endIndex.predecessor())
+        let remainingChanges = changes(from: oldSlice.dropLast(), to: newSlice, comparator: isSameRow)
         return [deletion] + remainingChanges
 
     case (.None, .Some):
-        let insertion = Change.Insert(index: groupB.endIndex.predecessor())
-        let remainingChanges = changes(from: groupA, to: groupB.dropLast(), comparator: isSameRow)
+        let insertion = Change.Insert(index: newSlice.endIndex.predecessor())
+        let remainingChanges = changes(from: oldSlice, to: newSlice.dropLast(), comparator: isSameRow)
         return [insertion] + remainingChanges
 
     case (.None, .None):

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -43,46 +43,52 @@ private func changes<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<
         if isSameRow(oldRow, newRow) {
             // The old and new rows are the same row, and can be represented by an Update
             // TODO: Don't update if the rows are truly equal
-            // TODO: Test update indices
-            let update = Change.Update(index: newRows.endIndex.predecessor())
-            let remainingChanges = changes(from: oldRows.dropLast(), to: newRows.dropLast(),
-                comparator: isSameRow)
-            return [update] + remainingChanges
+            return changesWithUpdate(from: oldRows, to: newRows, comparator: isSameRow)
         } else {
             // The old and new rows are different, so compute the two possible change sets:
             // one where the old row is deleted, another where the new row is inserted
-            let insertion = Change.Insert(index: newRows.endIndex.predecessor())
-            let changesAfterInsertion = changes(from: oldRows, to: newRows.dropLast(),
-                comparator: isSameRow)
-            let changesWithInsertion = [insertion] + changesAfterInsertion
-
-            let deletion = Change.Delete(index: oldRows.endIndex.predecessor())
-            let changesAfterDeletion = changes(from: oldRows.dropLast(), to: newRows,
-                comparator: isSameRow)
-            let changesWithDeletion = [deletion] + changesAfterDeletion
+            let changesA = changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
+            let changesB = changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
 
             // Return the shorter of the two change sets
-            return changesWithInsertion.count < changesWithDeletion.count
-                ? changesWithInsertion
-                : changesWithDeletion
+            return changesA.count < changesB.count ? changesA : changesB
         }
 
     case (.Some, .None):
         // Only old rows remain, which must be deleted
-        let deletion = Change.Delete(index: oldRows.endIndex.predecessor())
-        let changesAfterDeletion = changes(from: oldRows.dropLast(), to: newRows,
-            comparator: isSameRow)
-        return [deletion] + changesAfterDeletion
+        return changesWithDeletion(from: oldRows, to: newRows, comparator: isSameRow)
 
     case (.None, .Some):
         // Only new rows remain, which must be inserted
-        let insertion = Change.Insert(index: newRows.endIndex.predecessor())
-        let changesAfterInsertion = changes(from: oldRows, to: newRows.dropLast(),
-            comparator: isSameRow)
-        return [insertion] + changesAfterInsertion
+        return changesWithInsertion(from: oldRows, to: newRows, comparator: isSameRow)
 
     case (.None, .None):
         // All rows are accounted for
         return []
     }
+}
+
+private func changesWithInsertion<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
+    comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
+        let insertion = Change.Insert(index: newRows.endIndex.predecessor())
+        let changesAfterInsertion = changes(from: oldRows, to: newRows.dropLast(),
+            comparator: isSameRow)
+        return [insertion] + changesAfterInsertion
+}
+
+private func changesWithUpdate<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
+    comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
+        // TODO: Test update indices
+        let update = Change.Update(index: newRows.endIndex.predecessor())
+        let changesAfterUpdate = changes(from: oldRows.dropLast(), to: newRows.dropLast(),
+            comparator: isSameRow)
+        return [update] + changesAfterUpdate
+}
+
+private func changesWithDeletion<Row>(from oldRows: ArraySlice<Row>, to newRows: ArraySlice<Row>,
+    comparator isSameRow: (Row, Row) -> Bool) -> [Change] {
+        let deletion = Change.Delete(index: oldRows.endIndex.predecessor())
+        let changesAfterDeletion = changes(from: oldRows.dropLast(), to: newRows,
+            comparator: isSameRow)
+        return [deletion] + changesAfterDeletion
 }

--- a/Authenticator/Source/TextFieldRowCell.swift
+++ b/Authenticator/Source/TextFieldRowCell.swift
@@ -91,7 +91,11 @@ class TextFieldRowCell: UITableViewCell {
         textField.keyboardType = viewModel.keyboardType
         textField.returnKeyType = viewModel.returnKeyType
 
-        textField.text = viewModel.value
+        // UITextField can behave erratically if its text is updated while it is being edited,
+        // especially with Chinese text entry. Only update if truly necessary.
+        if textField.text != viewModel.value {
+            textField.text = viewModel.value
+        }
         changeAction = viewModel.changeAction
     }
 

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -50,7 +50,7 @@ class TokenEditForm: TokenForm {
 
     private var state: State {
         didSet {
-            presenter?.formValuesDidChange(self)
+            presenter?.updateWithViewModel(viewModel)
         }
     }
 

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -59,7 +59,7 @@ class TokenEntryForm: TokenForm {
 
     private var state: State {
         didSet {
-            presenter?.formValuesDidChange(self)
+            presenter?.updateWithViewModel(viewModel)
         }
     }
 
@@ -224,7 +224,7 @@ class TokenEntryForm: TokenForm {
     func toggleAdvancedOptions() {
         if !state.showsAdvancedOptions {
             state.showsAdvancedOptions = true
-            presenter?.formValuesDidChange(self)
+            presenter?.updateWithViewModel(viewModel)
             // TODO: Scroll to the newly-expanded section
         }
     }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -113,7 +113,8 @@ class TokenEntryForm: TokenForm {
 
     private var advancedSectionHeader: Form.HeaderModel {
         let model = ButtonHeaderViewModel(title: "Advanced Options") { [weak self] in
-            self?.toggleAdvancedOptions()
+            self?.state.showsAdvancedOptions = true
+            // TODO: Scroll to the newly-expanded section
         }
         return .ButtonHeader(model)
     }
@@ -219,13 +220,5 @@ class TokenEntryForm: TokenForm {
 
         // If the method hasn't returned by this point, token creation failed
         presenter?.form(self, didFailWithErrorMessage: "Invalid Token")
-    }
-
-    func toggleAdvancedOptions() {
-        if !state.showsAdvancedOptions {
-            state.showsAdvancedOptions = true
-            presenter?.updateWithViewModel(viewModel)
-            // TODO: Scroll to the newly-expanded section
-        }
     }
 }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -50,6 +50,8 @@ class TokenEntryForm: TokenForm {
         var digitCount: Int
         var algorithm: Generator.Algorithm
 
+        var showsAdvancedOptions: Bool
+
         var isValid: Bool {
             return !secret.isEmpty && !(issuer.isEmpty && name.isEmpty)
         }
@@ -61,9 +63,6 @@ class TokenEntryForm: TokenForm {
         }
     }
 
-    // TODO: move this into State when form(_:didReloadSection:) is no longer necessary
-    var showsAdvancedOptions = false
-
     // MARK: Initialization
 
     init(callback: (Event) -> ()) {
@@ -74,7 +73,8 @@ class TokenEntryForm: TokenForm {
             secret: "",
             tokenType: .Timer,
             digitCount: 6,
-            algorithm: .SHA1
+            algorithm: .SHA1,
+            showsAdvancedOptions: false
         )
     }
 
@@ -97,7 +97,7 @@ class TokenEntryForm: TokenForm {
                 ],
                 Section(
                     header: advancedSectionHeader,
-                    rows: !showsAdvancedOptions ? [] :
+                    rows: !state.showsAdvancedOptions ? [] :
                         [
                             tokenTypeRowModel,
                             digitCountRowModel,
@@ -222,8 +222,8 @@ class TokenEntryForm: TokenForm {
     }
 
     func toggleAdvancedOptions() {
-        if !showsAdvancedOptions {
-            showsAdvancedOptions = true
+        if !state.showsAdvancedOptions {
+            state.showsAdvancedOptions = true
             presenter?.formValuesDidChange(self)
             // TODO: Scroll to the newly-expanded section
         }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -224,8 +224,8 @@ class TokenEntryForm: TokenForm {
     func toggleAdvancedOptions() {
         if !showsAdvancedOptions {
             showsAdvancedOptions = true
-            // TODO: Don't hard-code this index
-            presenter?.form(self, didReloadSection: 1)
+            presenter?.formValuesDidChange(self)
+            // TODO: Scroll to the newly-expanded section
         }
     }
 }

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -30,5 +30,4 @@ protocol TokenForm {
 protocol TokenFormPresenter: class {
     func formValuesDidChange(form: TokenForm)
     func form(form: TokenForm, didFailWithErrorMessage errorMessage: String)
-    func form(form: TokenForm, didReloadSection section: Int)
 }

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -28,6 +28,6 @@ protocol TokenForm {
 }
 
 protocol TokenFormPresenter: class {
-    func formValuesDidChange(form: TokenForm)
+    func updateWithViewModel(viewModel: TableViewModel<Form>)
     func form(form: TokenForm, didFailWithErrorMessage errorMessage: String)
 }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -40,7 +40,7 @@ class TokenFormViewController: UITableViewController {
                 let newSection = viewModel.sections[sectionIndex]
                 let changes = diff(from: oldSection.rows, to: newSection.rows, comparator: {
                     // As currently used, form rows don't move around much, so comparing the row
-                    // type is sufficient here. For more complex changes, row models should be 
+                    // type is sufficient here. For more complex changes, row models should be
                     // compared for identity.
                     switch ($0, $1) {
                     case (.TextFieldRow, .TextFieldRow): return true

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -52,8 +52,9 @@ class TokenFormViewController: UITableViewController {
                     case .Insert(let rowIndex):
                         let indexPaths = [NSIndexPath(forRow: rowIndex, inSection: sectionIndex)]
                         tableView.insertRowsAtIndexPaths(indexPaths, withRowAnimation: .Automatic)
-                    case .Update:
-                        break // FIXME: Update rows without reloading
+                    case .Update(let rowIndex):
+                        let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
+                        updateRowAtIndexPath(indexPath)
                     case .Delete(let rowIndex):
                         let indexPaths = [NSIndexPath(forRow: rowIndex, inSection: sectionIndex)]
                         tableView.deleteRowsAtIndexPaths(indexPaths, withRowAnimation: .Automatic)
@@ -246,6 +247,36 @@ class TokenFormViewController: UITableViewController {
             cell.updateWithViewModel(viewModel)
             return cell
         }
+    }
+
+    func updateRowAtIndexPath(indexPath: NSIndexPath) {
+        guard let cell = tableView.cellForRowAtIndexPath(indexPath) else {
+            return
+        }
+        guard let rowModel = viewModel.modelForRowAtIndexPath(indexPath) else {
+            // TODO: handle a nil row model
+            return
+        }
+
+        switch rowModel {
+        case .TextFieldRow(let viewModel):
+            if let cell = cell as? TextFieldRowCell {
+                cell.updateWithViewModel(viewModel)
+            }
+        case .TokenTypeRow(let viewModel):
+            if let cell = cell as? SegmentedControlRowCell<TokenTypeRowViewModel> {
+                cell.updateWithViewModel(viewModel)
+            }
+        case .DigitCountRow(let viewModel):
+            if let cell = cell as? SegmentedControlRowCell<DigitCountRowViewModel> {
+                cell.updateWithViewModel(viewModel)
+            }
+        case .AlgorithmRow(let viewModel):
+            if let cell = cell as? SegmentedControlRowCell<AlgorithmRowViewModel> {
+                cell.updateWithViewModel(viewModel)
+            }
+        }
+        // TODO: handle the case where a row cell cannot be updated
     }
 
     func heightForRowModel(rowModel: Form.RowModel) -> CGFloat {

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -288,13 +288,6 @@ extension TokenFormViewController: TokenFormPresenter {
     func form(form: TokenForm, didFailWithErrorMessage errorMessage: String) {
         SVProgressHUD.showErrorWithStatus(errorMessage)
     }
-
-    func form(form: TokenForm, didReloadSection section: Int) {
-        viewModel = form.viewModel
-        tableView.scrollToRowAtIndexPath(NSIndexPath(forRow: 0, inSection: section),
-            atScrollPosition: .Top,
-            animated: true)
-    }
 }
 
 extension TokenFormViewController: TextFieldRowCellDelegate {

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -59,9 +59,9 @@ class TokenFormViewController: UITableViewController {
                         let indexPaths = [NSIndexPath(forRow: rowIndex, inSection: sectionIndex)]
                         tableView.deleteRowsAtIndexPaths(indexPaths, withRowAnimation: .Automatic)
                     case let .Move(fromRowIndex, toRowIndex):
-                        let fromIndexPath = NSIndexPath(forRow: fromRowIndex, inSection: sectionIndex)
-                        let toIndexPath = NSIndexPath(forRow: toRowIndex, inSection: sectionIndex)
-                        tableView.moveRowAtIndexPath(fromIndexPath, toIndexPath: toIndexPath)
+                        let origin = NSIndexPath(forRow: fromRowIndex, inSection: sectionIndex)
+                        let destination = NSIndexPath(forRow: toRowIndex, inSection: sectionIndex)
+                        tableView.moveRowAtIndexPath(origin, toIndexPath: destination)
                     }
                 }
             }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -251,32 +251,43 @@ class TokenFormViewController: UITableViewController {
 
     func updateRowAtIndexPath(indexPath: NSIndexPath) {
         guard let cell = tableView.cellForRowAtIndexPath(indexPath) else {
+            // If the given row is not visible, the table view will have no cell for it, and it
+            // doesn't need to be updated.
             return
         }
         guard let rowModel = viewModel.modelForRowAtIndexPath(indexPath) else {
-            // TODO: handle a nil row model
+            // If there is no row model for the given index path, just tell the table view to
+            // reload it and hope for the best.
+            tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             return
         }
 
         switch rowModel {
         case .TextFieldRow(let viewModel):
-            if let cell = cell as? TextFieldRowCell {
-                cell.updateWithViewModel(viewModel)
+            guard let cell = cell as? TextFieldRowCell else  {
+                tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                return
             }
+            cell.updateWithViewModel(viewModel)
         case .TokenTypeRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<TokenTypeRowViewModel> {
-                cell.updateWithViewModel(viewModel)
+            guard let cell = cell as? SegmentedControlRowCell<TokenTypeRowViewModel> else  {
+                tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                return
             }
+            cell.updateWithViewModel(viewModel)
         case .DigitCountRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<DigitCountRowViewModel> {
-                cell.updateWithViewModel(viewModel)
+            guard let cell = cell as? SegmentedControlRowCell<DigitCountRowViewModel> else  {
+                tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                return
             }
+            cell.updateWithViewModel(viewModel)
         case .AlgorithmRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<AlgorithmRowViewModel> {
-                cell.updateWithViewModel(viewModel)
+            guard let cell = cell as? SegmentedControlRowCell<AlgorithmRowViewModel> else  {
+                tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                return
             }
+            cell.updateWithViewModel(viewModel)
         }
-        // TODO: handle the case where a row cell cannot be updated
     }
 
     func heightForRowModel(rowModel: Form.RowModel) -> CGFloat {

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -39,6 +39,9 @@ class TokenFormViewController: UITableViewController {
                 let oldSection = oldValue.sections[sectionIndex]
                 let newSection = viewModel.sections[sectionIndex]
                 let changes = diff(from: oldSection.rows, to: newSection.rows, comparator: {
+                    // As currently used, form rows don't move around much, so comparing the row
+                    // type is sufficient here. For more complex changes, row models should be 
+                    // compared for identity.
                     switch ($0, $1) {
                     case (.TextFieldRow, .TextFieldRow): return true
                     case (.TokenTypeRow, .TokenTypeRow): return true
@@ -50,14 +53,14 @@ class TokenFormViewController: UITableViewController {
                 for change in changes {
                     switch change {
                     case .Insert(let rowIndex):
-                        let indexPaths = [NSIndexPath(forRow: rowIndex, inSection: sectionIndex)]
-                        tableView.insertRowsAtIndexPaths(indexPaths, withRowAnimation: .Automatic)
+                        let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
+                        tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
                     case .Update(let rowIndex):
                         let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                         updateRowAtIndexPath(indexPath)
                     case .Delete(let rowIndex):
-                        let indexPaths = [NSIndexPath(forRow: rowIndex, inSection: sectionIndex)]
-                        tableView.deleteRowsAtIndexPaths(indexPaths, withRowAnimation: .Automatic)
+                        let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
+                        tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
                     case let .Move(fromRowIndex, toRowIndex):
                         let origin = NSIndexPath(forRow: fromRowIndex, inSection: sectionIndex)
                         let destination = NSIndexPath(forRow: toRowIndex, inSection: sectionIndex)
@@ -264,29 +267,29 @@ class TokenFormViewController: UITableViewController {
 
         switch rowModel {
         case .TextFieldRow(let viewModel):
-            guard let cell = cell as? TextFieldRowCell else  {
+            if let cell = cell as? TextFieldRowCell {
+                cell.updateWithViewModel(viewModel)
+            } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-                return
             }
-            cell.updateWithViewModel(viewModel)
         case .TokenTypeRow(let viewModel):
-            guard let cell = cell as? SegmentedControlRowCell<TokenTypeRowViewModel> else  {
+            if let cell = cell as? SegmentedControlRowCell<TokenTypeRowViewModel> {
+                cell.updateWithViewModel(viewModel)
+            } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-                return
             }
-            cell.updateWithViewModel(viewModel)
         case .DigitCountRow(let viewModel):
-            guard let cell = cell as? SegmentedControlRowCell<DigitCountRowViewModel> else  {
+            if let cell = cell as? SegmentedControlRowCell<DigitCountRowViewModel> {
+                cell.updateWithViewModel(viewModel)
+            } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-                return
             }
-            cell.updateWithViewModel(viewModel)
         case .AlgorithmRow(let viewModel):
-            guard let cell = cell as? SegmentedControlRowCell<AlgorithmRowViewModel> else  {
+            if let cell = cell as? SegmentedControlRowCell<AlgorithmRowViewModel> {
+                cell.updateWithViewModel(viewModel)
+            } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-                return
             }
-            cell.updateWithViewModel(viewModel)
         }
     }
 

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -322,8 +322,8 @@ class TokenFormViewController: UITableViewController {
 
 extension TokenFormViewController: TokenFormPresenter {
 
-    func formValuesDidChange(form: TokenForm) {
-        viewModel = form.viewModel
+    func updateWithViewModel(viewModel: TableViewModel<Form>) {
+        self.viewModel = viewModel
         updateBarButtonItems()
     }
 

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -38,7 +38,7 @@ class TokenFormViewController: UITableViewController {
             for sectionIndex in oldValue.sections.indices {
                 let oldSection = oldValue.sections[sectionIndex]
                 let newSection = viewModel.sections[sectionIndex]
-                let changes = diff(from: ArraySlice(oldSection.rows), to: ArraySlice(newSection.rows), comparator: {
+                let changes = diff(from: oldSection.rows, to: newSection.rows, comparator: {
                     switch ($0, $1) {
                     case (.TextFieldRow, .TextFieldRow): return true
                     case (.TokenTypeRow, .TokenTypeRow): return true


### PR DESCRIPTION
Comparing an old and new table view model with a simple SES algorithm produces a collection of `Change`s, which can be used to automatically call the corresponding animation methods on a `UITableView`. This removes the need to manually trigger the correct animations when the data model changes.