### PR TITLE
Improve clean clones

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -199,8 +199,10 @@
 				C931A5FB1BFF6F3A00706A1C /* Tools */,
 				C9776E32185187E8003D53CB /* Docs */,
 			);
+			indentWidth = 4;
 			name = CustomTemplate;
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		29B97317FDCFA39411CA2CEA /* Resources */ = {
 			isa = PBXGroup;

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ Authenticator is a simple, free, and open source [two-factor authentication](htt
   git clone https://github.com/mattrubin/Authenticator.git
   ```
 
-2. Check out the project's dependencies:
+2. In the Authenticator directory, check out the project's dependencies:
   ```
+  cd Authenticator
   git submodule update --init --recursive
   ```
 


### PR DESCRIPTION
Improve the "Getting Started" instructions and add project-wide indentation configuration to the Xcode project.