### PR TITLE
ActionHandler

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		C9AAB0811B9187F8000CE547 /* TokenForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB0801B9187F8000CE547 /* TokenForm.swift */; };
 		C9B7328D1C09495D0076F77E /* TableDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B7328C1C09495D0076F77E /* TableDiff.swift */; };
 		C9B7328F1C0A8AE60076F77E /* TokenListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B7328E1C0A8AE60076F77E /* TokenListViewModel.swift */; };
-		C9BA64E81C0C26BA00610C7C /* MasterPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BA64E71C0C26BA00610C7C /* MasterPresenter.swift */; };
+		C9BA64E81C0C26BA00610C7C /* ActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BA64E71C0C26BA00610C7C /* ActionHandler.swift */; };
 		C9BA64EA1C0C4FBC00610C7C /* UITableView+ReusableCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9BA64E91C0C4FBC00610C7C /* UITableView+ReusableCells.swift */; };
 		C9BEAE6019C67FD800533385 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = C9BEAE5F19C67FD800533385 /* LaunchScreen.xib */; };
 		C9C6CCA21842E331000100C2 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C9C6CCA11842E331000100C2 /* Images.xcassets */; };
@@ -126,7 +126,7 @@
 		C9AAB0801B9187F8000CE547 /* TokenForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenForm.swift; sourceTree = "<group>"; };
 		C9B7328C1C09495D0076F77E /* TableDiff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableDiff.swift; sourceTree = "<group>"; };
 		C9B7328E1C0A8AE60076F77E /* TokenListViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenListViewModel.swift; sourceTree = "<group>"; };
-		C9BA64E71C0C26BA00610C7C /* MasterPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MasterPresenter.swift; sourceTree = "<group>"; };
+		C9BA64E71C0C26BA00610C7C /* ActionHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionHandler.swift; sourceTree = "<group>"; };
 		C9BA64E91C0C4FBC00610C7C /* UITableView+ReusableCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+ReusableCells.swift"; sourceTree = "<group>"; };
 		C9BEAE5F19C67FD800533385 /* LaunchScreen.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		C9C6CCA11842E331000100C2 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -162,7 +162,7 @@
 			isa = PBXGroup;
 			children = (
 				1D3623250D0F684500981E51 /* OTPAppDelegate.swift */,
-				C9BA64E71C0C26BA00610C7C /* MasterPresenter.swift */,
+				C9BA64E71C0C26BA00610C7C /* ActionHandler.swift */,
 				C98C1C4917D2F03400A07D3F /* Display */,
 				C98C1C4617D2EE6500A07D3F /* Entry */,
 				C98C1C4E17D2F14500A07D3F /* Utility */,
@@ -543,7 +543,7 @@
 				C9919CE21BA733FD006237C1 /* Section.swift in Sources */,
 				C9D6C8461906CD54004F0E08 /* TextFieldRowCell.swift in Sources */,
 				C9B7328D1C09495D0076F77E /* TableDiff.swift in Sources */,
-				C9BA64E81C0C26BA00610C7C /* MasterPresenter.swift in Sources */,
+				C9BA64E81C0C26BA00610C7C /* ActionHandler.swift in Sources */,
 				C97CDF2C1BEEC90100D64406 /* QRScanner.swift in Sources */,
 				C9AAB07F1B917EC3000CE547 /* TokenEditForm.swift in Sources */,
 				C9D6C84C19075044004F0E08 /* OTPProgressRing.swift in Sources */,

--- a/Authenticator/Source/ActionHandler.swift
+++ b/Authenticator/Source/ActionHandler.swift
@@ -1,5 +1,5 @@
 //
-//  MasterPresenter.swift
+//  ActionHandler.swift
 //  Authenticator
 //
 //  Copyright (c) 2015 Authenticator authors
@@ -23,7 +23,6 @@
 //  SOFTWARE.
 //
 
-import UIKit
 import OneTimePassword
 
 enum AppAction {

--- a/Authenticator/Source/MasterPresenter.swift
+++ b/Authenticator/Source/MasterPresenter.swift
@@ -35,3 +35,7 @@ enum AppAction {
     case CancelTokenEntry
     case SaveNewToken(Token)
 }
+
+protocol ActionHandler: class {
+    func handleAction(action: AppAction)
+}

--- a/Authenticator/Source/MasterPresenter.swift
+++ b/Authenticator/Source/MasterPresenter.swift
@@ -30,3 +30,8 @@ protocol MasterPresenter: class {
     func beginAddToken()
     func beginEditPersistentToken(persistentToken: PersistentToken)
 }
+
+enum AppAction {
+    case CancelTokenEntry
+    case SaveNewToken(Token)
+}

--- a/Authenticator/Source/MasterPresenter.swift
+++ b/Authenticator/Source/MasterPresenter.swift
@@ -34,6 +34,9 @@ protocol MasterPresenter: class {
 enum AppAction {
     case CancelTokenEntry
     case SaveNewToken(Token)
+
+    case CancelTokenEdit
+    case SaveChanges(Token, PersistentToken)
 }
 
 protocol ActionHandler: class {

--- a/Authenticator/Source/MasterPresenter.swift
+++ b/Authenticator/Source/MasterPresenter.swift
@@ -26,15 +26,12 @@
 import UIKit
 import OneTimePassword
 
-protocol MasterPresenter: class {
-    func beginAddToken()
-    func beginEditPersistentToken(persistentToken: PersistentToken)
-}
-
 enum AppAction {
+    case BeginTokenEntry
     case CancelTokenEntry
     case SaveNewToken(Token)
 
+    case BeginTokenEdit(PersistentToken)
     case CancelTokenEdit
     case SaveChanges(Token, PersistentToken)
 }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -90,10 +90,10 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
 extension OTPAppDelegate: MasterPresenter {
     func beginAddToken() {
         if QRScanner.deviceCanScan {
-            let scannerViewController = TokenScannerViewController(delegate: self)
+            let scannerViewController = TokenScannerViewController(actionHandler: self)
             presentViewController(scannerViewController)
         } else {
-            let form = TokenEntryForm(delegate: self)
+            let form = TokenEntryForm(actionHandler: self)
             let formController = TokenFormViewController(form: form)
             presentViewController(formController)
         }
@@ -117,7 +117,7 @@ extension OTPAppDelegate: MasterPresenter {
     }
 }
 
-extension OTPAppDelegate: TokenEntryFormDelegate, TokenScannerViewControllerDelegate {
+extension OTPAppDelegate: ActionHandler {
     func handleAction(action: AppAction) {
         switch action {
         case .SaveNewToken(let token):

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -114,7 +114,7 @@ extension OTPAppDelegate: MasterPresenter {
     }
 
     func beginEditPersistentToken(persistentToken: PersistentToken) {
-        let form = TokenEditForm(token: persistentToken.token) { [weak self] (event) in
+        let form = TokenEditForm(persistentToken: persistentToken) { [weak self] (event) in
             switch event {
             case .Save(let token):
                 self?.tokenList.saveToken(token, toPersistentToken: persistentToken)

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -100,7 +100,7 @@ extension OTPAppDelegate: MasterPresenter {
     }
 
     func beginEditPersistentToken(persistentToken: PersistentToken) {
-        let form = TokenEditForm(persistentToken: persistentToken, delegate: self)
+        let form = TokenEditForm(persistentToken: persistentToken, actionHandler: self)
         let editController = TokenFormViewController(form: form)
         presentViewController(editController)
     }
@@ -125,17 +125,10 @@ extension OTPAppDelegate: ActionHandler {
             dismissViewController()
         case .CancelTokenEntry:
             dismissViewController()
-        }
-    }
-}
-
-extension OTPAppDelegate: TokenEditFormDelegate {
-    func handleAction(action: TokenEditForm.Action) {
-        switch action {
         case let .SaveChanges(token, persistentToken):
             tokenList.saveToken(token, toPersistentToken: persistentToken)
             dismissViewController()
-        case .Cancel:
+        case .CancelTokenEdit:
             dismissViewController()
         }
     }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -114,14 +114,7 @@ extension OTPAppDelegate: MasterPresenter {
     }
 
     func beginEditPersistentToken(persistentToken: PersistentToken) {
-        let form = TokenEditForm(persistentToken: persistentToken) { [weak self] (event) in
-            switch event {
-            case .Save(let token):
-                self?.tokenList.saveToken(token, toPersistentToken: persistentToken)
-            case .Close:
-                self?.dismissViewController()
-            }
-        }
+        let form = TokenEditForm(persistentToken: persistentToken, delegate: self)
         let editController = TokenFormViewController(form: form)
         presentViewController(editController)
     }
@@ -135,5 +128,16 @@ extension OTPAppDelegate: MasterPresenter {
 
     private func dismissViewController() {
         window?.rootViewController?.dismissViewControllerAnimated(true, completion: nil)
+    }
+}
+
+extension OTPAppDelegate: TokenEditFormDelegate {
+    func handleEvent(event: TokenEditForm.Event) {
+        switch event {
+        case let .Save(token, persistentToken):
+            self.tokenList.saveToken(token, toPersistentToken: persistentToken)
+        case .Close:
+            self.dismissViewController()
+        }
     }
 }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -30,7 +30,7 @@ import SVProgressHUD
 class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow? = UIWindow(frame: UIScreen.mainScreen().bounds)
     private lazy var tokenList: TokenList = {
-        TokenList(delegate: self)
+        TokenList(actionHandler: self)
     }()
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
@@ -87,22 +87,38 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
-extension OTPAppDelegate: MasterPresenter {
-    func beginAddToken() {
-        if QRScanner.deviceCanScan {
-            let scannerViewController = TokenScannerViewController(actionHandler: self)
-            presentViewController(scannerViewController)
-        } else {
-            let form = TokenEntryForm(actionHandler: self)
-            let formController = TokenFormViewController(form: form)
-            presentViewController(formController)
-        }
-    }
+extension OTPAppDelegate: ActionHandler {
+    func handleAction(action: AppAction) {
+        switch action {
+        case .BeginTokenEntry:
+            if QRScanner.deviceCanScan {
+                let scannerViewController = TokenScannerViewController(actionHandler: self)
+                presentViewController(scannerViewController)
+            } else {
+                let form = TokenEntryForm(actionHandler: self)
+                let formController = TokenFormViewController(form: form)
+                presentViewController(formController)
+            }
 
-    func beginEditPersistentToken(persistentToken: PersistentToken) {
-        let form = TokenEditForm(persistentToken: persistentToken, actionHandler: self)
-        let editController = TokenFormViewController(form: form)
-        presentViewController(editController)
+        case .SaveNewToken(let token):
+            tokenList.addToken(token)
+            dismissViewController()
+
+        case .CancelTokenEntry:
+            dismissViewController()
+
+        case .BeginTokenEdit(let persistentToken):
+            let form = TokenEditForm(persistentToken: persistentToken, actionHandler: self)
+            let editController = TokenFormViewController(form: form)
+            presentViewController(editController)
+
+        case let .SaveChanges(token, persistentToken):
+            tokenList.saveToken(token, toPersistentToken: persistentToken)
+            dismissViewController()
+
+        case .CancelTokenEdit:
+            dismissViewController()
+        }
     }
 
     private func presentViewController(viewController: UIViewController) {
@@ -114,22 +130,5 @@ extension OTPAppDelegate: MasterPresenter {
 
     private func dismissViewController() {
         window?.rootViewController?.dismissViewControllerAnimated(true, completion: nil)
-    }
-}
-
-extension OTPAppDelegate: ActionHandler {
-    func handleAction(action: AppAction) {
-        switch action {
-        case .SaveNewToken(let token):
-            tokenList.addToken(token)
-            dismissViewController()
-        case .CancelTokenEntry:
-            dismissViewController()
-        case let .SaveChanges(token, persistentToken):
-            tokenList.saveToken(token, toPersistentToken: persistentToken)
-            dismissViewController()
-        case .CancelTokenEdit:
-            dismissViewController()
-        }
     }
 }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -117,13 +117,13 @@ extension OTPAppDelegate: MasterPresenter {
     }
 }
 
-extension OTPAppDelegate: TokenEntryFormDelegate {
-    func handleAction(action: TokenEntryForm.Action) {
+extension OTPAppDelegate: TokenEntryFormDelegate, TokenScannerViewControllerDelegate {
+    func handleAction(action: AppAction) {
         switch action {
-        case .Save(let token):
+        case .SaveNewToken(let token):
             tokenList.addToken(token)
             dismissViewController()
-        case .Cancel:
+        case .CancelTokenEntry:
             dismissViewController()
         }
     }
@@ -134,18 +134,6 @@ extension OTPAppDelegate: TokenEditFormDelegate {
         switch action {
         case let .SaveChanges(token, persistentToken):
             tokenList.saveToken(token, toPersistentToken: persistentToken)
-            dismissViewController()
-        case .Cancel:
-            dismissViewController()
-        }
-    }
-}
-
-extension OTPAppDelegate: TokenScannerViewControllerDelegate {
-    func handleAction(action: TokenScannerViewController.Action) {
-        switch action {
-        case .Save(let token):
-            tokenList.addToken(token)
             dismissViewController()
         case .Cancel:
             dismissViewController()

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -93,14 +93,7 @@ extension OTPAppDelegate: MasterPresenter {
             let scannerViewController = TokenScannerViewController(delegate: self)
             presentViewController(scannerViewController)
         } else {
-            let form = TokenEntryForm() { [weak self] (event) in
-                switch event {
-                case .Save(let token):
-                    self?.tokenList.addToken(token)
-                case .Close:
-                    self?.dismissViewController()
-                }
-            }
+            let form = TokenEntryForm(delegate: self)
             let formController = TokenFormViewController(form: form)
             presentViewController(formController)
         }
@@ -121,6 +114,18 @@ extension OTPAppDelegate: MasterPresenter {
 
     private func dismissViewController() {
         window?.rootViewController?.dismissViewControllerAnimated(true, completion: nil)
+    }
+}
+
+extension OTPAppDelegate: TokenEntryFormDelegate {
+    func handleAction(action: TokenEntryForm.Action) {
+        switch action {
+        case .Save(let token):
+            tokenList.addToken(token)
+            dismissViewController()
+        case .Cancel:
+            dismissViewController()
+        }
     }
 }
 

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -132,12 +132,13 @@ extension OTPAppDelegate: MasterPresenter {
 }
 
 extension OTPAppDelegate: TokenEditFormDelegate {
-    func handleEvent(event: TokenEditForm.Event) {
-        switch event {
-        case let .Save(token, persistentToken):
-            self.tokenList.saveToken(token, toPersistentToken: persistentToken)
-        case .Close:
-            self.dismissViewController()
+    func handleAction(action: TokenEditForm.Action) {
+        switch action {
+        case let .SaveChanges(token, persistentToken):
+            tokenList.saveToken(token, toPersistentToken: persistentToken)
+            dismissViewController()
+        case .Cancel:
+            dismissViewController()
         }
     }
 }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -90,14 +90,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
 extension OTPAppDelegate: MasterPresenter {
     func beginAddToken() {
         if QRScanner.deviceCanScan {
-            let scannerViewController = TokenScannerViewController() { [weak self] (event) in
-                switch event {
-                case .Save(let token):
-                    self?.tokenList.addToken(token)
-                case .Close:
-                    self?.dismissViewController()
-                }
-            }
+            let scannerViewController = TokenScannerViewController(delegate: self)
             presentViewController(scannerViewController)
         } else {
             let form = TokenEntryForm() { [weak self] (event) in
@@ -136,6 +129,18 @@ extension OTPAppDelegate: TokenEditFormDelegate {
         switch action {
         case let .SaveChanges(token, persistentToken):
             tokenList.saveToken(token, toPersistentToken: persistentToken)
+            dismissViewController()
+        case .Cancel:
+            dismissViewController()
+        }
+    }
+}
+
+extension OTPAppDelegate: TokenScannerViewControllerDelegate {
+    func handleAction(action: TokenScannerViewController.Action) {
+        switch action {
+        case .Save(let token):
+            tokenList.addToken(token)
             dismissViewController()
         case .Cancel:
             dismissViewController()

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -24,21 +24,9 @@
 
 import OneTimePassword
 
-protocol TokenEditFormDelegate: class {
-    func handleAction(action: TokenEditForm.Action)
-}
-
 class TokenEditForm: TokenForm {
     weak var presenter: TokenFormPresenter?
-
-    // MARK: Actions
-
-    enum Action {
-        case Cancel
-        case SaveChanges(Token, PersistentToken)
-    }
-
-    private weak var delegate: TokenEditFormDelegate?
+    private weak var actionHandler: ActionHandler?
 
     // MARK: State
 
@@ -111,15 +99,15 @@ class TokenEditForm: TokenForm {
 
     // MARK: Initialization
 
-    init(persistentToken: PersistentToken, delegate: TokenEditFormDelegate) {
+    init(persistentToken: PersistentToken, actionHandler: ActionHandler) {
         state = State(persistentToken: persistentToken)
-        self.delegate = delegate
+        self.actionHandler = actionHandler
     }
 
     // MARK: Actions
 
     func cancel() {
-        delegate?.handleAction(.Cancel)
+        actionHandler?.handleAction(.CancelTokenEdit)
     }
 
     func submit() {
@@ -130,6 +118,6 @@ class TokenEditForm: TokenForm {
             issuer: state.issuer,
             generator: state.persistentToken.token.generator
         )
-        delegate?.handleAction(.SaveChanges(token, state.persistentToken))
+        actionHandler?.handleAction(.SaveChanges(token, state.persistentToken))
     }
 }

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -39,12 +39,19 @@ class TokenEditForm: TokenForm {
     // MARK: State
 
     private struct State {
+        let persistentToken: PersistentToken
+
         var issuer: String
         var name: String
-        let generator: Generator
 
         var isValid: Bool {
             return !(issuer.isEmpty && name.isEmpty)
+        }
+
+        init(persistentToken: PersistentToken) {
+            self.persistentToken = persistentToken
+            issuer = persistentToken.token.issuer
+            name = persistentToken.token.name
         }
     }
 
@@ -100,13 +107,9 @@ class TokenEditForm: TokenForm {
 
     // MARK: Initialization
 
-    init(token: Token, callback: (Event) -> ()) {
+    init(persistentToken: PersistentToken, callback: (Event) -> ()) {
         self.callback = callback
-        state = State(
-            issuer: token.issuer,
-            name: token.name,
-            generator: token.generator
-        )
+        state = State(persistentToken: persistentToken)
     }
 
     // MARK: Actions
@@ -121,7 +124,7 @@ class TokenEditForm: TokenForm {
         let token = Token(
             name: state.name,
             issuer: state.issuer,
-            generator: state.generator
+            generator: state.persistentToken.token.generator
         )
         callback(.Save(token))
         callback(.Close)

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -24,17 +24,21 @@
 
 import OneTimePassword
 
+protocol TokenEditFormDelegate: class {
+    func handleEvent(event: TokenEditForm.Event)
+}
+
 class TokenEditForm: TokenForm {
     weak var presenter: TokenFormPresenter?
 
     // MARK: Events
 
     enum Event {
-        case Save(Token)
+        case Save(Token, PersistentToken)
         case Close
     }
 
-    private let callback: (Event) -> ()
+    private weak var delegate: TokenEditFormDelegate?
 
     // MARK: State
 
@@ -107,15 +111,15 @@ class TokenEditForm: TokenForm {
 
     // MARK: Initialization
 
-    init(persistentToken: PersistentToken, callback: (Event) -> ()) {
-        self.callback = callback
+    init(persistentToken: PersistentToken, delegate: TokenEditFormDelegate) {
         state = State(persistentToken: persistentToken)
+        self.delegate = delegate
     }
 
     // MARK: Actions
 
     func cancel() {
-        callback(.Close)
+        delegate?.handleEvent(.Close)
     }
 
     func submit() {
@@ -126,7 +130,7 @@ class TokenEditForm: TokenForm {
             issuer: state.issuer,
             generator: state.persistentToken.token.generator
         )
-        callback(.Save(token))
-        callback(.Close)
+        delegate?.handleEvent(.Save(token, state.persistentToken))
+        delegate?.handleEvent(.Close)
     }
 }

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -25,17 +25,17 @@
 import OneTimePassword
 
 protocol TokenEditFormDelegate: class {
-    func handleEvent(event: TokenEditForm.Event)
+    func handleAction(action: TokenEditForm.Action)
 }
 
 class TokenEditForm: TokenForm {
     weak var presenter: TokenFormPresenter?
 
-    // MARK: Events
+    // MARK: Actions
 
-    enum Event {
-        case Save(Token, PersistentToken)
-        case Close
+    enum Action {
+        case Cancel
+        case SaveChanges(Token, PersistentToken)
     }
 
     private weak var delegate: TokenEditFormDelegate?
@@ -119,7 +119,7 @@ class TokenEditForm: TokenForm {
     // MARK: Actions
 
     func cancel() {
-        delegate?.handleEvent(.Close)
+        delegate?.handleAction(.Cancel)
     }
 
     func submit() {
@@ -130,7 +130,6 @@ class TokenEditForm: TokenForm {
             issuer: state.issuer,
             generator: state.persistentToken.token.generator
         )
-        delegate?.handleEvent(.Save(token, state.persistentToken))
-        delegate?.handleEvent(.Close)
+        delegate?.handleAction(.SaveChanges(token, state.persistentToken))
     }
 }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -27,7 +27,7 @@ import Foundation
 import OneTimePassword
 
 protocol TokenEntryFormDelegate: class {
-    func handleAction(action: TokenEntryForm.Action)
+    func handleAction(action: AppAction)
 }
 
 private let defaultTimerFactor = Generator.Factor.Timer(period: 30)
@@ -35,14 +35,6 @@ private let defaultCounterFactor = Generator.Factor.Counter(0)
 
 class TokenEntryForm: TokenForm {
     weak var presenter: TokenFormPresenter?
-
-    // MARK: Events
-
-    enum Action {
-        case Cancel
-        case Save(Token)
-    }
-
     private weak var delegate: TokenEntryFormDelegate?
 
     // MARK: State
@@ -200,7 +192,7 @@ extension TokenEntryForm {
 
 private extension TokenEntryForm {
     func cancel() {
-        delegate?.handleAction(.Cancel)
+        delegate?.handleAction(.CancelTokenEntry)
     }
 
     func submit() {
@@ -228,7 +220,7 @@ private extension TokenEntryForm {
                             generator: generator
                         )
 
-                        delegate?.handleAction(.Save(token))
+                        delegate?.handleAction(.SaveNewToken(token))
                         return
                 }
             }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -26,6 +26,10 @@
 import Foundation
 import OneTimePassword
 
+protocol TokenEntryFormDelegate: class {
+    func handleAction(action: TokenEntryForm.Action)
+}
+
 private let defaultTimerFactor = Generator.Factor.Timer(period: 30)
 private let defaultCounterFactor = Generator.Factor.Counter(0)
 
@@ -34,12 +38,12 @@ class TokenEntryForm: TokenForm {
 
     // MARK: Events
 
-    enum Event {
+    enum Action {
+        case Cancel
         case Save(Token)
-        case Close
     }
 
-    private let callback: (Event) -> ()
+    private weak var delegate: TokenEntryFormDelegate?
 
     // MARK: State
 
@@ -72,8 +76,8 @@ class TokenEntryForm: TokenForm {
 
     // MARK: Initialization
 
-    init(callback: (Event) -> ()) {
-        self.callback = callback
+    init(delegate: TokenEntryFormDelegate) {
+        self.delegate = delegate
         state = State(
             issuer: "",
             name: "",
@@ -196,7 +200,7 @@ extension TokenEntryForm {
 
 private extension TokenEntryForm {
     func cancel() {
-        callback(.Close)
+        delegate?.handleAction(.Cancel)
     }
 
     func submit() {
@@ -224,8 +228,7 @@ private extension TokenEntryForm {
                             generator: generator
                         )
 
-                        callback(.Save(token))
-                        callback(.Close)
+                        delegate?.handleAction(.Save(token))
                         return
                 }
             }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -26,16 +26,12 @@
 import Foundation
 import OneTimePassword
 
-protocol TokenEntryFormDelegate: class {
-    func handleAction(action: AppAction)
-}
-
 private let defaultTimerFactor = Generator.Factor.Timer(period: 30)
 private let defaultCounterFactor = Generator.Factor.Counter(0)
 
 class TokenEntryForm: TokenForm {
     weak var presenter: TokenFormPresenter?
-    private weak var delegate: TokenEntryFormDelegate?
+    private weak var actionHandler: ActionHandler?
 
     // MARK: State
 
@@ -68,8 +64,8 @@ class TokenEntryForm: TokenForm {
 
     // MARK: Initialization
 
-    init(delegate: TokenEntryFormDelegate) {
-        self.delegate = delegate
+    init(actionHandler: ActionHandler) {
+        self.actionHandler = actionHandler
         state = State(
             issuer: "",
             name: "",
@@ -192,7 +188,7 @@ extension TokenEntryForm {
 
 private extension TokenEntryForm {
     func cancel() {
-        delegate?.handleAction(.CancelTokenEntry)
+        actionHandler?.handleAction(.CancelTokenEntry)
     }
 
     func submit() {
@@ -220,7 +216,7 @@ private extension TokenEntryForm {
                             generator: generator
                         )
 
-                        delegate?.handleAction(.SaveNewToken(token))
+                        actionHandler?.handleAction(.SaveNewToken(token))
                         return
                 }
             }

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -29,7 +29,7 @@ import OneTimePassword
 import UIKit
 
 class TokenList {
-    weak var delegate: MasterPresenter?
+    private weak var actionHandler: ActionHandler?
     weak var presenter: TokenListPresenter?
 
     private let keychain = Keychain.sharedInstance
@@ -39,8 +39,8 @@ class TokenList {
         }
     }
 
-    init(delegate: MasterPresenter) {
-        self.delegate = delegate
+    init(actionHandler: ActionHandler) {
+        self.actionHandler = actionHandler
         do {
             let persistentTokenSet = try keychain.allPersistentTokens()
             let sortedIdentifiers = TokenList.persistentIdentifiers()
@@ -119,11 +119,11 @@ class TokenList {
 
 extension TokenList: TokenListDelegate {
     func beginAddToken() {
-        delegate?.beginAddToken()
+        actionHandler?.handleAction(.BeginTokenEntry)
     }
 
     func beginEditPersistentToken(persistentToken: PersistentToken) {
-        delegate?.beginEditPersistentToken(persistentToken)
+        actionHandler?.handleAction(.BeginTokenEdit(persistentToken))
     }
 
     func updatePersistentToken(persistentToken: PersistentToken) {

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -28,20 +28,12 @@ import OneTimePassword
 import SVProgressHUD
 
 protocol TokenScannerViewControllerDelegate: class, TokenEntryFormDelegate {
-    func handleAction(action: TokenScannerViewController.Action)
+    func handleAction(action: AppAction)
 }
 
 class TokenScannerViewController: UIViewController, QRScannerDelegate {
     private let scanner = QRScanner()
     private let videoLayer = AVCaptureVideoPreviewLayer()
-
-    // MARK: Actions
-
-    enum Action {
-        case Cancel
-        case Save(Token)
-    }
-
     private weak var delegate: TokenScannerViewControllerDelegate?
 
     // MARK: Initialization
@@ -98,7 +90,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     // MARK: Target Actions
 
     func cancel() {
-        delegate?.handleAction(.Cancel)
+        delegate?.handleAction(.CancelTokenEntry)
     }
 
     func addTokenManually() {
@@ -124,7 +116,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
         // Halt the video capture
         scanner.stop()
         // Inform the delegate that an auth URL was captured
-        delegate?.handleAction(.Save(token))
+        delegate?.handleAction(.SaveNewToken(token))
     }
 
     func handleError(error: ErrorType) {

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -27,7 +27,7 @@ import AVFoundation
 import OneTimePassword
 import SVProgressHUD
 
-protocol TokenScannerViewControllerDelegate: class {
+protocol TokenScannerViewControllerDelegate: class, TokenEntryFormDelegate {
     func handleAction(action: TokenScannerViewController.Action)
 }
 
@@ -35,7 +35,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     private let scanner = QRScanner()
     private let videoLayer = AVCaptureVideoPreviewLayer()
 
-    // MARK: Events
+    // MARK: Actions
 
     enum Action {
         case Cancel
@@ -102,15 +102,10 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     }
 
     func addTokenManually() {
-        let form = TokenEntryForm() { [weak delegate] (event) in
-            // Forward corresponding events to the scanner callback
-            switch event {
-            case .Save(let token):
-                delegate?.handleAction(.Save(token))
-            case .Close:
-                delegate?.handleAction(.Cancel)
-            }
+        guard let delegate = delegate else {
+            return
         }
+        let form = TokenEntryForm(delegate: delegate)
         let entryController = TokenFormViewController(form: form)
         navigationController?.pushViewController(entryController, animated: true)
     }

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -90,6 +90,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     }
 
     func addTokenManually() {
+        // TODO: Route screen change through ActionHandler
         guard let actionHandler = actionHandler else {
             return
         }

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -27,19 +27,15 @@ import AVFoundation
 import OneTimePassword
 import SVProgressHUD
 
-protocol TokenScannerViewControllerDelegate: class, TokenEntryFormDelegate {
-    func handleAction(action: AppAction)
-}
-
 class TokenScannerViewController: UIViewController, QRScannerDelegate {
     private let scanner = QRScanner()
     private let videoLayer = AVCaptureVideoPreviewLayer()
-    private weak var delegate: TokenScannerViewControllerDelegate?
+    private weak var actionHandler: ActionHandler?
 
     // MARK: Initialization
 
-    init(delegate: TokenScannerViewControllerDelegate) {
-        self.delegate = delegate
+    init(actionHandler: ActionHandler) {
+        self.actionHandler = actionHandler
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -90,14 +86,14 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     // MARK: Target Actions
 
     func cancel() {
-        delegate?.handleAction(.CancelTokenEntry)
+        actionHandler?.handleAction(.CancelTokenEntry)
     }
 
     func addTokenManually() {
-        guard let delegate = delegate else {
+        guard let actionHandler = actionHandler else {
             return
         }
-        let form = TokenEntryForm(delegate: delegate)
+        let form = TokenEntryForm(actionHandler: actionHandler)
         let entryController = TokenFormViewController(form: form)
         navigationController?.pushViewController(entryController, animated: true)
     }
@@ -116,7 +112,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
         // Halt the video capture
         scanner.stop()
         // Inform the delegate that an auth URL was captured
-        delegate?.handleAction(.SaveNewToken(token))
+        actionHandler?.handleAction(.SaveNewToken(token))
     }
 
     func handleError(error: ErrorType) {


### PR DESCRIPTION
Replace each screen's individual `Event`s and `callback` closures with a single `ActionHandler` which handles `AppAction`s sent from all screens. This is part of an app-wide effort to replace action *functions* with action *types*, which can be compared, serialized, and replayed easily.