### PR TITLE
Segmented control rows

### DIFF
--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -31,9 +31,9 @@ enum Form: TableViewModelFamily {
 
     enum RowModel: Identifiable {
         case TextFieldRow(TextFieldRowModel)
-        case TokenTypeRow(TokenTypeRowModel<Form.Action>)
-        case DigitCountRow(DigitCountRowModel<Form.Action>)
-        case AlgorithmRow(AlgorithmRowModel<Form.Action>)
+        case TokenTypeRow(TokenTypeRowModel<Action>)
+        case DigitCountRow(DigitCountRowModel<Action>)
+        case AlgorithmRow(AlgorithmRowModel<Action>)
 
         func hasSameIdentity(other: RowModel) -> Bool {
             // As currently used, form rows don't move around much, so comparing the row

--- a/Authenticator/Source/FormModels.swift
+++ b/Authenticator/Source/FormModels.swift
@@ -31,9 +31,9 @@ enum Form: TableViewModelFamily {
 
     enum RowModel: Identifiable {
         case TextFieldRow(TextFieldRowModel)
-        case TokenTypeRow(TokenTypeRowModel)
-        case DigitCountRow(DigitCountRowModel)
-        case AlgorithmRow(AlgorithmRowModel)
+        case TokenTypeRow(TokenTypeRowModel<Form.Action>)
+        case DigitCountRow(DigitCountRowModel<Form.Action>)
+        case AlgorithmRow(AlgorithmRowModel<Form.Action>)
 
         func hasSameIdentity(other: RowModel) -> Bool {
             // As currently used, form rows don't move around much, so comparing the row

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -32,12 +32,7 @@ class SegmentedControlRowCell<Value: Equatable, Action>: UITableViewCell {
     var dispatchAction: ((Action) -> ())?
 
     private let segmentedControl = UISegmentedControl()
-    private var values: [Value] = []
-    private var changeAction: ((Value) -> Action)?
-
-    var value: Value {
-        return values[segmentedControl.selectedSegmentIndex]
-    }
+    private var actions: [Action] = []
 
     // MARK: - Init
 
@@ -65,8 +60,7 @@ class SegmentedControlRowCell<Value: Equatable, Action>: UITableViewCell {
 
     // MARK: - View Model
 
-    func updateWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value, ViewModel.Action == Action>(viewModel: ViewModel) {
-        changeAction = viewModel.changeAction
+    func updateWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Action == Action>(viewModel: ViewModel) {
         // Remove any old segments
         segmentedControl.removeAllSegments()
         // Add new segments
@@ -74,21 +68,20 @@ class SegmentedControlRowCell<Value: Equatable, Action>: UITableViewCell {
             let segment = viewModel.segments[i]
             segmentedControl.insertSegmentWithTitle(segment.title, atIndex: i, animated: false)
         }
-        // Store values
-        values = viewModel.segments.map { $0.value }
-        // Select the initial value
-        segmentedControl.selectedSegmentIndex = values.indexOf(viewModel.value) ?? 0
+        // Store the action associated with each segment
+        actions = viewModel.segments.map({ $0.action })
+        // Select the initial segment
+        segmentedControl.selectedSegmentIndex = viewModel.selectedSegmentIndex ?? UISegmentedControlNoSegment
     }
 
-    static func heightWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value, ViewModel.Action == Action>(viewModel: ViewModel) -> CGFloat {
+    static func heightWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Action == Action>(viewModel: ViewModel) -> CGFloat {
         return preferredHeight
     }
 
     // MARK: - Target Action
 
     func segmentedControlValueChanged() {
-        if let action = changeAction?(value) {
-            dispatchAction?(action)
-        }
+        let action = actions[segmentedControl.selectedSegmentIndex]
+        dispatchAction?(action)
     }
 }

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -28,14 +28,12 @@ import UIKit
 // "static stored properties not yet supported in generic types"
 private let preferredHeight: CGFloat = 54
 
-class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewCell {
-    typealias Value = ViewModel.Value
-
-    var dispatchAction: ((Form.Action) -> ())?
+class SegmentedControlRowCell<Value: Equatable, Action>: UITableViewCell {
+    var dispatchAction: ((Action) -> ())?
 
     private let segmentedControl = UISegmentedControl()
     private var values: [Value] = []
-    private var changeAction: ((Value) -> Form.Action)?
+    private var changeAction: ((Value) -> Action)?
 
     var value: Value {
         return values[segmentedControl.selectedSegmentIndex]
@@ -67,7 +65,7 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
 
     // MARK: - View Model
 
-    func updateWithViewModel(viewModel: ViewModel) {
+    func updateWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value, ViewModel.Action == Action>(viewModel: ViewModel) {
         changeAction = viewModel.changeAction
         // Remove any old segments
         segmentedControl.removeAllSegments()
@@ -82,7 +80,7 @@ class SegmentedControlRowCell<ViewModel: SegmentedControlRowModel>: UITableViewC
         segmentedControl.selectedSegmentIndex = values.indexOf(viewModel.value) ?? 0
     }
 
-    static func heightWithViewModel(viewModel: ViewModel) -> CGFloat {
+    static func heightWithViewModel<ViewModel: SegmentedControlRowModel where ViewModel.Value == Value, ViewModel.Action == Action>(viewModel: ViewModel) -> CGFloat {
         return preferredHeight
     }
 

--- a/Authenticator/Source/SegmentedControlRowCell.swift
+++ b/Authenticator/Source/SegmentedControlRowCell.swift
@@ -28,7 +28,7 @@ import UIKit
 // "static stored properties not yet supported in generic types"
 private let preferredHeight: CGFloat = 54
 
-class SegmentedControlRowCell<Value: Equatable, Action>: UITableViewCell {
+class SegmentedControlRowCell<Action>: UITableViewCell {
     var dispatchAction: ((Action) -> ())?
 
     private let segmentedControl = UISegmentedControl()

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -29,9 +29,9 @@ protocol SegmentedControlRowModel {
     typealias Value: Equatable
     typealias Action
 
-    var segments: [(title: String, value: Value)] { get }
     var value: Value { get }
     var changeAction: (Value) -> Action { get }
+    var segments: [(title: String, value: Value)] { get }
 }
 
 enum TokenType {
@@ -40,47 +40,53 @@ enum TokenType {
 
 struct TokenTypeRowModel: SegmentedControlRowModel {
     typealias Value = TokenType
+    typealias Action = Form.Action
+
+    init(value: Value, changeAction: (Value) -> Action) {
+        self.value = value
+        self.changeAction = changeAction
+    }
+
+    let value: Value
+    let changeAction: (Value) -> Action
     let segments = [
         (title: "Time Based", value: Value.Timer),
         (title: "Counter Based", value: Value.Counter),
     ]
-    let value: Value
-    let changeAction: (Value) -> Form.Action
-
-    init(value: Value, changeAction: (Value) -> Form.Action) {
-        self.value = value
-        self.changeAction = changeAction
-    }
 }
 
 struct DigitCountRowModel: SegmentedControlRowModel {
     typealias Value = Int
+    typealias Action = Form.Action
+
+    init(value: Value, changeAction: (Value) -> Action) {
+        self.value = value
+        self.changeAction = changeAction
+    }
+
+    let value: Value
+    let changeAction: (Value) -> Action
     let segments = [
         (title: "6 Digits", value: 6),
         (title: "7 Digits", value: 7),
         (title: "8 Digits", value: 8),
     ]
-    let value: Value
-    let changeAction: (Value) -> Form.Action
-
-    init(value: Value, changeAction: (Value) -> Form.Action) {
-        self.value = value
-        self.changeAction = changeAction
-    }
 }
 
 struct AlgorithmRowModel: SegmentedControlRowModel {
     typealias Value = Generator.Algorithm
+    typealias Action = Form.Action
+
+    init(value: Value, changeAction: (Value) -> Action) {
+        self.value = value
+        self.changeAction = changeAction
+    }
+
+    let value: Value
+    let changeAction: (Value) -> Action
     let segments = [
         (title: "SHA-1", value: Value.SHA1),
         (title: "SHA-256", value: Value.SHA256),
         (title: "SHA-512", value: Value.SHA512),
     ]
-    let value: Value
-    let changeAction: (Value) -> Form.Action
-
-    init(value: Value, changeAction: (Value) -> Form.Action) {
-        self.value = value
-        self.changeAction = changeAction
-    }
 }

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -36,14 +36,11 @@ enum TokenType {
     case Counter, Timer
 }
 
-struct TokenTypeRowModel: SegmentedControlRowModel {
-    typealias Value = TokenType
-    typealias Action = Form.Action
-
-    init(value: Value, changeAction: (Value) -> Action) {
+struct TokenTypeRowModel<Action>: SegmentedControlRowModel {
+    init(value: TokenType, changeAction: (TokenType) -> Action) {
         let options = [
-            (title: "Time Based", value: Value.Timer),
-            (title: "Counter Based", value: Value.Counter),
+            (title: "Time Based", value: TokenType.Timer),
+            (title: "Counter Based", value: TokenType.Counter),
         ]
         segments = options.map({ option in
             return (title: option.title, action: changeAction(option.value))
@@ -55,9 +52,8 @@ struct TokenTypeRowModel: SegmentedControlRowModel {
     let selectedSegmentIndex: Int?
 }
 
-struct DigitCountRowModel: SegmentedControlRowModel {
+struct DigitCountRowModel<Action>: SegmentedControlRowModel {
     typealias Value = Int
-    typealias Action = Form.Action
 
     init(value: Value, changeAction: (Value) -> Action) {
         self.value = value
@@ -81,9 +77,8 @@ struct DigitCountRowModel: SegmentedControlRowModel {
     }
 }
 
-struct AlgorithmRowModel: SegmentedControlRowModel {
+struct AlgorithmRowModel<Action>: SegmentedControlRowModel {
     typealias Value = Generator.Algorithm
-    typealias Action = Form.Action
 
     init(value: Value, changeAction: (Value) -> Action) {
         self.value = value

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -27,9 +27,11 @@ import OneTimePassword
 
 protocol SegmentedControlRowModel {
     typealias Value: Equatable
+    typealias Action
+
     var segments: [(title: String, value: Value)] { get }
     var value: Value { get }
-    var changeAction: (Value) -> Form.Action { get }
+    var changeAction: (Value) -> Action { get }
 }
 
 enum TokenType {

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -26,12 +26,10 @@
 import OneTimePassword
 
 protocol SegmentedControlRowModel {
-    typealias Value: Equatable
     typealias Action
 
-    var value: Value { get }
-    var changeAction: (Value) -> Action { get }
-    var segments: [(title: String, value: Value)] { get }
+    var segments: [(title: String, action: Action)] { get }
+    var selectedSegmentIndex: Int? { get }
 }
 
 enum TokenType {
@@ -43,16 +41,18 @@ struct TokenTypeRowModel: SegmentedControlRowModel {
     typealias Action = Form.Action
 
     init(value: Value, changeAction: (Value) -> Action) {
-        self.value = value
-        self.changeAction = changeAction
+        let options = [
+            (title: "Time Based", value: Value.Timer),
+            (title: "Counter Based", value: Value.Counter),
+        ]
+        segments = options.map({ option in
+            return (title: option.title, action: changeAction(option.value))
+        })
+        selectedSegmentIndex = options.map({ $0.value }).indexOf(value)
     }
 
-    let value: Value
-    let changeAction: (Value) -> Action
-    let segments = [
-        (title: "Time Based", value: Value.Timer),
-        (title: "Counter Based", value: Value.Counter),
-    ]
+    let segments: [(title: String, action: Action)]
+    let selectedSegmentIndex: Int?
 }
 
 struct DigitCountRowModel: SegmentedControlRowModel {
@@ -66,11 +66,19 @@ struct DigitCountRowModel: SegmentedControlRowModel {
 
     let value: Value
     let changeAction: (Value) -> Action
-    let segments = [
+    let options = [
         (title: "6 Digits", value: 6),
         (title: "7 Digits", value: 7),
         (title: "8 Digits", value: 8),
     ]
+    var segments: [(title: String, action: Action)] {
+        return options.map({ option in
+            return (title: option.title, action: changeAction(option.value))
+        })
+    }
+    var selectedSegmentIndex: Int? {
+        return options.map({ $0.value }).indexOf(value)
+    }
 }
 
 struct AlgorithmRowModel: SegmentedControlRowModel {
@@ -84,9 +92,17 @@ struct AlgorithmRowModel: SegmentedControlRowModel {
 
     let value: Value
     let changeAction: (Value) -> Action
-    let segments = [
+    let options = [
         (title: "SHA-1", value: Value.SHA1),
         (title: "SHA-256", value: Value.SHA256),
         (title: "SHA-512", value: Value.SHA512),
     ]
+    var segments: [(title: String, action: Action)] {
+        return options.map({ option in
+            return (title: option.title, action: changeAction(option.value))
+        })
+    }
+    var selectedSegmentIndex: Int? {
+        return options.map({ $0.value }).indexOf(value)
+    }
 }

--- a/Authenticator/Source/SegmentedControlRowModel.swift
+++ b/Authenticator/Source/SegmentedControlRowModel.swift
@@ -37,67 +37,51 @@ enum TokenType {
 }
 
 struct TokenTypeRowModel<Action>: SegmentedControlRowModel {
-    init(value: TokenType, changeAction: (TokenType) -> Action) {
+    let segments: [(title: String, action: Action)]
+    let selectedSegmentIndex: Int?
+
+    init(value: TokenType, @noescape changeAction: (TokenType) -> Action) {
         let options = [
             (title: "Time Based", value: TokenType.Timer),
             (title: "Counter Based", value: TokenType.Counter),
         ]
         segments = options.map({ option in
-            return (title: option.title, action: changeAction(option.value))
+            (title: option.title, action: changeAction(option.value))
         })
         selectedSegmentIndex = options.map({ $0.value }).indexOf(value)
     }
-
-    let segments: [(title: String, action: Action)]
-    let selectedSegmentIndex: Int?
 }
 
 struct DigitCountRowModel<Action>: SegmentedControlRowModel {
-    typealias Value = Int
+    let segments: [(title: String, action: Action)]
+    let selectedSegmentIndex: Int?
 
-    init(value: Value, changeAction: (Value) -> Action) {
-        self.value = value
-        self.changeAction = changeAction
-    }
-
-    let value: Value
-    let changeAction: (Value) -> Action
-    let options = [
-        (title: "6 Digits", value: 6),
-        (title: "7 Digits", value: 7),
-        (title: "8 Digits", value: 8),
-    ]
-    var segments: [(title: String, action: Action)] {
-        return options.map({ option in
-            return (title: option.title, action: changeAction(option.value))
+    init(value: Int, @noescape changeAction: (Int) -> Action) {
+        let options = [
+            (title: "6 Digits", value: 6),
+            (title: "7 Digits", value: 7),
+            (title: "8 Digits", value: 8),
+        ]
+        segments = options.map({ option in
+            (title: option.title, action: changeAction(option.value))
         })
-    }
-    var selectedSegmentIndex: Int? {
-        return options.map({ $0.value }).indexOf(value)
+        selectedSegmentIndex = options.map({ $0.value }).indexOf(value)
     }
 }
 
 struct AlgorithmRowModel<Action>: SegmentedControlRowModel {
-    typealias Value = Generator.Algorithm
+    let segments: [(title: String, action: Action)]
+    let selectedSegmentIndex: Int?
 
-    init(value: Value, changeAction: (Value) -> Action) {
-        self.value = value
-        self.changeAction = changeAction
-    }
-
-    let value: Value
-    let changeAction: (Value) -> Action
-    let options = [
-        (title: "SHA-1", value: Value.SHA1),
-        (title: "SHA-256", value: Value.SHA256),
-        (title: "SHA-512", value: Value.SHA512),
-    ]
-    var segments: [(title: String, action: Action)] {
-        return options.map({ option in
-            return (title: option.title, action: changeAction(option.value))
+    init(value: Generator.Algorithm, @noescape changeAction: (Generator.Algorithm) -> Action) {
+        let options = [
+            (title: "SHA-1", value: Generator.Algorithm.SHA1),
+            (title: "SHA-256", value: Generator.Algorithm.SHA256),
+            (title: "SHA-512", value: Generator.Algorithm.SHA512),
+        ]
+        segments = options.map({ option in
+            (title: option.title, action: changeAction(option.value))
         })
-    }
-    var selectedSegmentIndex: Int? {
-        return options.map({ $0.value }).indexOf(value)
+        selectedSegmentIndex = options.map({ $0.value }).indexOf(value)
     }
 }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -26,10 +26,6 @@ import UIKit
 import OneTimePassword
 import SVProgressHUD
 
-typealias TokenTypeRowCell = SegmentedControlRowCell<TokenType, Form.Action>
-typealias DigitCountRowCell = SegmentedControlRowCell<Int, Form.Action>
-typealias AlgorithmRowCell = SegmentedControlRowCell<Generator.Algorithm, Form.Action>
-
 class TokenFormViewController: UITableViewController {
     private let dispatchAction: (Form.Action) -> ()
     private var viewModel: TableViewModel<Form> {
@@ -238,19 +234,19 @@ extension TokenFormViewController {
             return cell
 
         case .TokenTypeRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(TokenTypeRowCell.self)
+            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<Form.Action>.self)
             cell.updateWithViewModel(viewModel)
             cell.dispatchAction = dispatchAction
             return cell
 
         case .DigitCountRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(DigitCountRowCell.self)
+            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<Form.Action>.self)
             cell.updateWithViewModel(viewModel)
             cell.dispatchAction = dispatchAction
             return cell
 
         case .AlgorithmRow(let viewModel):
-            let cell = tableView.dequeueReusableCellWithClass(AlgorithmRowCell.self)
+            let cell = tableView.dequeueReusableCellWithClass(SegmentedControlRowCell<Form.Action>.self)
             cell.updateWithViewModel(viewModel)
             cell.dispatchAction = dispatchAction
             return cell
@@ -278,19 +274,19 @@ extension TokenFormViewController {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .TokenTypeRow(let viewModel):
-            if let cell = cell as? TokenTypeRowCell {
+            if let cell = cell as? SegmentedControlRowCell<Form.Action> {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .DigitCountRow(let viewModel):
-            if let cell = cell as? DigitCountRowCell {
+            if let cell = cell as? SegmentedControlRowCell<Form.Action> {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             }
         case .AlgorithmRow(let viewModel):
-            if let cell = cell as? AlgorithmRowCell {
+            if let cell = cell as? SegmentedControlRowCell<Form.Action> {
                 cell.updateWithViewModel(viewModel)
             } else {
                 tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
@@ -303,11 +299,11 @@ extension TokenFormViewController {
         case .TextFieldRow(let viewModel):
             return TextFieldRowCell.heightWithViewModel(viewModel)
         case .TokenTypeRow(let viewModel):
-            return TokenTypeRowCell.heightWithViewModel(viewModel)
+            return SegmentedControlRowCell<Form.Action>.heightWithViewModel(viewModel)
         case .DigitCountRow(let viewModel):
-            return DigitCountRowCell.heightWithViewModel(viewModel)
+            return SegmentedControlRowCell<Form.Action>.heightWithViewModel(viewModel)
         case .AlgorithmRow(let viewModel):
-            return AlgorithmRowCell.heightWithViewModel(viewModel)
+            return SegmentedControlRowCell<Form.Action>.heightWithViewModel(viewModel)
         }
     }
 

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -23,11 +23,12 @@
 //
 
 import UIKit
+import OneTimePassword
 import SVProgressHUD
 
-typealias TokenTypeRowCell = SegmentedControlRowCell<TokenTypeRowModel>
-typealias DigitCountRowCell = SegmentedControlRowCell<DigitCountRowModel>
-typealias AlgorithmRowCell = SegmentedControlRowCell<AlgorithmRowModel>
+typealias TokenTypeRowCell = SegmentedControlRowCell<TokenType, Form.Action>
+typealias DigitCountRowCell = SegmentedControlRowCell<Int, Form.Action>
+typealias AlgorithmRowCell = SegmentedControlRowCell<Generator.Algorithm, Form.Action>
 
 class TokenFormViewController: UITableViewController {
     private let dispatchAction: (Form.Action) -> ()

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -23,7 +23,6 @@
 //
 
 import UIKit
-import OneTimePassword
 import SVProgressHUD
 
 class TokenFormViewController: UITableViewController {


### PR DESCRIPTION
This PR re-genericizes `SegmentedControlRowCell` on the type of `Action` dispatched when a segment is selected. It also simplifies `SegmentedControlRowModel` to not expose raw values, and to expose instead a title and action for each segment and a selected segment index. The values represented by the segments become a private detail of the row models, and the values are wrapped in a change action before being passed to the cell.