### PR TITLE
Form Structs

### DIFF
--- a/Authenticator/Source/AppModel.swift
+++ b/Authenticator/Source/AppModel.swift
@@ -91,8 +91,7 @@ extension AppModel: ActionHandler {
             modalState = .None
 
         case .BeginTokenEdit(let persistentToken):
-            var form = TokenEditForm(persistentToken: persistentToken)
-            form.presenter = self
+            let form = TokenEditForm(persistentToken: persistentToken)
             modalState = .EditForm(form)
 
         case let .SaveChanges(token, persistentToken):

--- a/Authenticator/Source/AppModel.swift
+++ b/Authenticator/Source/AppModel.swift
@@ -105,7 +105,10 @@ extension AppModel: ActionHandler {
 
         case .TokenEntryFormAction(let action):
             if case .EntryForm(let form) = modalState {
-                let resultingAppAction = form.handleAction(action)
+                var newForm = form
+                let resultingAppAction = newForm.handleAction(action)
+                modalState = .EntryForm(newForm)
+                // Handle the resulting action after committing the changes of the initial action
                 if let resultingAppAction = resultingAppAction {
                     handleAction(resultingAppAction)
                 }
@@ -116,6 +119,7 @@ extension AppModel: ActionHandler {
                 var newForm = form
                 let resultingAppAction = newForm.handleAction(action)
                 modalState = .EditForm(newForm)
+                // Handle the resulting action after committing the changes of the initial action
                 if let resultingAppAction = resultingAppAction {
                     handleAction(resultingAppAction)
                 }

--- a/Authenticator/Source/AppModel.swift
+++ b/Authenticator/Source/AppModel.swift
@@ -79,7 +79,7 @@ extension AppModel: ActionHandler {
             modalState = .EntryScanner
 
         case .BeginManualTokenEntry:
-            let form = TokenEntryForm(actionHandler: self)
+            let form = TokenEntryForm()
             form.presenter = self
             modalState = .EntryForm(form)
 
@@ -106,7 +106,10 @@ extension AppModel: ActionHandler {
 
         case .TokenEntryFormAction(let action):
             if case .EntryForm(let form) = modalState {
-                form.handleAction(action)
+                let resultingAppAction = form.handleAction(action)
+                if let resultingAppAction = resultingAppAction {
+                    handleAction(resultingAppAction)
+                }
             }
 
         case .TokenEditFormAction(let action):

--- a/Authenticator/Source/AppModel.swift
+++ b/Authenticator/Source/AppModel.swift
@@ -91,7 +91,7 @@ extension AppModel: ActionHandler {
             modalState = .None
 
         case .BeginTokenEdit(let persistentToken):
-            let form = TokenEditForm(persistentToken: persistentToken, actionHandler: self)
+            var form = TokenEditForm(persistentToken: persistentToken)
             form.presenter = self
             modalState = .EditForm(form)
 
@@ -112,7 +112,12 @@ extension AppModel: ActionHandler {
 
         case .TokenEditFormAction(let action):
             if case .EditForm(let form) = modalState {
-                form.handleAction(action)
+                var newForm = form
+                let resultingAppAction = newForm.handleAction(action)
+                modalState = .EditForm(newForm)
+                if let resultingAppAction = resultingAppAction {
+                    handleAction(resultingAppAction)
+                }
             }
         }
     }

--- a/Authenticator/Source/AppModel.swift
+++ b/Authenticator/Source/AppModel.swift
@@ -80,7 +80,6 @@ extension AppModel: ActionHandler {
 
         case .BeginManualTokenEntry:
             let form = TokenEntryForm()
-            form.presenter = self
             modalState = .EntryForm(form)
 
         case .SaveNewToken(let token):
@@ -122,11 +121,5 @@ extension AppModel: ActionHandler {
                 }
             }
         }
-    }
-}
-
-extension AppModel: TokenFormPresenter {
-    func updateWithViewModel(viewModel: TableViewModel<Form>) {
-        presenter?.updateWithViewModel(self.viewModel)
     }
 }

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -115,10 +115,12 @@ struct TokenEditForm {
 
     // MARK: Actions
 
+    @warn_unused_result
     private func cancel() -> AppAction {
         return .CancelTokenEdit
     }
 
+    @warn_unused_result
     private func submit() -> AppAction? {
         guard state.isValid else {
             // TODO: Show error message?

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -24,9 +24,8 @@
 
 import OneTimePassword
 
-class TokenEditForm: TokenForm {
+struct TokenEditForm: TokenForm {
     weak var presenter: TokenFormPresenter?
-    private weak var actionHandler: ActionHandler?
 
     // MARK: State
 
@@ -89,7 +88,8 @@ class TokenEditForm: TokenForm {
 
     // MARK: Action handling
 
-    func handleAction(action: Form.Action) {
+    @warn_unused_result
+    mutating func handleAction(action: Form.Action) -> AppAction? {
         switch action {
         case .Issuer(let value):
             state.issuer = value
@@ -106,33 +106,36 @@ class TokenEditForm: TokenForm {
         case .ShowAdvancedOptions:
             fatalError()
         case .Cancel:
-            cancel()
+            return cancel()
         case .Submit:
-            submit()
+            return submit()
         }
+        return nil
     }
 
     // MARK: Initialization
 
-    init(persistentToken: PersistentToken, actionHandler: ActionHandler) {
+    init(persistentToken: PersistentToken) {
         state = State(persistentToken: persistentToken)
-        self.actionHandler = actionHandler
     }
 
     // MARK: Actions
 
-    private func cancel() {
-        actionHandler?.handleAction(.CancelTokenEdit)
+    private func cancel() -> AppAction {
+        return .CancelTokenEdit
     }
 
-    private func submit() {
-        guard state.isValid else { return }
+    private func submit() -> AppAction? {
+        guard state.isValid else {
+            // TODO: Show error message?
+            return nil
+        }
 
         let token = Token(
             name: state.name,
             issuer: state.issuer,
             generator: state.persistentToken.token.generator
         )
-        actionHandler?.handleAction(.SaveChanges(token, state.persistentToken))
+        return .SaveChanges(token, state.persistentToken)
     }
 }

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -24,10 +24,10 @@
 
 import OneTimePassword
 
-struct TokenEditForm: TokenForm {
-    weak var presenter: TokenFormPresenter?
-
+struct TokenEditForm {
     // MARK: State
+
+    private var state: State
 
     private struct State {
         let persistentToken: PersistentToken
@@ -43,12 +43,6 @@ struct TokenEditForm: TokenForm {
             self.persistentToken = persistentToken
             issuer = persistentToken.token.issuer
             name = persistentToken.token.name
-        }
-    }
-
-    private var state: State {
-        didSet {
-            presenter?.updateWithViewModel(viewModel)
         }
     }
 

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -29,7 +29,7 @@ import OneTimePassword
 private let defaultTimerFactor = Generator.Factor.Timer(period: 30)
 private let defaultCounterFactor = Generator.Factor.Counter(0)
 
-class TokenEntryForm {
+struct TokenEntryForm {
     // MARK: State
 
     private var state: State
@@ -158,7 +158,7 @@ extension TokenEntryForm {
 
     // MARK: Action handling
     @warn_unused_result
-    func handleAction(action: Form.Action) -> AppAction? {
+    mutating func handleAction(action: Form.Action) -> AppAction? {
         switch action {
         case .Issuer(let value):
             state.issuer = value
@@ -186,18 +186,18 @@ extension TokenEntryForm {
 // MARK: Actions
 
 private extension TokenEntryForm {
-    func showAdvancedOptions() {
+    mutating func showAdvancedOptions() {
         state.showsAdvancedOptions = true
         // TODO: Scroll to the newly-expanded section
     }
 
     @warn_unused_result
-    func cancel() -> AppAction {
+    mutating func cancel() -> AppAction {
         return .CancelTokenEntry
     }
 
     @warn_unused_result
-    func submit() -> AppAction? {
+    mutating func submit() -> AppAction? {
         if !state.isValid {
             // TODO: Show error message?
             return nil

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -159,6 +159,7 @@ extension TokenEntryForm {
     // MARK: Action handling
     @warn_unused_result
     mutating func handleAction(action: Form.Action) -> AppAction? {
+        state.resetEphemera()
         switch action {
         case .Issuer(let value):
             state.issuer = value

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -29,10 +29,10 @@ import OneTimePassword
 private let defaultTimerFactor = Generator.Factor.Timer(period: 30)
 private let defaultCounterFactor = Generator.Factor.Counter(0)
 
-class TokenEntryForm: TokenForm {
-    weak var presenter: TokenFormPresenter?
-
+class TokenEntryForm {
     // MARK: State
+
+    private var state: State
 
     private struct State {
         var issuer: String
@@ -51,13 +51,6 @@ class TokenEntryForm: TokenForm {
 
         mutating func resetEphemera() {
             submitFailed = false
-        }
-    }
-
-    private var state: State {
-        didSet {
-            presenter?.updateWithViewModel(viewModel)
-            state.resetEphemera()
         }
     }
 

--- a/Authenticator/Source/TokenForm.swift
+++ b/Authenticator/Source/TokenForm.swift
@@ -22,15 +22,6 @@
 //  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-protocol TokenForm {
-    var viewModel: TableViewModel<Form> { get }
-    weak var presenter: TokenFormPresenter? { get set }
-}
-
 protocol FormActionHandler: class {
     func handleAction(action: Form.Action)
-}
-
-protocol TokenFormPresenter: class {
-    func updateWithViewModel(viewModel: TableViewModel<Form>)
 }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -328,7 +328,7 @@ extension TokenFormViewController {
     }
 }
 
-extension TokenFormViewController: TokenFormPresenter {
+extension TokenFormViewController {
     func updateWithViewModel(viewModel: TableViewModel<Form>) {
         self.viewModel = viewModel
         updateBarButtonItems()


### PR DESCRIPTION
Convert `TokenEntryForm` and `TokenEditForm` to `struct`s.
The forms' `presenter`s are removed, and the `AppModel` is responsible for handling updated view models when form state changes. The forms' `actionHandler`s are removed, and `AppAction`s resulting from form actions are routed via the return value of the form's `handleAction(_:)`.