### PR TITLE
Form routing

### DIFF
--- a/Authenticator/Source/ActionHandler.swift
+++ b/Authenticator/Source/ActionHandler.swift
@@ -36,6 +36,9 @@ enum AppAction {
     case SaveChanges(Token, PersistentToken)
 
     case AddTokenFromURL(Token)
+
+    case TokenEntryFormAction(Form.Action)
+    case TokenEditFormAction(Form.Action)
 }
 
 protocol ActionHandler: class {

--- a/Authenticator/Source/AppModel.swift
+++ b/Authenticator/Source/AppModel.swift
@@ -102,6 +102,16 @@ extension AppModel: ActionHandler {
 
         case .AddTokenFromURL(let token):
             tokenList.addToken(token)
+
+        case .TokenEntryFormAction(let action):
+            if case .EntryForm(let form) = modalState {
+                form.handleAction(action)
+            }
+
+        case .TokenEditFormAction(let action):
+            if case .EditForm(let form) = modalState {
+                form.handleAction(action)
+            }
         }
     }
 }

--- a/Authenticator/Source/AppModel.swift
+++ b/Authenticator/Source/AppModel.swift
@@ -57,9 +57,9 @@ class AppModel {
         case .EntryScanner:
             modal = .Scanner
         case .EntryForm(let form):
-            modal = .EntryForm(form)
+            modal = .EntryForm(form.viewModel)
         case .EditForm(let form):
-            modal = .EditForm(form)
+            modal = .EditForm(form.viewModel)
         }
         return AppViewModel(
             tokenList: tokenList,
@@ -80,6 +80,7 @@ extension AppModel: ActionHandler {
 
         case .BeginManualTokenEntry:
             let form = TokenEntryForm(actionHandler: self)
+            form.presenter = self
             modalState = .EntryForm(form)
 
         case .SaveNewToken(let token):
@@ -91,6 +92,7 @@ extension AppModel: ActionHandler {
 
         case .BeginTokenEdit(let persistentToken):
             let form = TokenEditForm(persistentToken: persistentToken, actionHandler: self)
+            form.presenter = self
             modalState = .EditForm(form)
 
         case let .SaveChanges(token, persistentToken):
@@ -113,5 +115,11 @@ extension AppModel: ActionHandler {
                 form.handleAction(action)
             }
         }
+    }
+}
+
+extension AppModel: TokenFormPresenter {
+    func updateWithViewModel(viewModel: TableViewModel<Form>) {
+        presenter?.updateWithViewModel(self.viewModel)
     }
 }

--- a/Authenticator/Source/AppViewController.swift
+++ b/Authenticator/Source/AppViewController.swift
@@ -124,11 +124,11 @@ extension AppViewController: AppPresenter {
 }
 
 class FormActionMapper: FormActionHandler {
-    let actionHandler: ActionHandler
-    let transform: (Form.Action) -> AppAction
+    private weak var actionHandler: ActionHandler?
+    private let transform: (Form.Action) -> AppAction
 
     func handleAction(action: Form.Action) {
-        actionHandler.handleAction(transform(action))
+        actionHandler?.handleAction(transform(action))
     }
 
     init(actionHandler: ActionHandler, transform: (Form.Action) -> AppAction) {

--- a/Authenticator/Source/AppViewController.swift
+++ b/Authenticator/Source/AppViewController.swift
@@ -34,6 +34,8 @@ class OpaqueNavigationController: UINavigationController {
 }
 
 class AppViewController: OpaqueNavigationController {
+    private var currentViewModel: AppViewModel
+
     private var tokenListViewController: TokenListViewController
     private var modalNavController: UINavigationController?
     private weak var actionHandler: ActionHandler?
@@ -41,6 +43,7 @@ class AppViewController: OpaqueNavigationController {
     private let editFormActionHandler: FormActionMapper
 
     init(viewModel: AppViewModel, actionHandler: ActionHandler) {
+        self.currentViewModel = viewModel
         self.actionHandler = actionHandler
         let tokenList = viewModel.tokenList
         tokenListViewController = TokenListViewController(viewModel: tokenList.viewModel,
@@ -96,18 +99,27 @@ extension AppViewController: AppPresenter {
             let scannerViewController = TokenScannerViewController(actionHandler: self)
             presentViewController(scannerViewController)
 
-        case .EntryForm(let form):
-            let formController = TokenFormViewController(viewModel: form.viewModel,
-                actionHandler: entryFormActionHandler)
-            form.presenter = formController
-            presentViewController(formController)
+        case .EntryForm(let formViewModel):
+            if case .EntryForm = currentViewModel.modal,
+                let editController = modalNavController?.topViewController as? TokenFormViewController {
+                editController.updateWithViewModel(formViewModel)
+            } else {
+                let formController = TokenFormViewController(viewModel: formViewModel,
+                    actionHandler: entryFormActionHandler)
+                presentViewController(formController)
+            }
 
-        case .EditForm(let form):
-            let editController = TokenFormViewController(viewModel: form.viewModel,
-                actionHandler: editFormActionHandler)
-            form.presenter = editController
-            presentViewController(editController)
+        case .EditForm(let formViewModel):
+            if case .EditForm = currentViewModel.modal,
+                let editController = modalNavController?.topViewController as? TokenFormViewController {
+                editController.updateWithViewModel(formViewModel)
+            } else {
+                let editController = TokenFormViewController(viewModel: formViewModel,
+                    actionHandler: editFormActionHandler)
+                presentViewController(editController)
+            }
         }
+        currentViewModel = viewModel
     }
 }
 

--- a/Authenticator/Source/AppViewModel.swift
+++ b/Authenticator/Source/AppViewModel.swift
@@ -30,8 +30,8 @@ struct AppViewModel {
     enum Modal {
         case None
         case Scanner
-        case EntryForm(TokenEntryForm)
-        case EditForm(TokenEditForm)
+        case EntryForm(TableViewModel<Form>)
+        case EditForm(TableViewModel<Form>)
     }
 }
 

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -22,7 +22,7 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-protocol TokenForm: FormActionHandler {
+protocol TokenForm {
     var viewModel: TableViewModel<Form> { get }
     weak var presenter: TokenFormPresenter? { get set }
 }


### PR DESCRIPTION
Route form view models from the component to the view controller via the `AppViewModel`, and route form actions from the view controller to the component via `AppAction` handling.
The goal of this change is to decouple `TokenForm` and `TokenFormViewController` by having that top-level component/view mediate between them.