### PR TITLE
Ephemeral Error Messages

### DIFF
--- a/Authenticator/Source/TableViewModel.swift
+++ b/Authenticator/Source/TableViewModel.swift
@@ -35,17 +35,20 @@ struct TableViewModel<Models: TableViewModelFamily> {
     var rightBarButton: BarButtonViewModel?
     var sections: [Section<Models.HeaderModel, Models.RowModel>]
     var doneKeyAction: (() -> ())?
+    var errorMessage: String?
 
     init(title: String,
         leftBarButton: BarButtonViewModel? = nil,
         rightBarButton: BarButtonViewModel? = nil,
         sections: [Section<Models.HeaderModel, Models.RowModel>],
-        doneKeyAction: (() -> ())? = nil) {
+        doneKeyAction: (() -> ())? = nil,
+        errorMessage: String? = nil) {
             self.title = title
             self.leftBarButton = leftBarButton
             self.rightBarButton = rightBarButton
             self.sections = sections
             self.doneKeyAction = doneKeyAction
+            self.errorMessage = errorMessage
     }
 }
 

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -51,14 +51,14 @@ class TokenEntryForm: TokenForm {
         var algorithm: Generator.Algorithm
 
         var showsAdvancedOptions: Bool
-        var errorMessage: String?
+        var submitFailed: Bool
 
         var isValid: Bool {
             return !secret.isEmpty && !(issuer.isEmpty && name.isEmpty)
         }
 
         mutating func resetEphemera() {
-            errorMessage = nil
+            submitFailed = false
         }
     }
 
@@ -81,7 +81,7 @@ class TokenEntryForm: TokenForm {
             digitCount: 6,
             algorithm: .SHA1,
             showsAdvancedOptions: false,
-            errorMessage: nil
+            submitFailed: false
         )
     }
 
@@ -115,7 +115,7 @@ class TokenEntryForm: TokenForm {
             doneKeyAction: { [weak self] in
                 self?.submit()
             },
-            errorMessage: state.errorMessage
+            errorMessage: state.submitFailed ? "Invalid Token" : nil
         )
     }
 
@@ -227,6 +227,6 @@ class TokenEntryForm: TokenForm {
         }
 
         // If the method hasn't returned by this point, token creation failed
-        state.errorMessage = "Invalid Token"
+        state.submitFailed = true
     }
 }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -51,6 +51,7 @@ class TokenEntryForm: TokenForm {
         var algorithm: Generator.Algorithm
 
         var showsAdvancedOptions: Bool
+        var errorMessage: String?
 
         var isValid: Bool {
             return !secret.isEmpty && !(issuer.isEmpty && name.isEmpty)
@@ -60,6 +61,8 @@ class TokenEntryForm: TokenForm {
     private var state: State {
         didSet {
             presenter?.updateWithViewModel(viewModel)
+            // Clear ephemeral message
+            state.errorMessage = nil
         }
     }
 
@@ -74,7 +77,8 @@ class TokenEntryForm: TokenForm {
             tokenType: .Timer,
             digitCount: 6,
             algorithm: .SHA1,
-            showsAdvancedOptions: false
+            showsAdvancedOptions: false,
+            errorMessage: nil
         )
     }
 
@@ -107,7 +111,8 @@ class TokenEntryForm: TokenForm {
             ],
             doneKeyAction: { [weak self] in
                 self?.submit()
-            }
+            },
+            errorMessage: state.errorMessage
         )
     }
 
@@ -219,6 +224,6 @@ class TokenEntryForm: TokenForm {
         }
 
         // If the method hasn't returned by this point, token creation failed
-        presenter?.form(self, didFailWithErrorMessage: "Invalid Token")
+        state.errorMessage = "Invalid Token"
     }
 }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -56,13 +56,16 @@ class TokenEntryForm: TokenForm {
         var isValid: Bool {
             return !secret.isEmpty && !(issuer.isEmpty && name.isEmpty)
         }
+
+        mutating func resetEphemera() {
+            errorMessage = nil
+        }
     }
 
     private var state: State {
         didSet {
             presenter?.updateWithViewModel(viewModel)
-            // Clear ephemeral message
-            state.errorMessage = nil
+            state.resetEphemera()
         }
     }
 

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -2,31 +2,32 @@
 //  TokenEntryForm.swift
 //  Authenticator
 //
-//  Copyright (c) 2015 Matt Rubin
+//  Copyright (c) 2015 Authenticator authors
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of
-//  this software and associated documentation files (the "Software"), to deal in
-//  the Software without restriction, including without limitation the rights to
-//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-//  the Software, and to permit persons to whom the Software is furnished to do so,
-//  subject to the following conditions:
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 import Foundation
 import OneTimePassword
 
-let defaultTimerFactor = Generator.Factor.Timer(period: 30)
-let defaultCounterFactor = Generator.Factor.Counter(0)
+private let defaultTimerFactor = Generator.Factor.Timer(period: 30)
+private let defaultCounterFactor = Generator.Factor.Counter(0)
 
 class TokenEntryForm: TokenForm {
     weak var presenter: TokenFormPresenter?
@@ -84,9 +85,11 @@ class TokenEntryForm: TokenForm {
             submitFailed: false
         )
     }
+}
 
-    // MARK: View Model
+// MARK: View Model
 
+extension TokenEntryForm {
     var viewModel: TableViewModel<Form> {
         return TableViewModel(
             title: "Add Token",

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -187,9 +187,11 @@ class TokenEntryForm: TokenForm {
         )
         return .AlgorithmRow(model)
     }
+}
 
-    // MARK: Actions
+// MARK: Actions
 
+private extension TokenEntryForm {
     func cancel() {
         callback(.Close)
     }

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -29,5 +29,4 @@ protocol TokenForm {
 
 protocol TokenFormPresenter: class {
     func updateWithViewModel(viewModel: TableViewModel<Form>)
-    func form(form: TokenForm, didFailWithErrorMessage errorMessage: String)
 }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -328,14 +328,12 @@ extension TokenFormViewController {
 }
 
 extension TokenFormViewController: TokenFormPresenter {
-
     func updateWithViewModel(viewModel: TableViewModel<Form>) {
         self.viewModel = viewModel
         updateBarButtonItems()
-    }
-
-    func form(form: TokenForm, didFailWithErrorMessage errorMessage: String) {
-        SVProgressHUD.showErrorWithStatus(errorMessage)
+        if let errorMessage = viewModel.errorMessage {
+            SVProgressHUD.showInfoWithStatus(errorMessage)
+        }
     }
 }
 

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -332,7 +332,7 @@ extension TokenFormViewController: TokenFormPresenter {
         self.viewModel = viewModel
         updateBarButtonItems()
         if let errorMessage = viewModel.errorMessage {
-            SVProgressHUD.showInfoWithStatus(errorMessage)
+            SVProgressHUD.showErrorWithStatus(errorMessage)
         }
     }
 }


### PR DESCRIPTION
Replace `form(_:didFailWithErrorMessage:)` with an ephemeral `errorMessage` property in `TableViewModel`.