### PR TITLE
Form field actions

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */; };
 		C9919CE21BA733FD006237C1 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CE11BA733FD006237C1 /* Section.swift */; };
 		C99B85251BC9AB7100A6C75D /* BarButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99B85241BC9AB7100A6C75D /* BarButtonViewModel.swift */; };
-		C9AAB0791B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB0781B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift */; };
+		C9AAB0791B9113BF000CE547 /* SegmentedControlRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB0781B9113BF000CE547 /* SegmentedControlRowModel.swift */; };
 		C9AAB07F1B917EC3000CE547 /* TokenEditForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB07E1B917EC3000CE547 /* TokenEditForm.swift */; };
 		C9AAB0811B9187F8000CE547 /* TokenForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9AAB0801B9187F8000CE547 /* TokenForm.swift */; };
 		C9B7328D1C09495D0076F77E /* TableDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B7328C1C09495D0076F77E /* TableDiff.swift */; };
@@ -121,7 +121,7 @@
 		C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonHeaderView.swift; sourceTree = "<group>"; };
 		C9919CE11BA733FD006237C1 /* Section.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
 		C99B85241BC9AB7100A6C75D /* BarButtonViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BarButtonViewModel.swift; sourceTree = "<group>"; };
-		C9AAB0781B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OTPSegmentedControlCell+TokenForm.swift"; sourceTree = "<group>"; };
+		C9AAB0781B9113BF000CE547 /* SegmentedControlRowModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControlRowModel.swift; sourceTree = "<group>"; };
 		C9AAB07E1B917EC3000CE547 /* TokenEditForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenEditForm.swift; sourceTree = "<group>"; };
 		C9AAB0801B9187F8000CE547 /* TokenForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenForm.swift; sourceTree = "<group>"; };
 		C9B7328C1C09495D0076F77E /* TableDiff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableDiff.swift; sourceTree = "<group>"; };
@@ -377,7 +377,7 @@
 			children = (
 				C9CC09521BA9133B008C54FE /* FocusCell.swift */,
 				C9D6C83E1906BD68004F0E08 /* SegmentedControlRowCell.swift */,
-				C9AAB0781B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift */,
+				C9AAB0781B9113BF000CE547 /* SegmentedControlRowModel.swift */,
 				C9D6C8451906CD54004F0E08 /* TextFieldRowCell.swift */,
 				C9078D171AB7E90A0068A11D /* TextFieldRowModel.swift */,
 				C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */,
@@ -538,7 +538,7 @@
 				C9BA64EA1C0C4FBC00610C7C /* UITableView+ReusableCells.swift in Sources */,
 				C9B7328F1C0A8AE60076F77E /* TokenListViewModel.swift in Sources */,
 				C99B85251BC9AB7100A6C75D /* BarButtonViewModel.swift in Sources */,
-				C9AAB0791B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift in Sources */,
+				C9AAB0791B9113BF000CE547 /* SegmentedControlRowModel.swift in Sources */,
 				1D3623260D0F684500981E51 /* OTPAppDelegate.swift in Sources */,
 				C9919CE21BA733FD006237C1 /* Section.swift in Sources */,
 				C9D6C8461906CD54004F0E08 /* TextFieldRowCell.swift in Sources */,

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		1D3623260D0F684500981E51 /* OTPAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* OTPAppDelegate.swift */; };
 		8B0028B511EB75920092DE18 /* ScannerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B0028B411EB75920092DE18 /* ScannerOverlayView.swift */; };
-		C9078D181AB7E90A0068A11D /* OTPTextFieldCell+TokenForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9078D171AB7E90A0068A11D /* OTPTextFieldCell+TokenForm.swift */; };
+		C9078D181AB7E90A0068A11D /* TextFieldRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9078D171AB7E90A0068A11D /* TextFieldRowModel.swift */; };
 		C910ADC11BF0315A00C988F5 /* TokenList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C910ADC01BF0315A00C988F5 /* TokenList.swift */; };
 		C914B8C51C0BFDF900D2B751 /* TokenListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C914B8C41C0BFDF900D2B751 /* TokenListDelegate.swift */; };
 		C92708AC19CFB0750033128B /* TokenListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C92708AB19CFB0750033128B /* TokenListViewController.swift */; };
@@ -81,7 +81,7 @@
 		8B0028B411EB75920092DE18 /* ScannerOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScannerOverlayView.swift; sourceTree = "<group>"; };
 		8B2B8AE1118BA49F00437315 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
 		8BF5147F118799AE005C936F /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C9078D171AB7E90A0068A11D /* OTPTextFieldCell+TokenForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "OTPTextFieldCell+TokenForm.swift"; sourceTree = "<group>"; };
+		C9078D171AB7E90A0068A11D /* TextFieldRowModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldRowModel.swift; sourceTree = "<group>"; };
 		C910ADC01BF0315A00C988F5 /* TokenList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenList.swift; sourceTree = "<group>"; };
 		C914B8C41C0BFDF900D2B751 /* TokenListDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenListDelegate.swift; sourceTree = "<group>"; };
 		C92708AB19CFB0750033128B /* TokenListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenListViewController.swift; sourceTree = "<group>"; };
@@ -379,7 +379,7 @@
 				C9D6C83E1906BD68004F0E08 /* SegmentedControlRowCell.swift */,
 				C9AAB0781B9113BF000CE547 /* OTPSegmentedControlCell+TokenForm.swift */,
 				C9D6C8451906CD54004F0E08 /* TextFieldRowCell.swift */,
-				C9078D171AB7E90A0068A11D /* OTPTextFieldCell+TokenForm.swift */,
+				C9078D171AB7E90A0068A11D /* TextFieldRowModel.swift */,
 				C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */,
 			);
 			name = Cells;
@@ -558,7 +558,7 @@
 				C98B1ECC1AB3CF0700C59E53 /* TokenRowCell.swift in Sources */,
 				C910ADC11BF0315A00C988F5 /* TokenList.swift in Sources */,
 				C9919CDD1BA64EED006237C1 /* TokenEntryForm.swift in Sources */,
-				C9078D181AB7E90A0068A11D /* OTPTextFieldCell+TokenForm.swift in Sources */,
+				C9078D181AB7E90A0068A11D /* TextFieldRowModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -22,6 +22,8 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import OneTimePassword
+
 enum Form: TableViewModelFamily {
     enum HeaderModel {
         case ButtonHeader(ButtonHeaderViewModel)
@@ -56,5 +58,11 @@ enum Form: TableViewModelFamily {
         case TokenType
         case DigitCount
         case Algorithm
+    }
+
+    enum Action {
+        case TokenType(Authenticator.TokenType)
+        case DigitCount(Int)
+        case Algorithm(Generator.Algorithm)
     }
 }

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -31,9 +31,9 @@ enum Form: TableViewModelFamily {
 
     enum RowModel: Identifiable {
         case TextFieldRow(TextFieldRowModel)
-        case TokenTypeRow(TokenTypeRowViewModel)
-        case DigitCountRow(DigitCountRowViewModel)
-        case AlgorithmRow(AlgorithmRowViewModel)
+        case TokenTypeRow(TokenTypeRowModel)
+        case DigitCountRow(DigitCountRowModel)
+        case AlgorithmRow(AlgorithmRowModel)
 
         func hasSameIdentity(other: RowModel) -> Bool {
             // As currently used, form rows don't move around much, so comparing the row

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -46,4 +46,10 @@ enum Form: TableViewModelFamily {
             }
         }
     }
+
+    enum Field: Equatable {
+        case Issuer
+        case Name
+        case Secret
+    }
 }

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -49,11 +49,6 @@ enum Form: TableViewModelFamily {
         }
     }
 
-    enum Field: Equatable {
-        case Issuer
-        case Name
-        case Secret
-    }
     enum OptionField: Equatable {
         case TokenType
         case DigitCount
@@ -61,6 +56,9 @@ enum Form: TableViewModelFamily {
     }
 
     enum Action {
+        case Issuer(String)
+        case Name(String)
+        case Secret(String)
         case TokenType(Authenticator.TokenType)
         case DigitCount(Int)
         case Algorithm(Generator.Algorithm)

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -28,7 +28,7 @@ enum Form: TableViewModelFamily {
     }
 
     enum RowModel: Identifiable {
-        case TextFieldRow(TextFieldRowViewModel)
+        case TextFieldRow(TextFieldRowModel)
         case TokenTypeRow(TokenTypeRowViewModel)
         case DigitCountRow(DigitCountRowViewModel)
         case AlgorithmRow(AlgorithmRowViewModel)

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -49,12 +49,6 @@ enum Form: TableViewModelFamily {
         }
     }
 
-    enum OptionField: Equatable {
-        case TokenType
-        case DigitCount
-        case Algorithm
-    }
-
     enum Action {
         case Issuer(String)
         case Name(String)

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -52,4 +52,9 @@ enum Form: TableViewModelFamily {
         case Name
         case Secret
     }
+    enum OptionField: Equatable {
+        case TokenType
+        case DigitCount
+        case Algorithm
+    }
 }

--- a/Authenticator/Source/OTPTextFieldCell+TokenForm.swift
+++ b/Authenticator/Source/OTPTextFieldCell+TokenForm.swift
@@ -34,11 +34,10 @@ struct IssuerRowViewModel: TextFieldRowViewModel {
     let returnKeyType: UIReturnKeyType = .Next
 
     let value: String
-    let changeAction: (String) -> ()
+    let identifier: Form.Field = .Issuer
 
-    init(value: String, changeAction: (String) -> ()) {
+    init(value: String) {
         self.value = value
-        self.changeAction = changeAction
     }
 }
 
@@ -52,12 +51,11 @@ struct NameRowViewModel: TextFieldRowViewModel {
     let returnKeyType: UIReturnKeyType
 
     let value: String
-    let changeAction: (String) -> ()
+    let identifier: Form.Field = .Name
 
-    init(value: String, returnKeyType: UIReturnKeyType, changeAction: (String) -> ()) {
+    init(value: String, returnKeyType: UIReturnKeyType) {
         self.value = value
         self.returnKeyType = returnKeyType
-        self.changeAction = changeAction
     }
 }
 
@@ -71,10 +69,9 @@ struct SecretRowViewModel: TextFieldRowViewModel {
     let returnKeyType: UIReturnKeyType = .Done
 
     let value: String
-    let changeAction: (String) -> ()
+    let identifier: Form.Field = .Secret
 
-    init(value: String, changeAction: (String) -> ()) {
+    init(value: String) {
         self.value = value
-        self.changeAction = changeAction
     }
 }

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -33,7 +33,9 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
 
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []
-    private var changeAction: ((Value) -> ())?
+    private var identifier: ViewModel.Identifier?
+
+    var changeAction: ((ViewModel.Identifier, Value) -> ())?
 
     var value: Value {
         return values[segmentedControl.selectedSegmentIndex]
@@ -66,7 +68,7 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
     // MARK: - View Model
 
     func updateWithViewModel(viewModel: ViewModel) {
-        changeAction = viewModel.changeAction
+        identifier = viewModel.identifier
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments
@@ -87,6 +89,8 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
     // MARK: - Target Action
 
     func segmentedControlValueChanged() {
-        changeAction?(value)
+        if let identifier = identifier {
+            changeAction?(identifier, value)
+        }
     }
 }

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -68,7 +68,7 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
     // MARK: - View Model
 
     func updateWithViewModel(viewModel: ViewModel) {
-        actionForValue = viewModel.actionForValue
+        actionForValue = viewModel.changeAction
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -25,17 +25,21 @@
 
 import UIKit
 
+protocol SegmentedControlRowCellDelegate: class {
+    func handleAction(action: Form.Action)
+}
+
 // "static stored properties not yet supported in generic types"
 private let preferredHeight: CGFloat = 54
 
 class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewCell {
     typealias Value = ViewModel.Value
 
+    weak var delegate: TextFieldRowCellDelegate?
+
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []
-    var actionForValue: ((Value) -> Form.Action)?
-
-    var changeAction: ((Form.Action) -> ())?
+    private var changeAction: ((Value) -> Form.Action)?
 
     var value: Value {
         return values[segmentedControl.selectedSegmentIndex]
@@ -68,7 +72,7 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
     // MARK: - View Model
 
     func updateWithViewModel(viewModel: ViewModel) {
-        actionForValue = viewModel.changeAction
+        changeAction = viewModel.changeAction
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments
@@ -89,8 +93,8 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
     // MARK: - Target Action
 
     func segmentedControlValueChanged() {
-        if let action = actionForValue?(value) {
-            changeAction?(action)
+        if let action = changeAction?(value) {
+            delegate?.handleAction(action)
         }
     }
 }

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -35,7 +35,7 @@ private let preferredHeight: CGFloat = 54
 class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewCell {
     typealias Value = ViewModel.Value
 
-    weak var delegate: TextFieldRowCellDelegate?
+    weak var delegate: SegmentedControlRowCellDelegate?
 
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -2,39 +2,33 @@
 //  SegmentedControlRowCell.swift
 //  Authenticator
 //
-//  Copyright (c) 2014 Matt Rubin
+//  Copyright (c) 2014-2015 Authenticator authors
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of
-//  this software and associated documentation files (the "Software"), to deal in
-//  the Software without restriction, including without limitation the rights to
-//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-//  the Software, and to permit persons to whom the Software is furnished to do so,
-//  subject to the following conditions:
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 import UIKit
 
-protocol SegmentedControlRowViewModel {
-    typealias Value: Equatable
-    var segments: [(title: String, value: Value)] { get }
-    var value: Value { get }
-    var changeAction: (Value) -> () { get }
-}
-
 // "static stored properties not yet supported in generic types"
 private let preferredHeight: CGFloat = 54
 
-class SegmentedControlRowCell<ViewModel: SegmentedControlRowViewModel>: UITableViewCell {
+class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewCell {
     typealias Value = ViewModel.Value
 
     private let segmentedControl = UISegmentedControl()

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -33,7 +33,6 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
 
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []
-    private var identifier: ViewModel.Identifier?
     var actionForValue: ((Value) -> Form.Action)?
 
     var changeAction: ((Form.Action) -> ())?
@@ -69,7 +68,6 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
     // MARK: - View Model
 
     func updateWithViewModel(viewModel: ViewModel) {
-        identifier = viewModel.identifier
         actionForValue = viewModel.actionForValue
         // Remove any old segments
         segmentedControl.removeAllSegments()

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -34,8 +34,9 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []
     private var identifier: ViewModel.Identifier?
+    var actionForValue: ((Value) -> Form.Action)?
 
-    var changeAction: ((ViewModel.Identifier, Value) -> ())?
+    var changeAction: ((Form.Action) -> ())?
 
     var value: Value {
         return values[segmentedControl.selectedSegmentIndex]
@@ -69,6 +70,7 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
 
     func updateWithViewModel(viewModel: ViewModel) {
         identifier = viewModel.identifier
+        actionForValue = viewModel.actionForValue
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments
@@ -89,8 +91,8 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
     // MARK: - Target Action
 
     func segmentedControlValueChanged() {
-        if let identifier = identifier {
-            changeAction?(identifier, value)
+        if let action = actionForValue?(value) {
+            changeAction?(action)
         }
     }
 }

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -26,10 +26,11 @@
 import OneTimePassword
 
 protocol SegmentedControlRowModel {
+    typealias Identifier
     typealias Value: Equatable
     var segments: [(title: String, value: Value)] { get }
     var value: Value { get }
-    var changeAction: (Value) -> () { get }
+    var identifier: Identifier { get }
 }
 
 enum TokenType {
@@ -43,11 +44,10 @@ struct TokenTypeRowViewModel: SegmentedControlRowModel {
         (title: "Counter Based", value: Value.Counter),
     ]
     let value: Value
-    let changeAction: (Value) -> ()
+    let identifier = Form.OptionField.TokenType
 
-    init(value: Value, changeAction: (Value) -> ()) {
+    init(value: Value) {
         self.value = value
-        self.changeAction = changeAction
     }
 }
 
@@ -59,11 +59,10 @@ struct DigitCountRowViewModel: SegmentedControlRowModel {
         (title: "8 Digits", value: 8),
     ]
     let value: Value
-    let changeAction: (Value) -> ()
+    let identifier = Form.OptionField.DigitCount
 
-    init(value: Value, changeAction: (Value) -> ()) {
+    init(value: Value) {
         self.value = value
-        self.changeAction = changeAction
     }
 }
 
@@ -75,10 +74,9 @@ struct AlgorithmRowViewModel: SegmentedControlRowModel {
         (title: "SHA-512", value: Value.SHA512),
     ]
     let value: Value
-    let changeAction: (Value) -> ()
+    let identifier = Form.OptionField.Algorithm
 
-    init(value: Value, changeAction: (Value) -> ()) {
+    init(value: Value) {
         self.value = value
-        self.changeAction = changeAction
     }
 }

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -29,7 +29,7 @@ protocol SegmentedControlRowModel {
     typealias Value: Equatable
     var segments: [(title: String, value: Value)] { get }
     var value: Value { get }
-    var actionForValue: (Value) -> Form.Action { get }
+    var changeAction: (Value) -> Form.Action { get }
 }
 
 enum TokenType {
@@ -43,12 +43,11 @@ struct TokenTypeRowViewModel: SegmentedControlRowModel {
         (title: "Counter Based", value: Value.Counter),
     ]
     let value: Value
-    let actionForValue: (Value) -> Form.Action = { (value) in
-        return Form.Action.TokenType(value)
-    }
+    let changeAction: (Value) -> Form.Action
 
-    init(value: Value) {
+    init(value: Value, changeAction: (Value) -> Form.Action) {
         self.value = value
+        self.changeAction = changeAction
     }
 }
 
@@ -60,12 +59,11 @@ struct DigitCountRowViewModel: SegmentedControlRowModel {
         (title: "8 Digits", value: 8),
     ]
     let value: Value
-    let actionForValue: (Value) -> Form.Action = { (value) in
-        return Form.Action.DigitCount(value)
-    }
+    let changeAction: (Value) -> Form.Action
 
-    init(value: Value) {
+    init(value: Value, changeAction: (Value) -> Form.Action) {
         self.value = value
+        self.changeAction = changeAction
     }
 }
 
@@ -77,11 +75,10 @@ struct AlgorithmRowViewModel: SegmentedControlRowModel {
         (title: "SHA-512", value: Value.SHA512),
     ]
     let value: Value
-    let actionForValue: (Value) -> Form.Action = { (value) in
-        return Form.Action.Algorithm(value)
-    }
+    let changeAction: (Value) -> Form.Action
 
-    init(value: Value) {
+    init(value: Value, changeAction: (Value) -> Form.Action) {
         self.value = value
+        self.changeAction = changeAction
     }
 }

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -31,6 +31,7 @@ protocol SegmentedControlRowModel {
     var segments: [(title: String, value: Value)] { get }
     var value: Value { get }
     var identifier: Identifier { get }
+    var actionForValue: (Value) -> Form.Action { get }
 }
 
 enum TokenType {
@@ -45,6 +46,9 @@ struct TokenTypeRowViewModel: SegmentedControlRowModel {
     ]
     let value: Value
     let identifier = Form.OptionField.TokenType
+    let actionForValue: (Value) -> Form.Action = { (value) in
+        return Form.Action.TokenType(value)
+    }
 
     init(value: Value) {
         self.value = value
@@ -60,6 +64,9 @@ struct DigitCountRowViewModel: SegmentedControlRowModel {
     ]
     let value: Value
     let identifier = Form.OptionField.DigitCount
+    let actionForValue: (Value) -> Form.Action = { (value) in
+        return Form.Action.DigitCount(value)
+    }
 
     init(value: Value) {
         self.value = value
@@ -75,6 +82,9 @@ struct AlgorithmRowViewModel: SegmentedControlRowModel {
     ]
     let value: Value
     let identifier = Form.OptionField.Algorithm
+    let actionForValue: (Value) -> Form.Action = { (value) in
+        return Form.Action.Algorithm(value)
+    }
 
     init(value: Value) {
         self.value = value

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -1,34 +1,42 @@
 //
-//  OTPSegmentedControlCell+TokenForm.swift
+//  SegmentedControlRowModel.swift
 //  Authenticator
 //
-//  Copyright (c) 2015 Matt Rubin
+//  Copyright (c) 2015 Authenticator authors
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of
-//  this software and associated documentation files (the "Software"), to deal in
-//  the Software without restriction, including without limitation the rights to
-//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-//  the Software, and to permit persons to whom the Software is furnished to do so,
-//  subject to the following conditions:
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 import OneTimePassword
+
+protocol SegmentedControlRowModel {
+    typealias Value: Equatable
+    var segments: [(title: String, value: Value)] { get }
+    var value: Value { get }
+    var changeAction: (Value) -> () { get }
+}
 
 enum TokenType {
     case Counter, Timer
 }
 
-struct TokenTypeRowViewModel: SegmentedControlRowViewModel {
+struct TokenTypeRowViewModel: SegmentedControlRowModel {
     typealias Value = TokenType
     let segments = [
         (title: "Time Based", value: Value.Timer),
@@ -43,7 +51,7 @@ struct TokenTypeRowViewModel: SegmentedControlRowViewModel {
     }
 }
 
-struct DigitCountRowViewModel: SegmentedControlRowViewModel {
+struct DigitCountRowViewModel: SegmentedControlRowModel {
     typealias Value = Int
     let segments = [
         (title: "6 Digits", value: 6),
@@ -59,7 +67,7 @@ struct DigitCountRowViewModel: SegmentedControlRowViewModel {
     }
 }
 
-struct AlgorithmRowViewModel: SegmentedControlRowViewModel {
+struct AlgorithmRowViewModel: SegmentedControlRowModel {
     typealias Value = Generator.Algorithm
     let segments = [
         (title: "SHA-1", value: Value.SHA1),

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -26,11 +26,9 @@
 import OneTimePassword
 
 protocol SegmentedControlRowModel {
-    typealias Identifier
     typealias Value: Equatable
     var segments: [(title: String, value: Value)] { get }
     var value: Value { get }
-    var identifier: Identifier { get }
     var actionForValue: (Value) -> Form.Action { get }
 }
 
@@ -45,7 +43,6 @@ struct TokenTypeRowViewModel: SegmentedControlRowModel {
         (title: "Counter Based", value: Value.Counter),
     ]
     let value: Value
-    let identifier = Form.OptionField.TokenType
     let actionForValue: (Value) -> Form.Action = { (value) in
         return Form.Action.TokenType(value)
     }
@@ -63,7 +60,6 @@ struct DigitCountRowViewModel: SegmentedControlRowModel {
         (title: "8 Digits", value: 8),
     ]
     let value: Value
-    let identifier = Form.OptionField.DigitCount
     let actionForValue: (Value) -> Form.Action = { (value) in
         return Form.Action.DigitCount(value)
     }
@@ -81,7 +77,6 @@ struct AlgorithmRowViewModel: SegmentedControlRowModel {
         (title: "SHA-512", value: Value.SHA512),
     ]
     let value: Value
-    let identifier = Form.OptionField.Algorithm
     let actionForValue: (Value) -> Form.Action = { (value) in
         return Form.Action.Algorithm(value)
     }

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -36,7 +36,7 @@ enum TokenType {
     case Counter, Timer
 }
 
-struct TokenTypeRowViewModel: SegmentedControlRowModel {
+struct TokenTypeRowModel: SegmentedControlRowModel {
     typealias Value = TokenType
     let segments = [
         (title: "Time Based", value: Value.Timer),
@@ -51,7 +51,7 @@ struct TokenTypeRowViewModel: SegmentedControlRowModel {
     }
 }
 
-struct DigitCountRowViewModel: SegmentedControlRowModel {
+struct DigitCountRowModel: SegmentedControlRowModel {
     typealias Value = Int
     let segments = [
         (title: "6 Digits", value: 6),
@@ -67,7 +67,7 @@ struct DigitCountRowViewModel: SegmentedControlRowModel {
     }
 }
 
-struct AlgorithmRowViewModel: SegmentedControlRowModel {
+struct AlgorithmRowModel: SegmentedControlRowModel {
     typealias Value = Generator.Algorithm
     let segments = [
         (title: "SHA-1", value: Value.SHA1),

--- a/Authenticator/Source/TextFieldRowCell.swift
+++ b/Authenticator/Source/TextFieldRowCell.swift
@@ -35,8 +35,7 @@ class TextFieldRowCell: UITableViewCell {
 
     let textField = UITextField()
     weak var delegate: TextFieldRowCellDelegate?
-    var changeAction: ((String) -> Form.Action)?
-
+    private var changeAction: ((String) -> Form.Action)?
 
     // MARK: - Init
 
@@ -96,8 +95,8 @@ class TextFieldRowCell: UITableViewCell {
 
     func textFieldValueChanged() {
         let newText = textField.text ?? ""
-        if let changeAction = changeAction {
-            delegate?.handleAction(changeAction(newText))
+        if let action = changeAction?(newText) {
+            delegate?.handleAction(action)
         }
     }
 }

--- a/Authenticator/Source/TextFieldRowCell.swift
+++ b/Authenticator/Source/TextFieldRowCell.swift
@@ -24,33 +24,17 @@
 
 import UIKit
 
-protocol TextFieldRowViewModel {
-    var label: String { get }
-    var placeholder: String { get }
-
-    var autocapitalizationType: UITextAutocapitalizationType { get }
-    var autocorrectionType: UITextAutocorrectionType { get }
-    var keyboardType: UIKeyboardType { get }
-    var returnKeyType: UIReturnKeyType { get }
-
-    var value: String { get }
-    var identifier: Form.Field { get }
-}
-
 protocol TextFieldRowCellDelegate: class {
     func textFieldCellDidReturn(textFieldCell: TextFieldRowCell)
     func textFieldCellChangedValue(value: String, forField field: Form.Field)
 }
 
 class TextFieldRowCell: UITableViewCell {
-    typealias Identifier = Form.Field
-    typealias Value = String
-
     private static let preferredHeight: CGFloat = 74
 
     let textField = UITextField()
     weak var delegate: TextFieldRowCellDelegate?
-    private var identifier: Identifier?
+    private var identifier: Form.Field?
 
     // MARK: - Init
 

--- a/Authenticator/Source/TextFieldRowCell.swift
+++ b/Authenticator/Source/TextFieldRowCell.swift
@@ -34,7 +34,7 @@ protocol TextFieldRowViewModel {
     var returnKeyType: UIReturnKeyType { get }
 
     var value: String { get }
-    var changeAction: (String) -> () { get }
+    var identifier: Form.Field { get }
 }
 
 protocol TextFieldRowCellDelegate: class {
@@ -42,12 +42,16 @@ protocol TextFieldRowCellDelegate: class {
 }
 
 class TextFieldRowCell: UITableViewCell {
+    typealias Identifier = Form.Field
+    typealias Value = String
+    typealias ChangeAction = (Identifier, Value) -> Void
+
     private static let preferredHeight: CGFloat = 74
 
     let textField = UITextField()
     weak var delegate: TextFieldRowCellDelegate?
-    var changeAction: ((String) -> ())?
-
+    private var changeAction: ChangeAction?
+    private var identifier: Identifier?
 
     // MARK: - Init
 
@@ -82,7 +86,7 @@ class TextFieldRowCell: UITableViewCell {
 
     // MARK: - View Model
 
-    func updateWithViewModel(viewModel: TextFieldRowViewModel) {
+    func updateWithViewModel(viewModel: TextFieldRowViewModel, changeAction: ChangeAction) {
         textLabel?.text = viewModel.label
         textField.placeholder = viewModel.placeholder
 
@@ -96,7 +100,8 @@ class TextFieldRowCell: UITableViewCell {
         if textField.text != viewModel.value {
             textField.text = viewModel.value
         }
-        changeAction = viewModel.changeAction
+        identifier = viewModel.identifier
+        self.changeAction = changeAction
     }
 
     static func heightWithViewModel(viewModel: TextFieldRowViewModel) -> CGFloat {
@@ -107,7 +112,9 @@ class TextFieldRowCell: UITableViewCell {
 
     func textFieldValueChanged() {
         let newText = textField.text ?? ""
-        changeAction?(newText)
+        if let identifier = identifier {
+            changeAction?(identifier, newText)
+        }
     }
 }
 

--- a/Authenticator/Source/TextFieldRowCell.swift
+++ b/Authenticator/Source/TextFieldRowCell.swift
@@ -69,7 +69,7 @@ class TextFieldRowCell: UITableViewCell {
 
     // MARK: - View Model
 
-    func updateWithViewModel(viewModel: TextFieldRowViewModel) {
+    func updateWithViewModel(viewModel: TextFieldRowModel) {
         textLabel?.text = viewModel.label
         textField.placeholder = viewModel.placeholder
 
@@ -86,7 +86,7 @@ class TextFieldRowCell: UITableViewCell {
         identifier = viewModel.identifier
     }
 
-    static func heightWithViewModel(viewModel: TextFieldRowViewModel) -> CGFloat {
+    static func heightWithViewModel(viewModel: TextFieldRowModel) -> CGFloat {
         return preferredHeight
     }
 

--- a/Authenticator/Source/TextFieldRowCell.swift
+++ b/Authenticator/Source/TextFieldRowCell.swift
@@ -27,7 +27,7 @@ import UIKit
 
 protocol TextFieldRowCellDelegate: class {
     func textFieldCellDidReturn(textFieldCell: TextFieldRowCell)
-    func textFieldCellChangedValue(value: String, forField field: Form.Field)
+    func handleAction(action: Form.Action)
 }
 
 class TextFieldRowCell: UITableViewCell {
@@ -35,7 +35,8 @@ class TextFieldRowCell: UITableViewCell {
 
     let textField = UITextField()
     weak var delegate: TextFieldRowCellDelegate?
-    private var identifier: Form.Field?
+    var changeAction: ((String) -> Form.Action)?
+
 
     // MARK: - Init
 
@@ -84,7 +85,7 @@ class TextFieldRowCell: UITableViewCell {
         if textField.text != viewModel.value {
             textField.text = viewModel.value
         }
-        identifier = viewModel.identifier
+        changeAction = viewModel.changeAction
     }
 
     static func heightWithViewModel(viewModel: TextFieldRowModel) -> CGFloat {
@@ -95,8 +96,8 @@ class TextFieldRowCell: UITableViewCell {
 
     func textFieldValueChanged() {
         let newText = textField.text ?? ""
-        if let identifier = identifier {
-            delegate?.textFieldCellChangedValue(newText, forField: identifier)
+        if let changeAction = changeAction {
+            delegate?.handleAction(changeAction(newText))
         }
     }
 }

--- a/Authenticator/Source/TextFieldRowCell.swift
+++ b/Authenticator/Source/TextFieldRowCell.swift
@@ -39,18 +39,17 @@ protocol TextFieldRowViewModel {
 
 protocol TextFieldRowCellDelegate: class {
     func textFieldCellDidReturn(textFieldCell: TextFieldRowCell)
+    func textFieldCellChangedValue(value: String, forField field: Form.Field)
 }
 
 class TextFieldRowCell: UITableViewCell {
     typealias Identifier = Form.Field
     typealias Value = String
-    typealias ChangeAction = (Identifier, Value) -> Void
 
     private static let preferredHeight: CGFloat = 74
 
     let textField = UITextField()
     weak var delegate: TextFieldRowCellDelegate?
-    private var changeAction: ChangeAction?
     private var identifier: Identifier?
 
     // MARK: - Init
@@ -86,7 +85,7 @@ class TextFieldRowCell: UITableViewCell {
 
     // MARK: - View Model
 
-    func updateWithViewModel(viewModel: TextFieldRowViewModel, changeAction: ChangeAction) {
+    func updateWithViewModel(viewModel: TextFieldRowViewModel) {
         textLabel?.text = viewModel.label
         textField.placeholder = viewModel.placeholder
 
@@ -101,7 +100,6 @@ class TextFieldRowCell: UITableViewCell {
             textField.text = viewModel.value
         }
         identifier = viewModel.identifier
-        self.changeAction = changeAction
     }
 
     static func heightWithViewModel(viewModel: TextFieldRowViewModel) -> CGFloat {
@@ -113,7 +111,7 @@ class TextFieldRowCell: UITableViewCell {
     func textFieldValueChanged() {
         let newText = textField.text ?? ""
         if let identifier = identifier {
-            changeAction?(identifier, newText)
+            delegate?.textFieldCellChangedValue(newText, forField: identifier)
         }
     }
 }

--- a/Authenticator/Source/TextFieldRowCell.swift
+++ b/Authenticator/Source/TextFieldRowCell.swift
@@ -1,25 +1,26 @@
 //
-//  OTPTextFieldCell.m
+//  TextFieldRowCell.swift
 //  Authenticator
 //
-//  Copyright (c) 2014 Matt Rubin
+//  Copyright (c) 2014-2015 Authenticator authors
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of
-//  this software and associated documentation files (the "Software"), to deal in
-//  the Software without restriction, including without limitation the rights to
-//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-//  the Software, and to permit persons to whom the Software is furnished to do so,
-//  subject to the following conditions:
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 import UIKit

--- a/Authenticator/Source/TextFieldRowModel.swift
+++ b/Authenticator/Source/TextFieldRowModel.swift
@@ -2,24 +2,25 @@
 //  TextFieldRowModel.swift
 //  Authenticator
 //
-//  Copyright (c) 2015 Matt Rubin
+//  Copyright (c) 2015 Authenticator authors
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of
-//  this software and associated documentation files (the "Software"), to deal in
-//  the Software without restriction, including without limitation the rights to
-//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-//  the Software, and to permit persons to whom the Software is furnished to do so,
-//  subject to the following conditions:
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 import UIKit

--- a/Authenticator/Source/TextFieldRowModel.swift
+++ b/Authenticator/Source/TextFieldRowModel.swift
@@ -1,5 +1,5 @@
 //
-//  OTPTextFieldCell+TokenForm.swift
+//  TextFieldRowModel.swift
 //  Authenticator
 //
 //  Copyright (c) 2015 Matt Rubin
@@ -23,6 +23,19 @@
 //
 
 import UIKit
+
+protocol TextFieldRowViewModel {
+    var label: String { get }
+    var placeholder: String { get }
+
+    var autocapitalizationType: UITextAutocapitalizationType { get }
+    var autocorrectionType: UITextAutocorrectionType { get }
+    var keyboardType: UIKeyboardType { get }
+    var returnKeyType: UIReturnKeyType { get }
+
+    var value: String { get }
+    var identifier: Form.Field { get }
+}
 
 struct IssuerRowViewModel: TextFieldRowViewModel {
     let label = "Issuer"

--- a/Authenticator/Source/TextFieldRowModel.swift
+++ b/Authenticator/Source/TextFieldRowModel.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-protocol TextFieldRowViewModel {
+protocol TextFieldRowModel {
     var label: String { get }
     var placeholder: String { get }
 
@@ -37,7 +37,7 @@ protocol TextFieldRowViewModel {
     var identifier: Form.Field { get }
 }
 
-struct IssuerRowViewModel: TextFieldRowViewModel {
+struct IssuerRowViewModel: TextFieldRowModel {
     let label = "Issuer"
     let placeholder = "Some Website"
 
@@ -54,7 +54,7 @@ struct IssuerRowViewModel: TextFieldRowViewModel {
     }
 }
 
-struct NameRowViewModel: TextFieldRowViewModel {
+struct NameRowViewModel: TextFieldRowModel {
     let label = "Account Name"
     let placeholder = "user@example.com"
 
@@ -72,7 +72,7 @@ struct NameRowViewModel: TextFieldRowViewModel {
     }
 }
 
-struct SecretRowViewModel: TextFieldRowViewModel {
+struct SecretRowViewModel: TextFieldRowModel {
     let label = "Secret Key"
     let placeholder = "•••• •••• •••• ••••"
 

--- a/Authenticator/Source/TextFieldRowModel.swift
+++ b/Authenticator/Source/TextFieldRowModel.swift
@@ -35,7 +35,7 @@ protocol TextFieldRowModel {
     var returnKeyType: UIReturnKeyType { get }
 
     var value: String { get }
-    var identifier: Form.Field { get }
+    var changeAction: (String) -> Form.Action { get }
 }
 
 struct IssuerRowViewModel: TextFieldRowModel {
@@ -48,10 +48,11 @@ struct IssuerRowViewModel: TextFieldRowModel {
     let returnKeyType: UIReturnKeyType = .Next
 
     let value: String
-    let identifier: Form.Field = .Issuer
+    let changeAction: (String) -> Form.Action
 
-    init(value: String) {
+    init(value: String, changeAction: (String) -> Form.Action) {
         self.value = value
+        self.changeAction = changeAction
     }
 }
 
@@ -65,11 +66,12 @@ struct NameRowViewModel: TextFieldRowModel {
     let returnKeyType: UIReturnKeyType
 
     let value: String
-    let identifier: Form.Field = .Name
+    let changeAction: (String) -> Form.Action
 
-    init(value: String, returnKeyType: UIReturnKeyType) {
+    init(value: String, returnKeyType: UIReturnKeyType, changeAction: (String) -> Form.Action) {
         self.value = value
         self.returnKeyType = returnKeyType
+        self.changeAction = changeAction
     }
 }
 
@@ -83,9 +85,10 @@ struct SecretRowViewModel: TextFieldRowModel {
     let returnKeyType: UIReturnKeyType = .Done
 
     let value: String
-    let identifier: Form.Field = .Secret
+    let changeAction: (String) -> Form.Action
 
-    init(value: String) {
+    init(value: String, changeAction: (String) -> Form.Action) {
         self.value = value
+        self.changeAction = changeAction
     }
 }

--- a/Authenticator/Source/TextFieldRowModel.swift
+++ b/Authenticator/Source/TextFieldRowModel.swift
@@ -38,7 +38,7 @@ protocol TextFieldRowModel {
     var changeAction: (String) -> Form.Action { get }
 }
 
-struct IssuerRowViewModel: TextFieldRowModel {
+struct IssuerRowModel: TextFieldRowModel {
     let label = "Issuer"
     let placeholder = "Some Website"
 
@@ -56,7 +56,7 @@ struct IssuerRowViewModel: TextFieldRowModel {
     }
 }
 
-struct NameRowViewModel: TextFieldRowModel {
+struct NameRowModel: TextFieldRowModel {
     let label = "Account Name"
     let placeholder = "user@example.com"
 
@@ -75,7 +75,7 @@ struct NameRowViewModel: TextFieldRowModel {
     }
 }
 
-struct SecretRowViewModel: TextFieldRowModel {
+struct SecretRowModel: TextFieldRowModel {
     let label = "Secret Key"
     let placeholder = "•••• •••• •••• ••••"
 

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -77,7 +77,7 @@ class TokenEditForm: TokenForm {
     }
 
     private var issuerRowModel: Form.RowModel {
-        let model = IssuerRowViewModel(
+        let model = IssuerRowModel(
             value: state.issuer,
             changeAction: Form.Action.Issuer
         )
@@ -85,7 +85,7 @@ class TokenEditForm: TokenForm {
     }
 
     private var nameRowModel: Form.RowModel {
-        let model = NameRowViewModel(
+        let model = NameRowModel(
             value: state.name,
             returnKeyType: .Done,
             changeAction: Form.Action.Name

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -105,18 +105,9 @@ class TokenEditForm: TokenForm {
         }
     }
 
-    func updateField(field: Form.OptionField, withValue value: TokenType) {
+    func handleAction(action: Form.Action) {
         fatalError()
     }
-
-    func updateField(field: Form.OptionField, withValue value: Int) {
-        fatalError()
-    }
-
-    func updateField(field: Form.OptionField, withValue value: Generator.Algorithm) {
-        fatalError()
-    }
-
 
     // MARK: Initialization
 

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -78,7 +78,8 @@ class TokenEditForm: TokenForm {
 
     private var issuerRowModel: Form.RowModel {
         let model = IssuerRowViewModel(
-            value: state.issuer
+            value: state.issuer,
+            changeAction: Form.Action.Issuer
         )
         return .TextFieldRow(model)
     }
@@ -86,27 +87,23 @@ class TokenEditForm: TokenForm {
     private var nameRowModel: Form.RowModel {
         let model = NameRowViewModel(
             value: state.name,
-            returnKeyType: .Done
+            returnKeyType: .Done,
+            changeAction: Form.Action.Name
         )
         return .TextFieldRow(model)
     }
 
     // MARK: Action handling
 
-    func updateField(field: Form.Field, withValue value: String) {
-        print("Update \(field) to \"\(value)\"")
-        switch field {
-        case .Issuer:
+    func handleAction(action: Form.Action) {
+        switch action {
+        case .Issuer(let value):
             state.issuer = value
-        case .Name:
+        case .Name(let value):
             state.name = value
-        case .Secret:
+        default:
             fatalError()
         }
-    }
-
-    func handleAction(action: Form.Action) {
-        fatalError()
     }
 
     // MARK: Initialization

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -105,6 +105,19 @@ class TokenEditForm: TokenForm {
         }
     }
 
+    func updateField(field: Form.OptionField, withValue value: TokenType) {
+        fatalError()
+    }
+
+    func updateField(field: Form.OptionField, withValue value: Int) {
+        fatalError()
+    }
+
+    func updateField(field: Form.OptionField, withValue value: Generator.Algorithm) {
+        fatalError()
+    }
+
+
     // MARK: Initialization
 
     init(persistentToken: PersistentToken, actionHandler: ActionHandler) {

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -78,10 +78,7 @@ class TokenEditForm: TokenForm {
 
     private var issuerRowModel: Form.RowModel {
         let model = IssuerRowViewModel(
-            value: state.issuer,
-            changeAction: { [weak self] (newIssuer) -> () in
-                self?.state.issuer = newIssuer
-            }
+            value: state.issuer
         )
         return .TextFieldRow(model)
     }
@@ -89,12 +86,23 @@ class TokenEditForm: TokenForm {
     private var nameRowModel: Form.RowModel {
         let model = NameRowViewModel(
             value: state.name,
-            returnKeyType: .Done,
-            changeAction: { [weak self] (newName) -> () in
-                self?.state.name = newName
-            }
+            returnKeyType: .Done
         )
         return .TextFieldRow(model)
+    }
+
+    // MARK: Action handling
+
+    func updateField(field: Form.Field, withValue value: String) {
+        print("Update \(field) to \"\(value)\"")
+        switch field {
+        case .Issuer:
+            state.issuer = value
+        case .Name:
+            state.name = value
+        case .Secret:
+            fatalError()
+        }
     }
 
     // MARK: Initialization

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -124,10 +124,7 @@ extension TokenEntryForm {
 
     private var issuerRowModel: Form.RowModel {
         let model = IssuerRowViewModel(
-            value: state.issuer,
-            changeAction: { [weak self] (newIssuer) -> () in
-                self?.state.issuer = newIssuer
-            }
+            value: state.issuer
         )
         return .TextFieldRow(model)
     }
@@ -135,20 +132,14 @@ extension TokenEntryForm {
     private var nameRowModel: Form.RowModel {
         let model = NameRowViewModel(
             value: state.name,
-            returnKeyType: .Next,
-            changeAction: { [weak self] (newName) -> () in
-                self?.state.name = newName
-            }
+            returnKeyType: .Next
         )
         return .TextFieldRow(model)
     }
 
     private var secretRowModel: Form.RowModel {
         let model = SecretRowViewModel(
-            value: state.secret,
-            changeAction: { [weak self] (newSecret) -> () in
-                self?.state.secret = newSecret
-            }
+            value: state.secret
         )
         return .TextFieldRow(model)
     }
@@ -181,6 +172,20 @@ extension TokenEntryForm {
             }
         )
         return .AlgorithmRow(model)
+    }
+
+    // MARK: Action handling
+
+    func updateField(field: Form.Field, withValue value: String) {
+        print("Update \(field) to \"\(value)\"")
+        switch field {
+        case .Issuer:
+            state.issuer = value
+        case .Name:
+            state.name = value
+        case .Secret:
+            state.secret = value
+        }
     }
 }
 

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -146,30 +146,30 @@ extension TokenEntryForm {
 
     private var tokenTypeRowModel: Form.RowModel {
         let model = TokenTypeRowViewModel(
-            value: state.tokenType,
-            changeAction: { [weak self] (newTokenType) -> () in
-                self?.state.tokenType = newTokenType
-            }
+            value: state.tokenType
+//            changeAction: { [weak self] (newTokenType) -> () in
+//                self?.state.tokenType = newTokenType
+//            }
         )
         return .TokenTypeRow(model)
     }
 
     private var digitCountRowModel: Form.RowModel {
         let model = DigitCountRowViewModel(
-            value: state.digitCount,
-            changeAction: { [weak self] (newDigitCount) -> () in
-                self?.state.digitCount = newDigitCount
-            }
+            value: state.digitCount
+//            changeAction: { [weak self] (newDigitCount) -> () in
+//                self?.state.digitCount = newDigitCount
+//            }
         )
         return .DigitCountRow(model)
     }
 
     private var algorithmRowModel: Form.RowModel {
         let model = AlgorithmRowViewModel(
-            value: state.algorithm,
-            changeAction: { [weak self] (newAlgorithm) -> () in
-                self?.state.algorithm = newAlgorithm
-            }
+            value: state.algorithm
+//            changeAction: { [weak self] (newAlgorithm) -> () in
+//                self?.state.algorithm = newAlgorithm
+//            }
         )
         return .AlgorithmRow(model)
     }
@@ -185,6 +185,33 @@ extension TokenEntryForm {
             state.name = value
         case .Secret:
             state.secret = value
+        }
+    }
+
+    func updateField(field: Form.OptionField, withValue value: TokenType) {
+        switch field {
+        case .TokenType:
+            state.tokenType = value
+        default:
+            fatalError()
+        }
+    }
+
+    func updateField(field: Form.OptionField, withValue value: Int) {
+        switch field {
+        case .DigitCount:
+            state.digitCount = value
+        default:
+            fatalError()
+        }
+    }
+
+    func updateField(field: Form.OptionField, withValue value: Generator.Algorithm) {
+        switch field {
+        case .Algorithm:
+            state.algorithm = value
+        default:
+            fatalError()
         }
     }
 }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -123,7 +123,7 @@ extension TokenEntryForm {
     }
 
     private var issuerRowModel: Form.RowModel {
-        let model = IssuerRowViewModel(
+        let model = IssuerRowModel(
             value: state.issuer,
             changeAction: Form.Action.Issuer
         )
@@ -131,7 +131,7 @@ extension TokenEntryForm {
     }
 
     private var nameRowModel: Form.RowModel {
-        let model = NameRowViewModel(
+        let model = NameRowModel(
             value: state.name,
             returnKeyType: .Next,
             changeAction: Form.Action.Name
@@ -140,7 +140,7 @@ extension TokenEntryForm {
     }
 
     private var secretRowModel: Form.RowModel {
-        let model = SecretRowViewModel(
+        let model = SecretRowModel(
             value: state.secret,
             changeAction: Form.Action.Secret
         )
@@ -148,7 +148,7 @@ extension TokenEntryForm {
     }
 
     private var tokenTypeRowModel: Form.RowModel {
-        let model = TokenTypeRowViewModel(
+        let model = TokenTypeRowModel(
             value: state.tokenType,
             changeAction: Form.Action.TokenType
         )
@@ -156,7 +156,7 @@ extension TokenEntryForm {
     }
 
     private var digitCountRowModel: Form.RowModel {
-        let model = DigitCountRowViewModel(
+        let model = DigitCountRowModel(
             value: state.digitCount,
             changeAction: Form.Action.DigitCount
         )
@@ -164,7 +164,7 @@ extension TokenEntryForm {
     }
 
     private var algorithmRowModel: Form.RowModel {
-        let model = AlgorithmRowViewModel(
+        let model = AlgorithmRowModel(
             value: state.algorithm,
             changeAction: Form.Action.Algorithm
         )

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -188,30 +188,14 @@ extension TokenEntryForm {
         }
     }
 
-    func updateField(field: Form.OptionField, withValue value: TokenType) {
-        switch field {
-        case .TokenType:
+    func handleAction(action: Form.Action) {
+        switch action {
+        case .TokenType(let value):
             state.tokenType = value
-        default:
-            fatalError()
-        }
-    }
-
-    func updateField(field: Form.OptionField, withValue value: Int) {
-        switch field {
-        case .DigitCount:
+        case .DigitCount(let value):
             state.digitCount = value
-        default:
-            fatalError()
-        }
-    }
-
-    func updateField(field: Form.OptionField, withValue value: Generator.Algorithm) {
-        switch field {
-        case .Algorithm:
+        case .Algorithm(let value):
             state.algorithm = value
-        default:
-            fatalError()
         }
     }
 }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -149,30 +149,24 @@ extension TokenEntryForm {
 
     private var tokenTypeRowModel: Form.RowModel {
         let model = TokenTypeRowViewModel(
-            value: state.tokenType
-//            changeAction: { [weak self] (newTokenType) -> () in
-//                self?.state.tokenType = newTokenType
-//            }
+            value: state.tokenType,
+            changeAction: Form.Action.TokenType
         )
         return .TokenTypeRow(model)
     }
 
     private var digitCountRowModel: Form.RowModel {
         let model = DigitCountRowViewModel(
-            value: state.digitCount
-//            changeAction: { [weak self] (newDigitCount) -> () in
-//                self?.state.digitCount = newDigitCount
-//            }
+            value: state.digitCount,
+            changeAction: Form.Action.DigitCount
         )
         return .DigitCountRow(model)
     }
 
     private var algorithmRowModel: Form.RowModel {
         let model = AlgorithmRowViewModel(
-            value: state.algorithm
-//            changeAction: { [weak self] (newAlgorithm) -> () in
-//                self?.state.algorithm = newAlgorithm
-//            }
+            value: state.algorithm,
+            changeAction: Form.Action.Algorithm
         )
         return .AlgorithmRow(model)
     }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -124,7 +124,8 @@ extension TokenEntryForm {
 
     private var issuerRowModel: Form.RowModel {
         let model = IssuerRowViewModel(
-            value: state.issuer
+            value: state.issuer,
+            changeAction: Form.Action.Issuer
         )
         return .TextFieldRow(model)
     }
@@ -132,14 +133,16 @@ extension TokenEntryForm {
     private var nameRowModel: Form.RowModel {
         let model = NameRowViewModel(
             value: state.name,
-            returnKeyType: .Next
+            returnKeyType: .Next,
+            changeAction: Form.Action.Name
         )
         return .TextFieldRow(model)
     }
 
     private var secretRowModel: Form.RowModel {
         let model = SecretRowViewModel(
-            value: state.secret
+            value: state.secret,
+            changeAction: Form.Action.Secret
         )
         return .TextFieldRow(model)
     }
@@ -176,20 +179,14 @@ extension TokenEntryForm {
 
     // MARK: Action handling
 
-    func updateField(field: Form.Field, withValue value: String) {
-        print("Update \(field) to \"\(value)\"")
-        switch field {
-        case .Issuer:
-            state.issuer = value
-        case .Name:
-            state.name = value
-        case .Secret:
-            state.secret = value
-        }
-    }
-
     func handleAction(action: Form.Action) {
         switch action {
+        case .Issuer(let value):
+            state.issuer = value
+        case .Name(let value):
+            state.name = value
+        case .Secret(let value):
+            state.secret = value
         case .TokenType(let value):
             state.tokenType = value
         case .DigitCount(let value):

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -22,10 +22,15 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import OneTimePassword
+
 protocol TokenForm {
     var viewModel: TableViewModel<Form> { get }
     weak var presenter: TokenFormPresenter? { get set }
     func updateField(field: Form.Field, withValue value: String)
+    func updateField(field: Form.OptionField, withValue value: TokenType)
+    func updateField(field: Form.OptionField, withValue value: Int)
+    func updateField(field: Form.OptionField, withValue value: Generator.Algorithm)
 }
 
 protocol TokenFormPresenter: class {

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -28,9 +28,7 @@ protocol TokenForm {
     var viewModel: TableViewModel<Form> { get }
     weak var presenter: TokenFormPresenter? { get set }
     func updateField(field: Form.Field, withValue value: String)
-    func updateField(field: Form.OptionField, withValue value: TokenType)
-    func updateField(field: Form.OptionField, withValue value: Int)
-    func updateField(field: Form.OptionField, withValue value: Generator.Algorithm)
+    func handleAction(action: Form.Action)
 }
 
 protocol TokenFormPresenter: class {

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -27,7 +27,6 @@ import OneTimePassword
 protocol TokenForm {
     var viewModel: TableViewModel<Form> { get }
     weak var presenter: TokenFormPresenter? { get set }
-    func updateField(field: Form.Field, withValue value: String)
     func handleAction(action: Form.Action)
 }
 

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -22,8 +22,6 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import OneTimePassword
-
 protocol TokenForm {
     var viewModel: TableViewModel<Form> { get }
     weak var presenter: TokenFormPresenter? { get set }

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -25,6 +25,7 @@
 protocol TokenForm {
     var viewModel: TableViewModel<Form> { get }
     weak var presenter: TokenFormPresenter? { get set }
+    func updateField(field: Form.Field, withValue value: String)
 }
 
 protocol TokenFormPresenter: class {

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -25,6 +25,10 @@
 import UIKit
 import SVProgressHUD
 
+typealias TokenTypeRowCell = SegmentedControlRowCell<TokenTypeRowModel>
+typealias DigitCountRowCell = SegmentedControlRowCell<DigitCountRowModel>
+typealias AlgorithmRowCell = SegmentedControlRowCell<AlgorithmRowModel>
+
 class TokenFormViewController: UITableViewController {
     private var form: TokenForm?
     private var viewModel: TableViewModel<Form> = EmptyTableViewModel() {
@@ -230,19 +234,19 @@ extension TokenFormViewController {
             return cell
 
         case .TokenTypeRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<TokenTypeRowModel>.self)
+            let cell = tableView.dequeueReusableCellWithClass(TokenTypeRowCell.self)
             cell.updateWithViewModel(viewModel)
             cell.delegate = self
             return cell
 
         case .DigitCountRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<DigitCountRowModel>.self)
+            let cell = tableView.dequeueReusableCellWithClass(DigitCountRowCell.self)
             cell.updateWithViewModel(viewModel)
             cell.delegate = self
             return cell
 
         case .AlgorithmRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<AlgorithmRowModel>.self)
+            let cell = tableView.dequeueReusableCellWithClass(AlgorithmRowCell.self)
             cell.updateWithViewModel(viewModel)
             cell.delegate = self
             return cell
@@ -270,19 +274,19 @@ extension TokenFormViewController {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .TokenTypeRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<TokenTypeRowModel> {
+            if let cell = cell as? TokenTypeRowCell {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .DigitCountRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<DigitCountRowModel> {
+            if let cell = cell as? DigitCountRowCell {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .AlgorithmRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<AlgorithmRowModel> {
+            if let cell = cell as? AlgorithmRowCell {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
@@ -295,11 +299,11 @@ extension TokenFormViewController {
         case .TextFieldRow(let viewModel):
             return TextFieldRowCell.heightWithViewModel(viewModel)
         case .TokenTypeRow(let viewModel):
-            return SegmentedControlRowCell.heightWithViewModel(viewModel)
+            return TokenTypeRowCell.heightWithViewModel(viewModel)
         case .DigitCountRow(let viewModel):
-            return SegmentedControlRowCell.heightWithViewModel(viewModel)
+            return DigitCountRowCell.heightWithViewModel(viewModel)
         case .AlgorithmRow(let viewModel):
-            return SegmentedControlRowCell.heightWithViewModel(viewModel)
+            return AlgorithmRowCell.heightWithViewModel(viewModel)
         }
     }
 

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -330,7 +330,7 @@ extension TokenFormViewController: TokenFormPresenter {
     }
 }
 
-extension TokenFormViewController: TextFieldRowCellDelegate {
+extension TokenFormViewController: TextFieldRowCellDelegate, SegmentedControlRowCellDelegate {
     func textFieldCellDidReturn(textFieldCell: TextFieldRowCell) {
         // Unfocus the field that returned
         textFieldCell.unfocus()

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -226,30 +226,25 @@ extension TokenFormViewController {
         case .TextFieldRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(TextFieldRowCell.self)
             cell.updateWithViewModel(viewModel)
+            cell.delegate = self
             return cell
 
         case .TokenTypeRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<TokenTypeRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
-            cell.changeAction = { [weak self] (action) in
-                self?.form?.handleAction(action)
-            }
+            cell.delegate = self
             return cell
 
         case .DigitCountRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<DigitCountRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
-            cell.changeAction = { [weak self] (action) in
-                self?.form?.handleAction(action)
-            }
+            cell.delegate = self
             return cell
 
         case .AlgorithmRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<AlgorithmRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
-            cell.changeAction = { [weak self] (action) in
-                self?.form?.handleAction(action)
-            }
+            cell.delegate = self
             return cell
         }
     }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -225,9 +225,7 @@ extension TokenFormViewController {
         switch rowModel {
         case .TextFieldRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(TextFieldRowCell.self)
-            cell.updateWithViewModel(viewModel, changeAction: { [weak self] in
-                self?.form?.updateField($0, withValue: $1)
-                })
+            cell.updateWithViewModel(viewModel)
             return cell
 
         case .TokenTypeRow(let viewModel):
@@ -263,9 +261,7 @@ extension TokenFormViewController {
         switch rowModel {
         case .TextFieldRow(let viewModel):
             if let cell = cell as? TextFieldRowCell {
-                cell.updateWithViewModel(viewModel, changeAction: { [weak self] in
-                    self?.form?.updateField($0, withValue: $1)
-                    })
+                cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
@@ -346,5 +342,9 @@ extension TokenFormViewController: TextFieldRowCellDelegate {
             // Try to submit the form
             viewModel.doneKeyAction?()
         }
+    }
+
+    func textFieldCellChangedValue(value: String, forField field: Form.Field) {
+        form?.updateField(field, withValue: value)
     }
 }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -231,24 +231,24 @@ extension TokenFormViewController {
         case .TokenTypeRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<TokenTypeRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
-            cell.changeAction = { [weak self] (field, value) in
-                self?.form?.updateField(field, withValue: value)
+            cell.changeAction = { [weak self] (action) in
+                self?.form?.handleAction(action)
             }
             return cell
 
         case .DigitCountRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<DigitCountRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
-            cell.changeAction = { [weak self] (field, value) in
-                self?.form?.updateField(field, withValue: value)
+            cell.changeAction = { [weak self] (action) in
+                self?.form?.handleAction(action)
             }
             return cell
 
         case .AlgorithmRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<AlgorithmRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
-            cell.changeAction = { [weak self] (field, value) in
-                self?.form?.updateField(field, withValue: value)
+            cell.changeAction = { [weak self] (action) in
+                self?.form?.handleAction(action)
             }
             return cell
         }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -353,7 +353,7 @@ extension TokenFormViewController: TextFieldRowCellDelegate {
         }
     }
 
-    func textFieldCellChangedValue(value: String, forField field: Form.Field) {
-        form?.updateField(field, withValue: value)
+    func handleAction(action: Form.Action) {
+        form?.handleAction(action)
     }
 }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -230,19 +230,19 @@ extension TokenFormViewController {
             return cell
 
         case .TokenTypeRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<TokenTypeRowViewModel>.self)
+            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<TokenTypeRowModel>.self)
             cell.updateWithViewModel(viewModel)
             cell.delegate = self
             return cell
 
         case .DigitCountRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<DigitCountRowViewModel>.self)
+            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<DigitCountRowModel>.self)
             cell.updateWithViewModel(viewModel)
             cell.delegate = self
             return cell
 
         case .AlgorithmRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<AlgorithmRowViewModel>.self)
+            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<AlgorithmRowModel>.self)
             cell.updateWithViewModel(viewModel)
             cell.delegate = self
             return cell
@@ -270,19 +270,19 @@ extension TokenFormViewController {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .TokenTypeRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<TokenTypeRowViewModel> {
+            if let cell = cell as? SegmentedControlRowCell<TokenTypeRowModel> {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .DigitCountRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<DigitCountRowViewModel> {
+            if let cell = cell as? SegmentedControlRowCell<DigitCountRowModel> {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .AlgorithmRow(let viewModel):
-            if let cell = cell as? SegmentedControlRowCell<AlgorithmRowViewModel> {
+            if let cell = cell as? SegmentedControlRowCell<AlgorithmRowModel> {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -231,16 +231,25 @@ extension TokenFormViewController {
         case .TokenTypeRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<TokenTypeRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
+            cell.changeAction = { [weak self] (field, value) in
+                self?.form?.updateField(field, withValue: value)
+            }
             return cell
 
         case .DigitCountRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<DigitCountRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
+            cell.changeAction = { [weak self] (field, value) in
+                self?.form?.updateField(field, withValue: value)
+            }
             return cell
 
         case .AlgorithmRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<AlgorithmRowViewModel>.self)
             cell.updateWithViewModel(viewModel)
+            cell.changeAction = { [weak self] (field, value) in
+                self?.form?.updateField(field, withValue: value)
+            }
             return cell
         }
     }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -225,7 +225,9 @@ extension TokenFormViewController {
         switch rowModel {
         case .TextFieldRow(let viewModel):
             let cell = tableView.dequeueReusableCellWithClass(TextFieldRowCell.self)
-            cell.updateWithViewModel(viewModel)
+            cell.updateWithViewModel(viewModel, changeAction: { [weak self] in
+                self?.form?.updateField($0, withValue: $1)
+                })
             return cell
 
         case .TokenTypeRow(let viewModel):
@@ -261,7 +263,9 @@ extension TokenFormViewController {
         switch rowModel {
         case .TextFieldRow(let viewModel):
             if let cell = cell as? TextFieldRowCell {
-                cell.updateWithViewModel(viewModel)
+                cell.updateWithViewModel(viewModel, changeAction: { [weak self] in
+                    self?.form?.updateField($0, withValue: $1)
+                    })
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }


### PR DESCRIPTION
Change the actions on form field row models from side-effect-laden closures which modify the form values directly to closures which generate an `Action` containing the new value, which is routed back to the form via delegate.