### PR TITLE
Root component struct

### DIFF
--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -34,9 +34,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         keychain: Keychain.sharedInstance,
         userDefaults: NSUserDefaults.standardUserDefaults()
     )
-    lazy var root: Root = {
-        Root(persistentTokens: self.store.persistentTokens)
-    }()
+    var root = Root(persistentTokens: [])
     lazy var rootViewController: RootViewController = {
         RootViewController(viewModel: self.root.viewModel,
             dispatchAction: self.handleAction)
@@ -57,6 +55,9 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
 
         // Restore white-on-black style
         SVProgressHUD.setDefaultStyle(.Dark)
+
+        root.updateWithPersistentTokens(store.persistentTokens)
+        rootViewController.updateWithViewModel(root.viewModel)
 
         self.window?.rootViewController = rootViewController
         self.window?.makeKeyAndVisible()

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -37,6 +37,10 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     lazy var root: Root = {
         Root(persistentTokens: self.store.persistentTokens)
     }()
+    lazy var rootViewController: RootViewController = {
+        RootViewController(viewModel: self.root.viewModel,
+            dispatchAction: self.handleAction)
+    }()
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         UINavigationBar.appearance().barTintColor = UIColor.otpBarBackgroundColor
@@ -54,10 +58,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         // Restore white-on-black style
         SVProgressHUD.setDefaultStyle(.Dark)
 
-        let navController = RootViewController(viewModel: root.viewModel,
-            dispatchAction: handleAction)
-        root.presenter = navController
-        self.window?.rootViewController = navController
+        self.window?.rootViewController = rootViewController
         self.window?.makeKeyAndVisible()
 
         return true
@@ -92,6 +93,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         if let effect = sideEffect {
             handleEffect(effect)
         }
+        rootViewController.updateWithViewModel(root.viewModel)
     }
 
     private func handleEffect(effect: Root.Effect) {

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -36,13 +36,10 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     )
     var root = Root(persistentTokens: []) {
         didSet {
-            rootViewController.updateWithViewModel(root.viewModel)
+            rootViewController?.updateWithViewModel(root.viewModel)
         }
     }
-    lazy var rootViewController: RootViewController = {
-        RootViewController(viewModel: self.root.viewModel,
-            dispatchAction: self.handleAction)
-    }()
+    var rootViewController: RootViewController?
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         UINavigationBar.appearance().barTintColor = UIColor.otpBarBackgroundColor
@@ -61,6 +58,8 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         SVProgressHUD.setDefaultStyle(.Dark)
 
         root.updateWithPersistentTokens(store.persistentTokens)
+        rootViewController = RootViewController(viewModel: root.viewModel,
+            dispatchAction: handleAction)
 
         self.window?.rootViewController = rootViewController
         self.window?.makeKeyAndVisible()

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -34,7 +34,11 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         keychain: Keychain.sharedInstance,
         userDefaults: NSUserDefaults.standardUserDefaults()
     )
-    var root = Root(persistentTokens: [])
+    var root = Root(persistentTokens: []) {
+        didSet {
+            rootViewController.updateWithViewModel(root.viewModel)
+        }
+    }
     lazy var rootViewController: RootViewController = {
         RootViewController(viewModel: self.root.viewModel,
             dispatchAction: self.handleAction)
@@ -57,7 +61,6 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         SVProgressHUD.setDefaultStyle(.Dark)
 
         root.updateWithPersistentTokens(store.persistentTokens)
-        rootViewController.updateWithViewModel(root.viewModel)
 
         self.window?.rootViewController = rootViewController
         self.window?.makeKeyAndVisible()
@@ -94,7 +97,6 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         if let effect = sideEffect {
             handleEffect(effect)
         }
-        rootViewController.updateWithViewModel(root.viewModel)
     }
 
     private func handleEffect(effect: Root.Effect) {

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -26,19 +26,8 @@
 import OneTimePassword
 
 struct Root {
-    weak var presenter: AppPresenter?
-
-    private var tokenList: TokenList {
-        didSet {
-            presenter?.updateWithViewModel(viewModel)
-        }
-    }
-
-    private var modalState: ModalState {
-        didSet {
-            presenter?.updateWithViewModel(viewModel)
-        }
-    }
+    private var tokenList: TokenList
+    private var modalState: ModalState
 
     private enum ModalState {
         case None

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -25,7 +25,7 @@
 
 import OneTimePassword
 
-class Root {
+struct Root {
     weak var presenter: AppPresenter?
 
     private var tokenList: TokenList {
@@ -90,12 +90,14 @@ extension Root {
     }
 
     @warn_unused_result
-    func handleAction(action: Action) -> Effect? {
+    mutating func handleAction(action: Action) -> Effect? {
         switch action {
         case .TokenListAction(let action):
             let effect = tokenList.handleAction(action)
             // Handle the resulting action after committing the changes of the initial action
-            return effect.flatMap(handleTokenListEffect)
+            if let effect = effect {
+                return handleTokenListEffect(effect)
+            }
 
         case .TokenEntryFormAction(let action):
             if case .EntryForm(let form) = modalState {
@@ -103,7 +105,9 @@ extension Root {
                 let effect = newForm.handleAction(action)
                 modalState = .EntryForm(newForm)
                 // Handle the resulting action after committing the changes of the initial action
-                return effect.flatMap(handleTokenEntryEffect)
+                if let effect = effect {
+                    return handleTokenEntryEffect(effect)
+                }
             }
 
         case .TokenEditFormAction(let action):
@@ -112,7 +116,9 @@ extension Root {
                 let effect = newForm.handleAction(action)
                 modalState = .EditForm(newForm)
                 // Handle the resulting effect after committing the changes of the initial action
-                return effect.flatMap(handleTokenEditEffect)
+                if let effect = effect {
+                    return handleTokenEditEffect(effect)
+                }
             }
 
         case .TokenScannerEffect(let effect):
@@ -122,7 +128,7 @@ extension Root {
     }
 
     @warn_unused_result
-    private func handleTokenListEffect(effect: TokenList.Effect) -> Effect? {
+    private mutating func handleTokenListEffect(effect: TokenList.Effect) -> Effect? {
         switch effect {
         case .BeginTokenEntry:
             guard QRScanner.deviceCanScan else {
@@ -149,7 +155,7 @@ extension Root {
     }
 
     @warn_unused_result
-    private func handleTokenEntryEffect(effect: TokenEntryForm.Effect) -> Effect? {
+    private mutating func handleTokenEntryEffect(effect: TokenEntryForm.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
@@ -162,7 +168,7 @@ extension Root {
     }
 
     @warn_unused_result
-    private func handleTokenEditEffect(effect: TokenEditForm.Effect) -> Effect? {
+    private mutating func handleTokenEditEffect(effect: TokenEditForm.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
@@ -175,7 +181,7 @@ extension Root {
     }
 
     @warn_unused_result
-    private func handleTokenScannerEffect(effect: TokenScannerViewController.Effect) -> Effect? {
+    private mutating func handleTokenScannerEffect(effect: TokenScannerViewController.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modalState = .None
@@ -191,12 +197,12 @@ extension Root {
         }
     }
 
-    private func beginManualTokenEntry() {
+    private mutating func beginManualTokenEntry() {
         let form = TokenEntryForm()
         modalState = .EntryForm(form)
     }
 
-    func updateWithPersistentTokens(persistentTokens: [PersistentToken]) {
+    mutating func updateWithPersistentTokens(persistentTokens: [PersistentToken]) {
         tokenList.updateWithPersistentTokens(persistentTokens)
     }
 }

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -75,7 +75,7 @@ class RootViewController: OpaqueNavigationController {
     }
 }
 
-extension RootViewController: AppPresenter {
+extension RootViewController {
     func updateWithViewModel(viewModel: RootViewModel) {
         tokenListViewController.updateWithViewModel(viewModel.tokenList)
 

--- a/Authenticator/Source/RootViewModel.swift
+++ b/Authenticator/Source/RootViewModel.swift
@@ -34,7 +34,3 @@ struct RootViewModel {
         case EditForm(TokenEditForm.ViewModel)
     }
 }
-
-protocol AppPresenter: class {
-    func updateWithViewModel(viewModel: RootViewModel)
-}


### PR DESCRIPTION
Convert the `Root` component to a struct, matching the pattern used with the child components. Remove the `AppPresenter` protocol and give the app delegate responsibility for updating the `RootViewController` when the app state changes.