### PR TITLE
Root Effects

### DIFF
--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -53,9 +53,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         SVProgressHUD.setDefaultStyle(.Dark)
 
         let navController = RootViewController(viewModel: root.viewModel,
-            dispatchAction: { [weak root] in
-                root?.handleAction($0)
-            })
+            dispatchAction: handleAction)
         root.presenter = navController
         self.window?.rootViewController = navController
         self.window?.makeKeyAndVisible()
@@ -72,7 +70,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
             let alert = UIAlertController(title: "Add Token", message: message, preferredStyle: .Alert)
 
             let acceptHandler: (UIAlertAction) -> Void = { [weak self] (_) in
-                self?.root.handleAction(.AddTokenFromURL(token))
+                self?.handleAction(.AddTokenFromURL(token))
             }
 
             alert.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: nil))
@@ -85,5 +83,9 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         return false
+    }
+
+    private func handleAction(action: Root.Action) {
+        root.handleAction(action)
     }
 }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -29,12 +29,14 @@ import SVProgressHUD
 @UIApplicationMain
 class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow? = UIWindow(frame: UIScreen.mainScreen().bounds)
-    let root = Root(
-        store: TokenStore(
-            keychain: Keychain.sharedInstance,
-            userDefaults: NSUserDefaults.standardUserDefaults()
-        )
+
+    let store = TokenStore(
+        keychain: Keychain.sharedInstance,
+        userDefaults: NSUserDefaults.standardUserDefaults()
     )
+    lazy var root: Root = {
+        Root(store: self.store)
+    }()
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         UINavigationBar.appearance().barTintColor = UIColor.otpBarBackgroundColor
@@ -95,20 +97,20 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     private func handleEffect(effect: Root.Effect) {
         switch effect {
         case .AddToken(let token):
-            root.tokenStore.addToken(token)
+            store.addToken(token)
 
         case let .SaveToken(token, persistentToken):
-            root.tokenStore.saveToken(token, toPersistentToken: persistentToken)
+            store.saveToken(token, toPersistentToken: persistentToken)
 
         case .UpdatePersistentToken(let persistentToken):
-            root.tokenStore.updatePersistentToken(persistentToken)
+            store.updatePersistentToken(persistentToken)
 
         case let .MoveToken(fromIndex, toIndex):
-            root.tokenStore.moveTokenFromIndex(fromIndex, toIndex: toIndex)
+            store.moveTokenFromIndex(fromIndex, toIndex: toIndex)
 
         case .DeletePersistentToken(let persistentToken):
-            root.tokenStore.deletePersistentToken(persistentToken)
+            store.deletePersistentToken(persistentToken)
         }
-        root.updateWithPersistentTokens(root.tokenStore.persistentTokens)
+        root.updateWithPersistentTokens(store.persistentTokens)
     }
 }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -70,7 +70,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
             let alert = UIAlertController(title: "Add Token", message: message, preferredStyle: .Alert)
 
             let acceptHandler: (UIAlertAction) -> Void = { [weak self] (_) in
-                self?.handleAction(.AddTokenFromURL(token))
+                self?.handleEffect(.AddToken(token))
             }
 
             alert.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: nil))

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -93,6 +93,10 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func handleEffect(effect: Root.Effect) {
-
+        switch effect {
+        case .AddToken(let token):
+            root.tokenStore.addToken(token)
+            root.updateWithPersistentTokens(root.tokenStore.persistentTokens)
+        }
     }
 }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -86,6 +86,13 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func handleAction(action: Root.Action) {
-        root.handleAction(action)
+        let sideEffect = root.handleAction(action)
+        if let effect = sideEffect {
+            handleEffect(effect)
+        }
+    }
+
+    private func handleEffect(effect: Root.Effect) {
+
     }
 }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -35,7 +35,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         userDefaults: NSUserDefaults.standardUserDefaults()
     )
     lazy var root: Root = {
-        Root(store: self.store)
+        Root(persistentTokens: self.store.persistentTokens)
     }()
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -99,6 +99,15 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
 
         case let .SaveToken(token, persistentToken):
             root.tokenStore.saveToken(token, toPersistentToken: persistentToken)
+
+        case .UpdatePersistentToken(let persistentToken):
+            root.tokenStore.updatePersistentToken(persistentToken)
+
+        case let .MoveToken(fromIndex, toIndex):
+            root.tokenStore.moveTokenFromIndex(fromIndex, toIndex: toIndex)
+
+        case .DeletePersistentToken(let persistentToken):
+            root.tokenStore.deletePersistentToken(persistentToken)
         }
         root.updateWithPersistentTokens(root.tokenStore.persistentTokens)
     }

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -96,7 +96,10 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         switch effect {
         case .AddToken(let token):
             root.tokenStore.addToken(token)
-            root.updateWithPersistentTokens(root.tokenStore.persistentTokens)
+
+        case let .SaveToken(token, persistentToken):
+            root.tokenStore.saveToken(token, toPersistentToken: persistentToken)
         }
+        root.updateWithPersistentTokens(root.tokenStore.persistentTokens)
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -125,7 +125,7 @@ extension Root {
     }
 
     @warn_unused_result
-    func handleTokenListEffect(effect: TokenList.Effect) -> Effect? {
+    private func handleTokenListEffect(effect: TokenList.Effect) -> Effect? {
         switch effect {
         case .BeginTokenEntry:
             guard QRScanner.deviceCanScan else {
@@ -152,7 +152,7 @@ extension Root {
     }
 
     @warn_unused_result
-    func handleTokenEntryEffect(effect: TokenEntryForm.Effect) -> Effect? {
+    private func handleTokenEntryEffect(effect: TokenEntryForm.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
@@ -165,7 +165,7 @@ extension Root {
     }
 
     @warn_unused_result
-    func handleTokenEditEffect(effect: TokenEditForm.Effect) -> Effect? {
+    private func handleTokenEditEffect(effect: TokenEditForm.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
@@ -178,7 +178,7 @@ extension Root {
     }
 
     @warn_unused_result
-    func handleTokenScannerEffect(effect: TokenScannerViewController.Effect) -> Effect? {
+    private func handleTokenScannerEffect(effect: TokenScannerViewController.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
@@ -194,7 +194,7 @@ extension Root {
         }
     }
 
-    func beginManualTokenEntry() {
+    private func beginManualTokenEntry() {
         let form = TokenEntryForm()
         modalState = .EntryForm(form)
     }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -28,7 +28,7 @@ import OneTimePassword
 class Root {
     weak var presenter: AppPresenter?
 
-    private let tokenStore: TokenStore
+    /*private*/ let tokenStore: TokenStore
 
     private var tokenList: TokenList {
         didSet {
@@ -87,14 +87,14 @@ extension Root {
     }
 
     enum Effect {
-
+        case AddToken(Token)
     }
 
     @warn_unused_result
     func handleAction(action: Action) -> Effect? {
         switch action {
         case .AddTokenFromURL(let token):
-            addToken(token)
+            return .AddToken(token)
 
         case .TokenListAction(let action):
             let sideEffect = tokenList.handleAction(action)
@@ -110,7 +110,7 @@ extension Root {
                 modalState = .EntryForm(newForm)
                 // Handle the resulting action after committing the changes of the initial action
                 if let effect = sideEffect {
-                    handleTokenEntryEffect(effect)
+                    return handleTokenEntryEffect(effect)
                 }
             }
 
@@ -126,7 +126,7 @@ extension Root {
             }
 
         case .TokenScannerEffect(let effect):
-            handleTokenScannerEffect(effect)
+            return handleTokenScannerEffect(effect)
         }
         return nil
     }
@@ -158,14 +158,16 @@ extension Root {
         }
     }
 
-    func handleTokenEntryEffect(effect: TokenEntryForm.Effect) {
+    @warn_unused_result
+    func handleTokenEntryEffect(effect: TokenEntryForm.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
+            return nil
 
         case .SaveNewToken(let token):
-            addToken(token)
             modalState = .None
+            return .AddToken(token)
         }
     }
 
@@ -181,17 +183,20 @@ extension Root {
         }
     }
 
-    func handleTokenScannerEffect(effect: TokenScannerViewController.Effect) {
+    @warn_unused_result
+    func handleTokenScannerEffect(effect: TokenScannerViewController.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
+            return nil
 
         case .BeginManualTokenEntry:
             beginManualTokenEntry()
+            return nil
 
         case .SaveNewToken(let token):
-            addToken(token)
             modalState = .None
+            return .AddToken(token)
         }
     }
 
@@ -200,8 +205,7 @@ extension Root {
         modalState = .EntryForm(form)
     }
 
-    func addToken(token: Token) {
-        tokenStore.addToken(token)
-        tokenList.updateWithPersistentTokens(tokenStore.persistentTokens)
+    func updateWithPersistentTokens(persistentTokens: [PersistentToken]) {
+        tokenList.updateWithPersistentTokens(persistentTokens)
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -86,6 +86,7 @@ extension Root {
 
     enum Effect {
         case AddToken(Token)
+        case SaveToken(Token, PersistentToken)
     }
 
     @warn_unused_result
@@ -116,7 +117,7 @@ extension Root {
                 modalState = .EditForm(newForm)
                 // Handle the resulting effect after committing the changes of the initial action
                 if let effect = sideEffect {
-                    handleTokenEditEffect(effect)
+                    return handleTokenEditEffect(effect)
                 }
             }
 
@@ -166,15 +167,16 @@ extension Root {
         }
     }
 
-    func handleTokenEditEffect(effect: TokenEditForm.Effect) {
+    @warn_unused_result
+    func handleTokenEditEffect(effect: TokenEditForm.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
+            return nil
 
         case let .SaveChanges(token, persistentToken):
-            tokenStore.saveToken(token, toPersistentToken: persistentToken)
-            tokenList.updateWithPersistentTokens(tokenStore.persistentTokens)
             modalState = .None
+            return .SaveToken(token, persistentToken)
         }
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -86,7 +86,12 @@ extension Root {
         case TokenScannerEffect(TokenScannerViewController.Effect)
     }
 
-    func handleAction(action: Action) {
+    enum Effect {
+
+    }
+
+    @warn_unused_result
+    func handleAction(action: Action) -> Effect? {
         switch action {
         case .AddTokenFromURL(let token):
             addToken(token)
@@ -123,6 +128,7 @@ extension Root {
         case .TokenScannerEffect(let effect):
             handleTokenScannerEffect(effect)
         }
+        return nil
     }
 
     func handleTokenListEffect(effect: TokenList.Effect) {

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -47,8 +47,8 @@ class Root {
         case EditForm(TokenEditForm)
     }
 
-    init(store: TokenStore) {
-        tokenList = TokenList(persistentTokens: store.persistentTokens)
+    init(persistentTokens: [PersistentToken]) {
+        tokenList = TokenList(persistentTokens: persistentTokens)
         modalState = .None
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -77,8 +77,6 @@ class Root {
 
 extension Root {
     enum Action {
-        case AddTokenFromURL(Token)
-
         case TokenListAction(TokenList.Action)
         case TokenEntryFormAction(TokenEntryForm.Action)
         case TokenEditFormAction(TokenEditForm.Action)
@@ -93,9 +91,6 @@ extension Root {
     @warn_unused_result
     func handleAction(action: Action) -> Effect? {
         switch action {
-        case .AddTokenFromURL(let token):
-            return .AddToken(token)
-
         case .TokenListAction(let action):
             let sideEffect = tokenList.handleAction(action)
             // Handle the resulting action after committing the changes of the initial action

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -96,32 +96,26 @@ extension Root {
     func handleAction(action: Action) -> Effect? {
         switch action {
         case .TokenListAction(let action):
-            let sideEffect = tokenList.handleAction(action)
+            let effect = tokenList.handleAction(action)
             // Handle the resulting action after committing the changes of the initial action
-            if let effect = sideEffect {
-                return handleTokenListEffect(effect)
-            }
+            return effect.flatMap(handleTokenListEffect)
 
         case .TokenEntryFormAction(let action):
             if case .EntryForm(let form) = modalState {
                 var newForm = form
-                let sideEffect = newForm.handleAction(action)
+                let effect = newForm.handleAction(action)
                 modalState = .EntryForm(newForm)
                 // Handle the resulting action after committing the changes of the initial action
-                if let effect = sideEffect {
-                    return handleTokenEntryEffect(effect)
-                }
+                return effect.flatMap(handleTokenEntryEffect)
             }
 
         case .TokenEditFormAction(let action):
             if case .EditForm(let form) = modalState {
                 var newForm = form
-                let sideEffect = newForm.handleAction(action)
+                let effect = newForm.handleAction(action)
                 modalState = .EditForm(newForm)
                 // Handle the resulting effect after committing the changes of the initial action
-                if let effect = sideEffect {
-                    return handleTokenEditEffect(effect)
-                }
+                return effect.flatMap(handleTokenEditEffect)
             }
 
         case .TokenScannerEffect(let effect):

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -28,8 +28,6 @@ import OneTimePassword
 class Root {
     weak var presenter: AppPresenter?
 
-    /*private*/ let tokenStore: TokenStore
-
     private var tokenList: TokenList {
         didSet {
             presenter?.updateWithViewModel(viewModel)
@@ -50,8 +48,7 @@ class Root {
     }
 
     init(store: TokenStore) {
-        tokenStore = store
-        tokenList = TokenList(persistentTokens: tokenStore.persistentTokens)
+        tokenList = TokenList(persistentTokens: store.persistentTokens)
         modalState = .None
     }
 


### PR DESCRIPTION
Move ownership of the token store out of the root component and into the app delegate. Use `Effect`s to send changes from the `Root` to the `TokenStore`.