### PR TITLE
Form action handler

### DIFF
--- a/Authenticator/Source/AppViewController.swift
+++ b/Authenticator/Source/AppViewController.swift
@@ -87,11 +87,15 @@ extension AppViewController: AppPresenter {
             presentViewController(scannerViewController)
 
         case .EntryForm(let form):
-            let formController = TokenFormViewController(viewModel: form.viewModel, form: form)
+            let formController = TokenFormViewController(viewModel: form.viewModel,
+                actionHandler: form)
+            form.presenter = formController
             presentViewController(formController)
 
         case .EditForm(let form):
-            let editController = TokenFormViewController(viewModel: form.viewModel, form: form)
+            let editController = TokenFormViewController(viewModel: form.viewModel,
+                actionHandler: form)
+            form.presenter = editController
             presentViewController(editController)
         }
     }

--- a/Authenticator/Source/AppViewController.swift
+++ b/Authenticator/Source/AppViewController.swift
@@ -87,11 +87,11 @@ extension AppViewController: AppPresenter {
             presentViewController(scannerViewController)
 
         case .EntryForm(let form):
-            let formController = TokenFormViewController(form: form)
+            let formController = TokenFormViewController(viewModel: form.viewModel, form: form)
             presentViewController(formController)
 
         case .EditForm(let form):
-            let editController = TokenFormViewController(form: form)
+            let editController = TokenFormViewController(viewModel: form.viewModel, form: form)
             presentViewController(editController)
         }
     }

--- a/Authenticator/Source/TableViewModel.swift
+++ b/Authenticator/Source/TableViewModel.swift
@@ -82,7 +82,3 @@ extension TableViewModel {
         return sections[section].header
     }
 }
-
-func EmptyTableViewModel<T>() -> TableViewModel<T> {
-    return TableViewModel(title: "", sections: [])
-}

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -22,9 +22,12 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-protocol TokenForm {
+protocol TokenForm: FormActionHandler {
     var viewModel: TableViewModel<Form> { get }
     weak var presenter: TokenFormPresenter? { get set }
+}
+
+protocol FormActionHandler: class {
     func handleAction(action: Form.Action)
 }
 

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -31,7 +31,7 @@ typealias AlgorithmRowCell = SegmentedControlRowCell<AlgorithmRowModel>
 
 class TokenFormViewController: UITableViewController {
     private weak var actionHandler: FormActionHandler?
-    private var viewModel: TableViewModel<Form> = EmptyTableViewModel() {
+    private var viewModel: TableViewModel<Form> {
         didSet {
             guard oldValue.sections.count == viewModel.sections.count else {
                 // Automatic updates aren't implemented for changing number of sections
@@ -72,7 +72,7 @@ class TokenFormViewController: UITableViewController {
     }
 
     required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
+        fatalError("init(coder:) has not been implemented")
     }
 
     // MARK: - View Lifecycle

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -65,12 +65,12 @@ class TokenFormViewController: UITableViewController {
         }
     }
 
-    init(form: TokenForm) {
+    init(viewModel: TableViewModel<Form>, form: TokenForm) {
+        self.viewModel = viewModel
         super.init(style: .Grouped)
         let presentedForm = form
         presentedForm.presenter = self
         self.actionHandler = presentedForm
-        viewModel = presentedForm.viewModel
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -65,12 +65,10 @@ class TokenFormViewController: UITableViewController {
         }
     }
 
-    init(viewModel: TableViewModel<Form>, form: TokenForm) {
+    init(viewModel: TableViewModel<Form>, actionHandler: FormActionHandler) {
         self.viewModel = viewModel
+        self.actionHandler = actionHandler
         super.init(style: .Grouped)
-        let presentedForm = form
-        presentedForm.presenter = self
-        self.actionHandler = presentedForm
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -30,7 +30,7 @@ typealias DigitCountRowCell = SegmentedControlRowCell<DigitCountRowModel>
 typealias AlgorithmRowCell = SegmentedControlRowCell<AlgorithmRowModel>
 
 class TokenFormViewController: UITableViewController {
-    private var form: TokenForm?
+    private weak var actionHandler: FormActionHandler?
     private var viewModel: TableViewModel<Form> = EmptyTableViewModel() {
         didSet {
             guard oldValue.sections.count == viewModel.sections.count else {
@@ -67,9 +67,9 @@ class TokenFormViewController: UITableViewController {
 
     init(form: TokenForm) {
         super.init(style: .Grouped)
-        var presentedForm = form
+        let presentedForm = form
         presentedForm.presenter = self
-        self.form = presentedForm
+        self.actionHandler = presentedForm
         viewModel = presentedForm.viewModel
     }
 
@@ -353,6 +353,6 @@ extension TokenFormViewController: TextFieldRowCellDelegate, SegmentedControlRow
     }
 
     func handleAction(action: Form.Action) {
-        form?.handleAction(action)
+        actionHandler?.handleAction(action)
     }
 }


### PR DESCRIPTION
Remove the `TokenFormViewController`'s reference to the `TokenForm`. Instead, initialize the view controller with an initial view model and a `FormActionHandler`.