### PR TITLE
Restore full token deletion animation

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -207,7 +207,7 @@ extension TokenListViewController {
     }
 
     private func updateTableViewWithChanges(changes: [Change]) {
-        if preventTableViewAnimations {
+        if changes.isEmpty || preventTableViewAnimations {
             return
         }
 


### PR DESCRIPTION
Every token list view model update – even those without any row changes – was triggering a table view update. As a result, the row animation when a token was deleted was cut short by the (empty) animation set of the next update. The fix is to prevent table updates except when truly necessary.