### PR TITLE
Check if a scanner is visible before presenting another

### DIFF
--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -94,11 +94,16 @@ extension RootViewController {
             dismissViewController()
 
         case .Scanner:
-            let scannerViewController = TokenScannerViewController(
-                dispatchAction: { [dispatchAction] in
-                    dispatchAction(.TokenScannerEffect($0))
-                })
-            presentViewController(scannerViewController)
+            if case .Scanner = currentViewModel.modal,
+                let _ = modalNavController?.topViewController as? TokenScannerViewController {
+                // The scanner has no view model of its own to update
+            } else {
+                let scannerViewController = TokenScannerViewController(
+                    dispatchAction: { [dispatchAction] in
+                        dispatchAction(.TokenScannerEffect($0))
+                    })
+                presentViewController(scannerViewController)
+            }
 
         case .EntryForm(let formViewModel):
             if case .EntryForm = currentViewModel.modal,


### PR DESCRIPTION
Unlike the cases for the entry form and edit form, when updating the view model with a scanner modal, the RootViewController had no check to determine whether a scanner view controller was already presented.