### PR TITLE
Lint Cleanup

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,10 +4,10 @@ excluded:
   - Carthage
 opt_in_rules:
   - empty_count
-  - force_unwrapping
+#  - force_unwrapping
   - missing_docs
 disabled_rules:
- - conditional_binding_cascade
- - cyclomatic_complexity
- - line_length
- - todo
+  - conditional_binding_cascade
+  - cyclomatic_complexity
+  - line_length
+  - todo

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,7 @@ excluded:
   - Carthage
 opt_in_rules:
   - empty_count
-#  - force_unwrapping
+  - force_unwrapping
   - missing_docs
 disabled_rules:
   - conditional_binding_cascade

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,5 @@ opt_in_rules:
   - missing_docs
 disabled_rules:
   - conditional_binding_cascade
-  - cyclomatic_complexity
   - line_length
   - todo

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,11 +2,12 @@
 
 excluded:
   - Carthage
-enabled_rules:
+opt_in_rules:
   - empty_count
   - force_unwrapping
+  - missing_docs
 disabled_rules:
+ - conditional_binding_cascade
  - cyclomatic_complexity
  - line_length
- - opening_brace
  - todo

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -34,6 +34,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     let app = AppController()
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
+        // swiftlint:disable:next force_unwrapping
         UIBarButtonItem.appearance().setTitleTextAttributes([NSFontAttributeName: UIFont(name: "HelveticaNeue-Light", size: 17)!], forState: UIControlState.Normal)
 
         // Restore white-on-black style

--- a/Authenticator/Source/OTPProgressRing.swift
+++ b/Authenticator/Source/OTPProgressRing.swift
@@ -46,8 +46,10 @@ class OTPProgressRing: UIView {
     override func drawRect(rect: CGRect) {
         let context = UIGraphicsGetCurrentContext()
 
+        let halfLineWidth = lineWidth / 2
+        let ringRect = self.bounds.insetBy(dx: halfLineWidth, dy: halfLineWidth)
+
         CGContextSetLineWidth(context, lineWidth)
-        let ringRect = CGRectInset(self.bounds, lineWidth/2, lineWidth/2)
 
         CGContextSetStrokeColorWithColor(context, self.tintColor.colorWithAlphaComponent(0.2).CGColor)
         CGContextStrokeEllipseInRect(context, ringRect)

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -34,6 +34,7 @@ class OpaqueNavigationController: UINavigationController {
         navigationBar.tintColor = UIColor.otpBarForegroundColor
         navigationBar.titleTextAttributes = [
             NSForegroundColorAttributeName: UIColor.otpBarForegroundColor,
+            // swiftlint:disable:next force_unwrapping
             NSFontAttributeName: UIFont(name: "HelveticaNeue-Light", size: 20)!
         ]
 

--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -48,9 +48,7 @@ func changesFrom<T: Identifiable where T: Equatable>(oldItems: [T], to newItems:
 }
 
 // Diff algorithm from the Eugene Myers' paper "An O(ND) Difference Algorithm and Its Variations"
-private func changesFrom<T>(oldItems: [T], to newItems: [T], hasSameIdentity: (T, T) -> Bool,
-    isEqual: (T, T) -> Bool) -> [Change]
-{
+private func changesFrom<T>(oldItems: [T], to newItems: [T], hasSameIdentity: (T, T) -> Bool, isEqual: (T, T) -> Bool) -> [Change] {
     let MAX = oldItems.count + newItems.count
     guard MAX > 0 else { return [] }
     let numDiagonals = (2 * MAX) + 1

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -145,34 +145,37 @@ extension TokenList {
 }
 
 func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
-    switch lhs {
-    case .BeginAddToken:
-        return rhs == .BeginAddToken
-    case let .EditPersistentToken(l):
-        if case let .EditPersistentToken(r) = rhs {
-            return l == r
-        }
-    case let .UpdatePersistentToken(l):
-        if case let .UpdatePersistentToken(r) = rhs {
-            return l == r
-        }
-    case let .MoveToken(l):
-        if case let .MoveToken(r) = rhs {
-            return l.fromIndex == r.fromIndex
-                && l.toIndex == r.toIndex
-        }
-    case let .DeletePersistentToken(l):
-        if case let .DeletePersistentToken(r) = rhs {
-            return l == r
-        }
-    case let .CopyPassword(l):
-        if case let .CopyPassword(r) = rhs {
-            return l == r
-        }
-    case let .UpdateViewModel(l):
-        if case let .UpdateViewModel(r) = rhs {
-            return l == r
-        }
+    switch (lhs, rhs) {
+    case (.BeginAddToken, .BeginAddToken):
+        return true
+
+    case let (.EditPersistentToken(l), .EditPersistentToken(r)):
+        return l == r
+
+    case let (.UpdatePersistentToken(l), .UpdatePersistentToken(r)):
+        return l == r
+
+    case let (.MoveToken(l), .MoveToken(r)):
+        return l.fromIndex == r.fromIndex
+            && l.toIndex == r.toIndex
+
+    case let (.DeletePersistentToken(l), .DeletePersistentToken(r)):
+        return l == r
+
+    case let (.CopyPassword(l), .CopyPassword(r)):
+        return l == r
+
+    case let (.UpdateViewModel(l), .UpdateViewModel(r)):
+        return l == r
+
+    case (.BeginAddToken, _),
+         (.EditPersistentToken, _),
+         (.UpdatePersistentToken, _),
+         (.MoveToken, _),
+         (.DeletePersistentToken, _),
+         (.CopyPassword, _),
+         (.UpdateViewModel, _):
+        // Unlike `default`, this final verbose case will cause an error if a new case is added.
+        return false
     }
-    return false
 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -44,6 +44,7 @@ class TokenListViewController: UITableViewController {
     private var displayLink: CADisplayLink?
     private let ring: OTPProgressRing = OTPProgressRing(frame: CGRect(x: 0, y: 0, width: 22, height: 22))
     private lazy var noTokensLabel: UILabel = {
+        // swiftlint:disable force_unwrapping
         let noTokenString = NSMutableAttributedString(string: "No Tokens\n",
             attributes: [NSFontAttributeName: UIFont(name: "HelveticaNeue-Light", size: 20)!])
         noTokenString.appendAttributedString(NSAttributedString(string: "Tap + to add a new token",
@@ -51,6 +52,7 @@ class TokenListViewController: UITableViewController {
         noTokenString.addAttributes(
             [NSFontAttributeName: UIFont(name: "HelveticaNeue-Light", size: 25)!],
             range: (noTokenString.string as NSString).rangeOfString("+"))
+        // swiftlint:enable force_unwrapping
 
         let label = UILabel()
         label.numberOfLines = 2

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -140,9 +140,7 @@ extension TokenListViewController {
         return viewModel.rowModels.count
     }
 
-    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath)
-        -> UITableViewCell
-    {
+    override func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCellWithClass(TokenRowCell.self)
         updateCell(cell, forRowAtIndexPath: indexPath)
         return cell
@@ -154,20 +152,14 @@ extension TokenListViewController {
         cell.dispatchAction = dispatchAction
     }
 
-    override func tableView(tableView: UITableView,
-        commitEditingStyle editingStyle: UITableViewCellEditingStyle,
-        forRowAtIndexPath indexPath: NSIndexPath)
-    {
+    override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
         let rowModel = viewModel.rowModels[indexPath.row]
         if editingStyle == .Delete {
             dispatchAction(rowModel.deleteAction)
         }
     }
 
-    override func tableView(tableView: UITableView,
-        moveRowAtIndexPath sourceIndexPath: NSIndexPath,
-        toIndexPath destinationIndexPath: NSIndexPath)
-    {
+    override func tableView(tableView: UITableView, moveRowAtIndexPath sourceIndexPath: NSIndexPath, toIndexPath destinationIndexPath: NSIndexPath) {
         preventTableViewAnimations = true
         dispatchAction(.MoveToken(fromIndex: sourceIndexPath.row,
             toIndex: destinationIndexPath.row))
@@ -178,9 +170,7 @@ extension TokenListViewController {
 
 // MARK: UITableViewDelegate
 extension TokenListViewController {
-    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath)
-        -> CGFloat
-    {
+    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
         return 85
     }
 }

--- a/Authenticator/Source/TokenRowCell.swift
+++ b/Authenticator/Source/TokenRowCell.swift
@@ -114,6 +114,7 @@ class TokenRowCell: UITableViewCell {
     private func setName(name: String, issuer: String) {
         let titleString = NSMutableAttributedString()
         if !issuer.isEmpty {
+            // swiftlint:disable:next force_unwrapping
             titleString.appendAttributedString(NSAttributedString(string: issuer, attributes:[NSFontAttributeName: UIFont(name: "HelveticaNeue-Medium", size: 15)!]))
         }
         if !issuer.isEmpty && !name.isEmpty {


### PR DESCRIPTION
Update SwiftLint configuration to enable additional rules, and make some source changes in response to linter warnings:
 - Refactor `OTPProgressRing` to use `CGRect` extension methods instead of legacy free functions.
 - Consolidate previously-wrapped function declarations onto single lines.
 - Refactor `TokenList.Action` equality to reduce the cyclomatic complexity.
 - Selectively disable force-unwrapping warnings for certain initializations of `UIFont`s