### PR TITLE
Table view model actions

### DIFF
--- a/Authenticator/Source/BarButtonViewModel.swift
+++ b/Authenticator/Source/BarButtonViewModel.swift
@@ -29,12 +29,12 @@ enum BarButtonStyle {
 
 struct BarButtonViewModel<Action> {
     let style: BarButtonStyle
-    let enabled: Bool
     let action: Action
+    let enabled: Bool
 
-    init(style: BarButtonStyle, enabled: Bool = true, action: Action) {
+    init(style: BarButtonStyle, action: Action, enabled: Bool = true) {
         self.style = style
-        self.enabled = enabled
         self.action = action
+        self.enabled = enabled
     }
 }

--- a/Authenticator/Source/BarButtonViewModel.swift
+++ b/Authenticator/Source/BarButtonViewModel.swift
@@ -22,17 +22,17 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-struct BarButtonViewModel {
-    enum Style {
-        case Done
-        case Cancel
-    }
+enum BarButtonStyle {
+    case Done
+    case Cancel
+}
 
-    let style: Style
+struct BarButtonViewModel<Action> {
+    let style: BarButtonStyle
     let enabled: Bool
-    let action: () -> ()
+    let action: Action
 
-    init(style: Style, enabled: Bool = true, action: () -> ()) {
+    init(style: BarButtonStyle, enabled: Bool = true, action: Action) {
         self.style = style
         self.enabled = enabled
         self.action = action

--- a/Authenticator/Source/ButtonHeaderView.swift
+++ b/Authenticator/Source/ButtonHeaderView.swift
@@ -24,20 +24,21 @@
 
 import UIKit
 
-struct ButtonHeaderViewModel {
+struct ButtonHeaderViewModel<Action> {
     let title: String
-    let action: (() -> ())?
+    let action: Action?
 
-    init(title: String, action: (() -> ())? = nil) {
+    init(title: String, action: Action? = nil) {
         self.title = title
         self.action = action
     }
 }
 
-class ButtonHeaderView: UIButton {
-    private static let preferredHeight: CGFloat = 54
+private let preferredHeight: CGFloat = 54
 
-    private var buttonAction: (() -> ())?
+class ButtonHeaderView<Action>: UIButton {
+    private var buttonAction: Action?
+    private var actionHandler: ((Action) -> ())?
 
     // MARK: - Init
 
@@ -63,23 +64,26 @@ class ButtonHeaderView: UIButton {
 
     // MARK: - View Model
 
-    convenience init(viewModel: ButtonHeaderViewModel) {
+    convenience init(viewModel: ButtonHeaderViewModel<Action>, actionHandler: (Action) -> ()) {
         self.init()
+        self.actionHandler = actionHandler
         updateWithViewModel(viewModel)
     }
 
-    func updateWithViewModel(viewModel: ButtonHeaderViewModel) {
+    func updateWithViewModel(viewModel: ButtonHeaderViewModel<Action>) {
         setTitle(viewModel.title, forState: .Normal)
         buttonAction = viewModel.action
     }
 
-    static func heightWithViewModel(viewModel: ButtonHeaderViewModel) -> CGFloat {
+    static func heightWithViewModel(viewModel: ButtonHeaderViewModel<Action>) -> CGFloat {
         return preferredHeight
     }
 
     // MARK: - Target Action
 
     func buttonWasPressed() {
-        buttonAction?()
+        if let action = buttonAction {
+            actionHandler?(action)
+        }
     }
 }

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -57,6 +57,7 @@ enum Form: TableViewModelFamily {
         case DigitCount(Int)
         case Algorithm(Generator.Algorithm)
 
+        case Cancel
         case Submit
     }
 }

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -26,7 +26,7 @@ import OneTimePassword
 
 enum Form: TableViewModelFamily {
     enum HeaderModel {
-        case ButtonHeader(ButtonHeaderViewModel)
+        case ButtonHeader(ButtonHeaderViewModel<Action>)
     }
 
     enum RowModel: Identifiable {
@@ -57,6 +57,7 @@ enum Form: TableViewModelFamily {
         case DigitCount(Int)
         case Algorithm(Generator.Algorithm)
 
+        case ShowAdvancedOptions
         case Cancel
         case Submit
     }

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -56,5 +56,7 @@ enum Form: TableViewModelFamily {
         case TokenType(Authenticator.TokenType)
         case DigitCount(Int)
         case Algorithm(Generator.Algorithm)
+
+        case Submit
     }
 }

--- a/Authenticator/Source/TableViewModel.swift
+++ b/Authenticator/Source/TableViewModel.swift
@@ -27,6 +27,7 @@ import Foundation
 protocol TableViewModelFamily {
     typealias HeaderModel
     typealias RowModel
+    typealias Action
 }
 
 struct TableViewModel<Models: TableViewModelFamily> {
@@ -34,14 +35,14 @@ struct TableViewModel<Models: TableViewModelFamily> {
     var leftBarButton: BarButtonViewModel?
     var rightBarButton: BarButtonViewModel?
     var sections: [Section<Models.HeaderModel, Models.RowModel>]
-    var doneKeyAction: (() -> ())?
+    var doneKeyAction: Models.Action
     var errorMessage: String?
 
     init(title: String,
         leftBarButton: BarButtonViewModel? = nil,
         rightBarButton: BarButtonViewModel? = nil,
         sections: [Section<Models.HeaderModel, Models.RowModel>],
-        doneKeyAction: (() -> ())? = nil,
+        doneKeyAction: Models.Action,
         errorMessage: String? = nil) {
             self.title = title
             self.leftBarButton = leftBarButton

--- a/Authenticator/Source/TableViewModel.swift
+++ b/Authenticator/Source/TableViewModel.swift
@@ -32,15 +32,15 @@ protocol TableViewModelFamily {
 
 struct TableViewModel<Models: TableViewModelFamily> {
     var title: String
-    var leftBarButton: BarButtonViewModel?
-    var rightBarButton: BarButtonViewModel?
+    var leftBarButton: BarButtonViewModel<Models.Action>?
+    var rightBarButton: BarButtonViewModel<Models.Action>?
     var sections: [Section<Models.HeaderModel, Models.RowModel>]
     var doneKeyAction: Models.Action
     var errorMessage: String?
 
     init(title: String,
-        leftBarButton: BarButtonViewModel? = nil,
-        rightBarButton: BarButtonViewModel? = nil,
+        leftBarButton: BarButtonViewModel<Models.Action>? = nil,
+        rightBarButton: BarButtonViewModel<Models.Action>? = nil,
         sections: [Section<Models.HeaderModel, Models.RowModel>],
         doneKeyAction: Models.Action,
         errorMessage: String? = nil) {

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -103,6 +103,8 @@ class TokenEditForm: TokenForm {
             fatalError()
         case .Algorithm:
             fatalError()
+        case .ShowAdvancedOptions:
+            fatalError()
         case .Cancel:
             cancel()
         case .Submit:

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -70,9 +70,7 @@ class TokenEditForm: TokenForm {
                     nameRowModel,
                 ]
             ],
-            doneKeyAction: { [weak self] in
-                self?.submit()
-            }
+            doneKeyAction: .Submit
         )
     }
 
@@ -101,8 +99,16 @@ class TokenEditForm: TokenForm {
             state.issuer = value
         case .Name(let value):
             state.name = value
-        default:
+        case .Secret:
             fatalError()
+        case .TokenType:
+            fatalError()
+        case .DigitCount:
+            fatalError()
+        case .Algorithm:
+            fatalError()
+        case .Submit:
+            self.submit()
         }
     }
 

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -59,7 +59,7 @@ class TokenEditForm: TokenForm {
         return TableViewModel(
             title: "Edit Token",
             leftBarButton: BarButtonViewModel(style: .Cancel, action: .Cancel),
-            rightBarButton: BarButtonViewModel(style: .Done, enabled: state.isValid, action: .Submit),
+            rightBarButton: BarButtonViewModel(style: .Done, action: .Submit, enabled: state.isValid),
             sections: [
                 [
                     issuerRowModel,

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -58,12 +58,8 @@ class TokenEditForm: TokenForm {
     var viewModel: TableViewModel<Form> {
         return TableViewModel(
             title: "Edit Token",
-            leftBarButton: BarButtonViewModel(style: .Cancel) { [weak self] in
-                self?.cancel()
-            },
-            rightBarButton: BarButtonViewModel(style: .Done, enabled: state.isValid) { [weak self] in
-                self?.submit()
-            },
+            leftBarButton: BarButtonViewModel(style: .Cancel, action: .Cancel),
+            rightBarButton: BarButtonViewModel(style: .Done, enabled: state.isValid, action: .Submit),
             sections: [
                 [
                     issuerRowModel,
@@ -107,8 +103,10 @@ class TokenEditForm: TokenForm {
             fatalError()
         case .Algorithm:
             fatalError()
+        case .Cancel:
+            cancel()
         case .Submit:
-            self.submit()
+            submit()
         }
     }
 
@@ -121,11 +119,11 @@ class TokenEditForm: TokenForm {
 
     // MARK: Actions
 
-    func cancel() {
+    private func cancel() {
         actionHandler?.handleAction(.CancelTokenEdit)
     }
 
-    func submit() {
+    private func submit() {
         guard state.isValid else { return }
 
         let token = Token(

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -109,10 +109,10 @@ extension TokenEntryForm {
     }
 
     private var advancedSectionHeader: Form.HeaderModel {
-        let model = ButtonHeaderViewModel(title: "Advanced Options") { [weak self] in
-            self?.state.showsAdvancedOptions = true
-            // TODO: Scroll to the newly-expanded section
-        }
+        let model = ButtonHeaderViewModel(
+            title: "Advanced Options",
+            action: Form.Action.ShowAdvancedOptions
+        )
         return .ButtonHeader(model)
     }
 
@@ -181,6 +181,8 @@ extension TokenEntryForm {
             state.digitCount = value
         case .Algorithm(let value):
             state.algorithm = value
+        case .ShowAdvancedOptions:
+            showAdvancedOptions()
         case .Cancel:
             cancel()
         case .Submit:
@@ -192,6 +194,11 @@ extension TokenEntryForm {
 // MARK: Actions
 
 private extension TokenEntryForm {
+    func showAdvancedOptions() {
+        state.showsAdvancedOptions = true
+        // TODO: Scroll to the newly-expanded section
+    }
+
     func cancel() {
         actionHandler?.handleAction(.CancelTokenEntry)
     }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -85,12 +85,8 @@ extension TokenEntryForm {
     var viewModel: TableViewModel<Form> {
         return TableViewModel(
             title: "Add Token",
-            leftBarButton: BarButtonViewModel(style: .Cancel) { [weak self] in
-                self?.cancel()
-            },
-            rightBarButton: BarButtonViewModel(style: .Done, enabled: state.isValid) { [weak self] in
-                self?.submit()
-            },
+            leftBarButton: BarButtonViewModel(style: .Cancel, action: .Cancel),
+            rightBarButton: BarButtonViewModel(style: .Done, enabled: state.isValid, action: .Submit),
             sections: [
                 [
                     issuerRowModel,
@@ -185,8 +181,10 @@ extension TokenEntryForm {
             state.digitCount = value
         case .Algorithm(let value):
             state.algorithm = value
+        case .Cancel:
+            cancel()
         case .Submit:
-            self.submit()
+            submit()
         }
     }
 }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -107,9 +107,7 @@ extension TokenEntryForm {
                         ]
                 ),
             ],
-            doneKeyAction: { [weak self] in
-                self?.submit()
-            },
+            doneKeyAction: .Submit,
             errorMessage: state.submitFailed ? "Invalid Token" : nil
         )
     }
@@ -187,6 +185,8 @@ extension TokenEntryForm {
             state.digitCount = value
         case .Algorithm(let value):
             state.algorithm = value
+        case .Submit:
+            self.submit()
         }
     }
 }

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -86,7 +86,7 @@ extension TokenEntryForm {
         return TableViewModel(
             title: "Add Token",
             leftBarButton: BarButtonViewModel(style: .Cancel, action: .Cancel),
-            rightBarButton: BarButtonViewModel(style: .Done, enabled: state.isValid, action: .Submit),
+            rightBarButton: BarButtonViewModel(style: .Done, action: .Submit, enabled: state.isValid),
             sections: [
                 [
                     issuerRowModel,

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -130,11 +130,15 @@ class TokenFormViewController: UITableViewController {
     // MARK: - Target Actions
 
     func leftBarButtonAction() {
-        viewModel.leftBarButton?.action()
+        if let action = viewModel.leftBarButton?.action {
+            actionHandler?.handleAction(action)
+        }
     }
 
     func rightBarButtonAction() {
-        viewModel.rightBarButton?.action()
+        if let action = viewModel.rightBarButton?.action {
+            actionHandler?.handleAction(action)
+        }
     }
 
     // MARK: - UITableViewDataSource
@@ -195,8 +199,8 @@ class TokenFormViewController: UITableViewController {
 extension TokenFormViewController {
     // MARK: Bar Button View Model
 
-    private func barButtomItemForViewModel(viewModel: BarButtonViewModel, target: AnyObject?, action: Selector) -> UIBarButtonItem {
-        func systemItemForStyle(style: BarButtonViewModel.Style) -> UIBarButtonSystemItem {
+    private func barButtomItemForViewModel(viewModel: BarButtonViewModel<Form.Action>, target: AnyObject?, action: Selector) -> UIBarButtonItem {
+        func systemItemForStyle(style: BarButtonStyle) -> UIBarButtonSystemItem {
             switch style {
             case .Done: return .Done
             case .Cancel: return .Cancel

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -346,7 +346,7 @@ extension TokenFormViewController: TextFieldRowCellDelegate, SegmentedControlRow
             }
         } else if textFieldCell.textField.returnKeyType == .Done {
             // Try to submit the form
-            viewModel.doneKeyAction?()
+            actionHandler?.handleAction(viewModel.doneKeyAction)
         }
     }
 

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -314,7 +314,9 @@ extension TokenFormViewController {
     func viewForHeaderModel(headerModel: Form.HeaderModel) -> UIView {
         switch headerModel {
         case .ButtonHeader(let viewModel):
-            return ButtonHeaderView(viewModel: viewModel)
+            return ButtonHeaderView(viewModel: viewModel) { [weak actionHandler] in
+                actionHandler?.handleAction($0)
+            }
         }
     }
 


### PR DESCRIPTION
Convert the action attributes of `TableViewModel`, `BarButtonViewModel`,  and `ButtonHeaderViewModel` from closures to `Form.Action`s. These declarative actions follow the same routing as the token forms' field actions, and avoid using opaque closures with side effects and direct references to the form state.