### PR TITLE
Add a "display time" parameter for time-based rendering

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		C93BD6291C168EBF00FFFB8F /* RootViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C93BD6281C168EBF00FFFB8F /* RootViewModel.swift */; };
 		C944A5571A7ECB0800E08B1E /* OneTimePassword.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C944A5561A7ECB0800E08B1E /* OneTimePassword.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C944A5591A7ECB3100E08B1E /* Base32.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C944A5581A7ECB3100E08B1E /* Base32.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C968D1151CB4C639004ED7BB /* DisplayTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = C968D1141CB4C639004ED7BB /* DisplayTime.swift */; };
 		C97B68C717D9226D005D1FE0 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = C97B68C617D9226D005D1FE0 /* Settings.bundle */; };
 		C97CDF261BEEA66A00D64406 /* SVProgressHUD.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = C97CDF241BEEA49300D64406 /* SVProgressHUD.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C97CDF2C1BEEC90100D64406 /* QRScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97CDF2B1BEEC90100D64406 /* QRScanner.swift */; };
@@ -106,6 +107,7 @@
 		C94765081C646E5E00C7527E /* Cartfile.private */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
 		C959A63C190A69120042DEC0 /* Icon.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Icon.svg; sourceTree = "<group>"; };
 		C959A63E190A69E60042DEC0 /* GenerateIcons.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = GenerateIcons.sh; sourceTree = "<group>"; };
+		C968D1141CB4C639004ED7BB /* DisplayTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayTime.swift; sourceTree = "<group>"; };
 		C9776E3318518801003D53CB /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		C97B68C617D9226D005D1FE0 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		C97CDF041BEE927200D64406 /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 			children = (
 				C98B1EC91AB2CEC300C59E53 /* TokenRowModel.swift */,
 				C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */,
+				C968D1141CB4C639004ED7BB /* DisplayTime.swift */,
 			);
 			name = Cells;
 			sourceTree = "<group>";
@@ -562,6 +565,7 @@
 				C99069D1180CBAC900BAEF53 /* TokenScannerViewController.swift in Sources */,
 				C9EB448E1C52A74200ACFA87 /* Component.swift in Sources */,
 				C9D6C83F1906BD68004F0E08 /* SegmentedControlRow.swift in Sources */,
+				C968D1151CB4C639004ED7BB /* DisplayTime.swift in Sources */,
 				8B0028B511EB75920092DE18 /* ScannerOverlayView.swift in Sources */,
 				C9CC09551BA91D1C008C54FE /* TableViewModel.swift in Sources */,
 				C92708AC19CFB0750033128B /* TokenListViewController.swift in Sources */,

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -45,7 +45,7 @@ class AppController {
             userDefaults: NSUserDefaults.standardUserDefaults()
         )
         let currentTime = DisplayTime(date: NSDate())
-        component = Root(persistentTokens: store.persistentTokens, time: currentTime)
+        component = Root(persistentTokens: store.persistentTokens, displayTime: currentTime)
     }
 
     // MARK: - Update

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -44,7 +44,8 @@ class AppController {
             keychain: Keychain.sharedInstance,
             userDefaults: NSUserDefaults.standardUserDefaults()
         )
-        component = Root(persistentTokens: store.persistentTokens)
+        let currentTime = DisplayTime(date: NSDate())
+        component = Root(persistentTokens: store.persistentTokens, time: currentTime)
     }
 
     // MARK: - Update

--- a/Authenticator/Source/DisplayTime.swift
+++ b/Authenticator/Source/DisplayTime.swift
@@ -1,0 +1,22 @@
+//
+//  DisplayTime.swift
+//  Authenticator
+//
+//  Created by Matt Rubin on 4/6/16.
+//  Copyright © 2016 Matt Rubin. All rights reserved.
+//
+
+import Foundation
+
+/// A simple value representing a moment in time, stored as the number of seconds since the epoch.
+struct DisplayTime: Equatable {
+    let timeIntervalSince1970: NSTimeInterval
+
+    init(date: NSDate) {
+        timeIntervalSince1970 = date.timeIntervalSince1970
+    }
+}
+
+func == (lhs: DisplayTime, rhs: DisplayTime) -> Bool {
+    return lhs.timeIntervalSince1970 == rhs.timeIntervalSince1970
+}

--- a/Authenticator/Source/DisplayTime.swift
+++ b/Authenticator/Source/DisplayTime.swift
@@ -2,8 +2,25 @@
 //  DisplayTime.swift
 //  Authenticator
 //
-//  Created by Matt Rubin on 4/6/16.
-//  Copyright © 2016 Matt Rubin. All rights reserved.
+//  Copyright (c) 2016 Authenticator authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
 //
 
 import Foundation

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -49,8 +49,8 @@ struct Root: Component {
         }
     }
 
-    init(persistentTokens: [PersistentToken]) {
-        tokenList = TokenList(persistentTokens: persistentTokens)
+    init(persistentTokens: [PersistentToken], time: DisplayTime) {
+        tokenList = TokenList(persistentTokens: persistentTokens, time: time)
         modal = .None
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -49,8 +49,8 @@ struct Root: Component {
         }
     }
 
-    init(persistentTokens: [PersistentToken], time: DisplayTime) {
-        tokenList = TokenList(persistentTokens: persistentTokens, time: time)
+    init(persistentTokens: [PersistentToken], displayTime: DisplayTime) {
+        tokenList = TokenList(persistentTokens: persistentTokens, displayTime: displayTime)
         modal = .None
     }
 }

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -77,6 +77,7 @@ struct TokenList: Component {
             // divide-by-zero error below.
             return 0
         }
+        // Calculate the percentage progress in the current period.
         return fmod(displayTime.timeIntervalSince1970, ringPeriod) / ringPeriod
     }
 }

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -45,9 +45,10 @@ struct TokenList: Component {
 
     var viewModel: TokenListViewModel {
         let rowModels = persistentTokens.map(TokenRowModel.init)
+        let currentTime = NSDate().timeIntervalSince1970
         return TokenListViewModel(
             rowModels: rowModels,
-            ringPeriod: timeBasedTokenPeriods.first,
+            ringProgress: ringProgress(timeIntervalSince1970: currentTime),
             ephemeralMessage: ephemeralMessage
         )
     }
@@ -61,6 +62,19 @@ struct TokenList: Component {
             }
         }
         return Array(periods).sort()
+    }
+
+    private func ringProgress(timeIntervalSince1970 time: NSTimeInterval) -> Double? {
+        guard let ringPeriod = timeBasedTokenPeriods.first else {
+            // If there are no time-based tokens, return nil to hide the progress ring.
+            return nil
+        }
+        guard ringPeriod > 0 else {
+            // If the period is >= zero, return zero to display the ring but avoid the potential
+            // divide-by-zero error below.
+            return 0
+        }
+        return fmod(time, ringPeriod) / ringPeriod
     }
 }
 

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -46,7 +46,9 @@ struct TokenList: Component {
     // MARK: View Model
 
     var viewModel: TokenListViewModel {
-        let rowModels = persistentTokens.map(TokenRowModel.init)
+        let rowModels = persistentTokens.map({
+            TokenRowModel(persistentToken: $0, displayTime: time)
+        })
         return TokenListViewModel(
             rowModels: rowModels,
             ringProgress: ringProgress,

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -30,12 +30,12 @@ import OneTimePassword
 
 struct TokenList: Component {
     private var persistentTokens: [PersistentToken]
-    private var time: DisplayTime
+    private var displayTime: DisplayTime
     private var ephemeralMessage: EphemeralMessage?
 
-    init(persistentTokens: [PersistentToken], time: DisplayTime) {
+    init(persistentTokens: [PersistentToken], displayTime: DisplayTime) {
         self.persistentTokens = persistentTokens
-        self.time = time
+        self.displayTime = displayTime
         ephemeralMessage = nil
     }
 
@@ -47,7 +47,7 @@ struct TokenList: Component {
 
     var viewModel: TokenListViewModel {
         let rowModels = persistentTokens.map({
-            TokenRowModel(persistentToken: $0, displayTime: time)
+            TokenRowModel(persistentToken: $0, displayTime: displayTime)
         })
         return TokenListViewModel(
             rowModels: rowModels,
@@ -77,7 +77,7 @@ struct TokenList: Component {
             // divide-by-zero error below.
             return 0
         }
-        return fmod(time.timeIntervalSince1970, ringPeriod) / ringPeriod
+        return fmod(displayTime.timeIntervalSince1970, ringPeriod) / ringPeriod
     }
 }
 
@@ -125,8 +125,8 @@ extension TokenList {
             copyPassword(password)
             return nil
 
-        case .UpdateViewModel(let time):
-            self.time = time
+        case .UpdateViewModel(let displayTime):
+            self.displayTime = displayTime
             return nil
         }
     }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -120,7 +120,7 @@ class TokenListViewController: UITableViewController {
     // MARK: Target Actions
 
     func tick() {
-        // Update the progress ring and currently-visible cells
+        // Dispatch an action to trigger a view model update.
         let newDisplayTime = DisplayTime(date: NSDate())
         dispatchAction(.UpdateViewModel(newDisplayTime))
     }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -120,8 +120,9 @@ class TokenListViewController: UITableViewController {
     // MARK: Target Actions
 
     func tick() {
-        // Update currently-visible cells
-        dispatchAction(.UpdateViewModel)
+        // Update the progress ring and currently-visible cells
+        let newDisplayTime = DisplayTime(date: NSDate())
+        dispatchAction(.UpdateViewModel(newDisplayTime))
     }
 
     func addToken() {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -122,12 +122,6 @@ class TokenListViewController: UITableViewController {
     func tick() {
         // Update currently-visible cells
         dispatchAction(.UpdateViewModel)
-
-        if let period = viewModel.ringPeriod where period > 0 {
-            self.ring.progress = fmod(NSDate().timeIntervalSince1970, period) / period
-        } else {
-            self.ring.progress = 0
-        }
     }
 
     func addToken() {
@@ -241,7 +235,10 @@ extension TokenListViewController {
 
     private func updatePeripheralViews() {
         // Show the countdown ring only if a time-based token is active
-        self.ring.hidden = (viewModel.ringPeriod == nil)
+        self.ring.hidden = (viewModel.ringProgress == nil)
+        if let ringProgress = viewModel.ringProgress {
+            ring.progress = ringProgress
+        }
 
         let hasTokens = !viewModel.rowModels.isEmpty
         editButtonItem().enabled = hasTokens

--- a/Authenticator/Source/TokenListViewModel.swift
+++ b/Authenticator/Source/TokenListViewModel.swift
@@ -27,7 +27,7 @@ import Foundation
 
 struct TokenListViewModel {
     let rowModels: [TokenRowModel]
-    let ringPeriod: NSTimeInterval?
+    let ringProgress: Double?
     let ephemeralMessage: EphemeralMessage?
 }
 

--- a/Authenticator/Source/TokenRowModel.swift
+++ b/Authenticator/Source/TokenRowModel.swift
@@ -38,10 +38,11 @@ struct TokenRowModel: Equatable, Identifiable {
 
     private let identifier: NSData
 
-    init(persistentToken: PersistentToken) {
+    init(persistentToken: PersistentToken, displayTime: DisplayTime) {
         name = persistentToken.token.name
         issuer = persistentToken.token.issuer
-        password = persistentToken.token.currentPassword ?? ""
+        let timeInterval = displayTime.timeIntervalSince1970
+        password = (try? persistentToken.token.generator.passwordAtTime(timeInterval)) ?? ""
         if case .Counter = persistentToken.token.generator.factor {
             showsButton = true
         } else {


### PR DESCRIPTION
Add the `DisplayTime` type and use it as a parameter for `TokenList` and `TokenRowModel`, to explicitly specify the time which should be used when rendering their time-based outputs (the progress ring and the time-based generated passwords).