### PR TITLE
Modernize CoreGraphics methods

### DIFF
--- a/Authenticator/Source/OTPProgressRing.swift
+++ b/Authenticator/Source/OTPProgressRing.swift
@@ -2,24 +2,25 @@
 //  OTPProgressRing.swift
 //  Authenticator
 //
-//  Copyright (c) 2014 Matt Rubin
+//  Copyright (c) 2014-2015 Authenticator authors
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of
-//  this software and associated documentation files (the "Software"), to deal in
-//  the Software without restriction, including without limitation the rights to
-//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-//  the Software, and to permit persons to whom the Software is furnished to do so,
-//  subject to the following conditions:
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 import UIKit
@@ -53,9 +54,9 @@ class OTPProgressRing: UIView {
 
         CGContextSetStrokeColorWithColor(context, self.tintColor.CGColor)
         CGContextAddArc(context,
-            CGRectGetMidX(ringRect),
-            CGRectGetMidY(ringRect),
-            CGRectGetWidth(ringRect)/2,
+            ringRect.midX,
+            ringRect.midY,
+            ringRect.width/2,
             CGFloat(-M_PI_2),
             CGFloat(2 * M_PI * self.progress - M_PI_2),
             1)

--- a/Authenticator/Source/ScannerOverlayView.swift
+++ b/Authenticator/Source/ScannerOverlayView.swift
@@ -2,24 +2,25 @@
 //  ScannerOverlayView.Swift
 //  Authenticator
 //
-//  Copyright (c) 2013 Matt Rubin
+//  Copyright (c) 2013-2015 Authenticator authors
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a copy of
-//  this software and associated documentation files (the "Software"), to deal in
-//  the Software without restriction, including without limitation the rights to
-//  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-//  the Software, and to permit persons to whom the Software is furnished to do so,
-//  subject to the following conditions:
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
 //
 //  The above copyright notice and this permission notice shall be included in all
 //  copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-//  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-//  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-//  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-//  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 import UIKit
@@ -45,10 +46,10 @@ class ScannerOverlayView: UIView {
 
         let smallestDimension = min(CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds))
         let windowSize = 0.9 * smallestDimension
-        let window = CGRectMake(CGRectGetMidX(rect) - windowSize/2,
-                                CGRectGetMidY(rect) - windowSize/2,
-                                windowSize,
-                                windowSize)
+        let window = CGRect(x: CGRectGetMidX(rect) - windowSize/2,
+            y: CGRectGetMidY(rect) - windowSize/2,
+            width: windowSize,
+            height: windowSize)
 
         CGContextFillRect(context, rect)
         CGContextClearRect(context, window)

--- a/Authenticator/Source/ScannerOverlayView.swift
+++ b/Authenticator/Source/ScannerOverlayView.swift
@@ -44,12 +44,14 @@ class ScannerOverlayView: UIView {
         UIColor(white: 0, alpha: 0.5).setFill()
         UIColor(white: 1, alpha: 0.2).setStroke()
 
-        let smallestDimension = min(CGRectGetWidth(self.bounds), CGRectGetHeight(self.bounds))
+        let smallestDimension = min(self.bounds.width, self.bounds.height)
         let windowSize = 0.9 * smallestDimension
-        let window = CGRect(x: CGRectGetMidX(rect) - windowSize/2,
-            y: CGRectGetMidY(rect) - windowSize/2,
+        let window = CGRect(
+            x: rect.midX - windowSize/2,
+            y: rect.midY - windowSize/2,
             width: windowSize,
-            height: windowSize)
+            height: windowSize
+        )
 
         CGContextFillRect(context, rect)
         CGContextClearRect(context, window)

--- a/Authenticator/Source/SegmentedControlRow.swift
+++ b/Authenticator/Source/SegmentedControlRow.swift
@@ -68,8 +68,9 @@ class SegmentedControlRowCell<Action>: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        let width = CGRectGetWidth(contentView.bounds) - 40
-        segmentedControl.frame = CGRect(x: 20, y: 15, width: width, height: 29)
+        let margin: CGFloat = 20
+        let width = contentView.bounds.width - (2 * margin)
+        segmentedControl.frame = CGRect(x: margin, y: 15, width: width, height: 29)
     }
 
     // MARK: - View Model

--- a/Authenticator/Source/SegmentedControlRow.swift
+++ b/Authenticator/Source/SegmentedControlRow.swift
@@ -67,7 +67,9 @@ class SegmentedControlRowCell<Action>: UITableViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        segmentedControl.frame = CGRectMake(20, 15, CGRectGetWidth(contentView.bounds) - 40, 29)
+
+        let width = CGRectGetWidth(contentView.bounds) - 40
+        segmentedControl.frame = CGRect(x: 20, y: 15, width: width, height: 29)
     }
 
     // MARK: - View Model

--- a/Authenticator/Source/TextFieldRow.swift
+++ b/Authenticator/Source/TextFieldRow.swift
@@ -86,8 +86,9 @@ class TextFieldRowCell<Action>: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        textLabel?.frame = CGRectMake(20, 15, CGRectGetWidth(contentView.bounds) - 40, 21)
-        textField.frame = CGRectMake(20, 44, CGRectGetWidth(contentView.bounds) - 40, 30)
+        let width = CGRectGetWidth(contentView.bounds) - 40
+        textLabel?.frame = CGRect(x: 20, y: 15, width: width, height: 21)
+        textField.frame = CGRect(x: 20, y: 44, width: width, height: 30)
     }
 
     // MARK: - View Model

--- a/Authenticator/Source/TextFieldRow.swift
+++ b/Authenticator/Source/TextFieldRow.swift
@@ -86,9 +86,10 @@ class TextFieldRowCell<Action>: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        let width = CGRectGetWidth(contentView.bounds) - 40
-        textLabel?.frame = CGRect(x: 20, y: 15, width: width, height: 21)
-        textField.frame = CGRect(x: 20, y: 44, width: width, height: 30)
+        let margin: CGFloat = 20
+        let width = contentView.bounds.width - (2 * margin)
+        textLabel?.frame = CGRect(x: margin, y: 15, width: width, height: 21)
+        textField.frame  = CGRect(x: margin, y: 44, width: width, height: 30)
     }
 
     // MARK: - View Model

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -42,7 +42,7 @@ class TokenListViewController: UITableViewController {
     }
 
     private var displayLink: CADisplayLink?
-    private let ring: OTPProgressRing = OTPProgressRing(frame: CGRectMake(0, 0, 22, 22))
+    private let ring: OTPProgressRing = OTPProgressRing(frame: CGRect(x: 0, y: 0, width: 22, height: 22))
     private lazy var noTokensLabel: UILabel = {
         let noTokenString = NSMutableAttributedString(string: "No Tokens\n",
             attributes: [NSFontAttributeName: UIFont(name: "HelveticaNeue-Light", size: 20)!])
@@ -86,9 +86,9 @@ class TokenListViewController: UITableViewController {
         self.navigationController?.toolbarHidden = false
 
         // Configure "no tokens" label
-        self.noTokensLabel.frame = CGRectMake(0, 0,
-            self.view.bounds.size.width,
-            self.view.bounds.size.height * 0.6)
+        self.noTokensLabel.frame = CGRect(x: 0, y: 0,
+            width: self.view.bounds.size.width,
+            height: self.view.bounds.size.height * 0.6)
         self.view.addSubview(self.noTokensLabel)
 
         // Update with current viewModel

--- a/Authenticator/Source/TokenRowCell.swift
+++ b/Authenticator/Source/TokenRowCell.swift
@@ -86,7 +86,7 @@ class TokenRowCell: UITableViewCell {
         passwordLabel.frame.origin.y += 20
         passwordLabel.frame.size.height -= 30
 
-        nextPasswordButton.center = CGPointMake(CGRectGetMaxX(fullFrame) - 25, CGRectGetMidY(passwordLabel.frame))
+        nextPasswordButton.center = CGPoint(x: fullFrame.maxX - 25, y: passwordLabel.frame.midY)
     }
 
 


### PR DESCRIPTION
 - Use modern constructors in place of `CGRectMake()` and `CGPointMake()`
 - Use `CGRect` extended properties instead of `CGRectGet*()` functions
