### PR TITLE
TokenStore update success callbacks

### DIFF
--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -61,22 +61,26 @@ class AppController {
 
     private func handleEffect(effect: Root.Effect) {
         switch effect {
-        case .AddToken(let token):
+        case let .AddToken(token, success):
             store.addToken(token)
+            component.update(success(store.persistentTokens))
 
-        case let .SaveToken(token, persistentToken):
+        case let .SaveToken(token, persistentToken, success):
             store.saveToken(token, toPersistentToken: persistentToken)
+            component.update(success(store.persistentTokens))
 
-        case .UpdatePersistentToken(let persistentToken):
+        case let .UpdatePersistentToken(persistentToken, success):
             store.updatePersistentToken(persistentToken)
+            component.update(success(store.persistentTokens))
 
-        case let .MoveToken(fromIndex, toIndex):
+        case let .MoveToken(fromIndex, toIndex, success):
             store.moveTokenFromIndex(fromIndex, toIndex: toIndex)
+            component.update(success(store.persistentTokens))
 
-        case .DeletePersistentToken(let persistentToken):
+        case let .DeletePersistentToken(persistentToken, success):
             store.deletePersistentToken(persistentToken)
+            component.update(success(store.persistentTokens))
         }
-        component.update(.UpdatePersistentTokens(store.persistentTokens))
     }
 
     // MARK: - Public
@@ -86,6 +90,6 @@ class AppController {
     }
 
     func addTokenFromURL(token: Token) {
-        handleEffect(.AddToken(token))
+        handleEffect(.AddToken(token, success: Root.Action.UpdatePersistentTokens))
     }
 }

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -90,7 +90,7 @@ class AppController {
     }
 
     func addTokenFromURL(token: Token) {
-        handleEffect(.AddToken(token,
-            success: { Root.Action.TokenListAction(TokenList.Action.UpdateWithPersistentTokens($0)) }))
+        // TODO: Add Root.Action.AddTokenFromURL
+        handleEffect(.AddToken(token, success: Root.Action.UpdateWithPersistentTokens))
     }
 }

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -63,23 +63,23 @@ class AppController {
         switch effect {
         case let .AddToken(token, success):
             store.addToken(token)
-            component.update(success(store.persistentTokens))
+            handleAction(success(store.persistentTokens))
 
         case let .SaveToken(token, persistentToken, success):
             store.saveToken(token, toPersistentToken: persistentToken)
-            component.update(success(store.persistentTokens))
+            handleAction(success(store.persistentTokens))
 
         case let .UpdatePersistentToken(persistentToken, success):
             store.updatePersistentToken(persistentToken)
-            component.update(success(store.persistentTokens))
+            handleAction(success(store.persistentTokens))
 
         case let .MoveToken(fromIndex, toIndex, success):
             store.moveTokenFromIndex(fromIndex, toIndex: toIndex)
-            component.update(success(store.persistentTokens))
+            handleAction(success(store.persistentTokens))
 
         case let .DeletePersistentToken(persistentToken, success):
             store.deletePersistentToken(persistentToken)
-            component.update(success(store.persistentTokens))
+            handleAction(success(store.persistentTokens))
         }
     }
 

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -76,7 +76,7 @@ class AppController {
         case .DeletePersistentToken(let persistentToken):
             store.deletePersistentToken(persistentToken)
         }
-        component.updateWithPersistentTokens(store.persistentTokens)
+        component.update(.UpdatePersistentTokens(store.persistentTokens))
     }
 
     // MARK: - Public

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -90,6 +90,7 @@ class AppController {
     }
 
     func addTokenFromURL(token: Token) {
-        handleEffect(.AddToken(token, success: Root.Action.UpdatePersistentTokens))
+        handleEffect(.AddToken(token,
+            success: { Root.Action.TokenListAction(TokenList.Action.UpdateWithPersistentTokens($0)) }))
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -82,11 +82,11 @@ extension Root {
     }
 
     enum Effect {
-        case AddToken(Token)
-        case SaveToken(Token, PersistentToken)
-        case UpdatePersistentToken(PersistentToken)
-        case MoveToken(fromIndex: Int, toIndex: Int)
-        case DeletePersistentToken(PersistentToken)
+        case AddToken(Token, success: ([PersistentToken]) -> Action)
+        case SaveToken(Token, PersistentToken, success: ([PersistentToken]) -> Action)
+        case UpdatePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
+        case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
+        case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
     }
 
     @warn_unused_result
@@ -132,13 +132,14 @@ extension Root {
             return nil
 
         case .UpdateToken(let persistentToken):
-            return .UpdatePersistentToken(persistentToken)
+            return .UpdatePersistentToken(persistentToken, success: Action.UpdatePersistentTokens)
 
         case let .MoveToken(fromIndex, toIndex):
-            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex)
+            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex,
+                              success: Action.UpdatePersistentTokens)
 
         case .DeletePersistentToken(let persistentToken):
-            return .DeletePersistentToken(persistentToken)
+            return .DeletePersistentToken(persistentToken, success: Action.UpdatePersistentTokens)
         }
     }
 
@@ -165,7 +166,7 @@ extension Root {
 
         case .SaveNewToken(let token):
             modal = .None
-            return .AddToken(token)
+            return .AddToken(token, success: Action.UpdatePersistentTokens)
         }
     }
 
@@ -192,7 +193,7 @@ extension Root {
 
         case let .SaveChanges(token, persistentToken):
             modal = .None
-            return .SaveToken(token, persistentToken)
+            return .SaveToken(token, persistentToken, success: Action.UpdatePersistentTokens)
         }
     }
 
@@ -209,7 +210,7 @@ extension Root {
 
         case .SaveNewToken(let token):
             modal = .None
-            return .AddToken(token)
+            return .AddToken(token, success: Action.UpdatePersistentTokens)
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -208,6 +208,7 @@ extension Root {
         }
     }
 
+    @available(*, deprecated)
     mutating func updateWithPersistentTokens(persistentTokens: [PersistentToken]) {
         tokenList.updateWithPersistentTokens(persistentTokens)
     }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -126,17 +126,17 @@ extension Root {
             modal = .EditForm(form)
             return nil
 
-        case .UpdateToken(let persistentToken):
-            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
-            return .UpdatePersistentToken(persistentToken, success: success)
+        case let .UpdateToken(persistentToken, success):
+            return .UpdatePersistentToken(persistentToken,
+                                          success: compose(success, Action.TokenListAction))
 
-        case let .MoveToken(fromIndex, toIndex):
-            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
-            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex, success: success)
+        case let .MoveToken(fromIndex, toIndex, success):
+            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex,
+                              success: compose(success, Action.TokenListAction))
 
-        case .DeletePersistentToken(let persistentToken):
-            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
-            return .DeletePersistentToken(persistentToken, success: success)
+        case let .DeletePersistentToken(persistentToken, success):
+            return .DeletePersistentToken(persistentToken,
+                                          success: compose(success, Action.TokenListAction))
         }
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -162,7 +162,9 @@ extension Root {
             return nil
 
         case .SaveNewToken(let token):
+            // TODO: Only dismiss the modal if the action succeeds.
             modal = .None
+            // On success, update the token list with the new array of persistent tokens.
             let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
             return .AddToken(token, success: success)
         }
@@ -190,7 +192,9 @@ extension Root {
             return nil
 
         case let .SaveChanges(token, persistentToken):
+            // TODO: Only dismiss the modal if the action succeeds.
             modal = .None
+            // On success, update the token list with the new array of persistent tokens.
             let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
             return .SaveToken(token, persistentToken, success: success)
         }
@@ -208,7 +212,9 @@ extension Root {
             return nil
 
         case .SaveNewToken(let token):
+            // TODO: Only dismiss the modal if the action succeeds.
             modal = .None
+            // On success, update the token list with the new array of persistent tokens.
             let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
             return .AddToken(token, success: success)
         }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -101,7 +101,7 @@ extension Root {
         case .TokenScannerEffect(let effect):
             return handleTokenScannerEffect(effect)
         case .UpdatePersistentTokens(let persistentTokens):
-            tokenList.updateWithPersistentTokens(persistentTokens)
+            tokenList.update(.UpdateWithPersistentTokens(persistentTokens))
             return nil
         }
     }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -77,6 +77,8 @@ extension Root {
         case TokenEditFormAction(TokenEditForm.Action)
 
         case TokenScannerEffect(TokenScannerViewController.Effect)
+
+        case UpdateWithPersistentTokens([PersistentToken])
     }
 
     enum Effect {
@@ -98,6 +100,9 @@ extension Root {
             return handleTokenEditFormAction(action)
         case .TokenScannerEffect(let effect):
             return handleTokenScannerEffect(effect)
+
+        case .UpdateWithPersistentTokens(let persistentTokens):
+            return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
         }
     }
 
@@ -164,9 +169,7 @@ extension Root {
         case .SaveNewToken(let token):
             // TODO: Only dismiss the modal if the action succeeds.
             modal = .None
-            // On success, update the token list with the new array of persistent tokens.
-            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
-            return .AddToken(token, success: success)
+            return .AddToken(token, success: Action.UpdateWithPersistentTokens)
         }
     }
 
@@ -194,9 +197,7 @@ extension Root {
         case let .SaveChanges(token, persistentToken):
             // TODO: Only dismiss the modal if the action succeeds.
             modal = .None
-            // On success, update the token list with the new array of persistent tokens.
-            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
-            return .SaveToken(token, persistentToken, success: success)
+            return .SaveToken(token, persistentToken, success: Action.UpdateWithPersistentTokens)
         }
     }
 
@@ -214,9 +215,7 @@ extension Root {
         case .SaveNewToken(let token):
             // TODO: Only dismiss the modal if the action succeeds.
             modal = .None
-            // On success, update the token list with the new array of persistent tokens.
-            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
-            return .AddToken(token, success: success)
+            return .AddToken(token, success: Action.UpdateWithPersistentTokens)
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -77,8 +77,6 @@ extension Root {
         case TokenEditFormAction(TokenEditForm.Action)
 
         case TokenScannerEffect(TokenScannerViewController.Effect)
-
-        case UpdatePersistentTokens([PersistentToken])
     }
 
     enum Effect {
@@ -100,9 +98,6 @@ extension Root {
             return handleTokenEditFormAction(action)
         case .TokenScannerEffect(let effect):
             return handleTokenScannerEffect(effect)
-        case .UpdatePersistentTokens(let persistentTokens):
-            tokenList.update(.UpdateWithPersistentTokens(persistentTokens))
-            return nil
         }
     }
 
@@ -132,14 +127,16 @@ extension Root {
             return nil
 
         case .UpdateToken(let persistentToken):
-            return .UpdatePersistentToken(persistentToken, success: Action.UpdatePersistentTokens)
+            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
+            return .UpdatePersistentToken(persistentToken, success: success)
 
         case let .MoveToken(fromIndex, toIndex):
-            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex,
-                              success: Action.UpdatePersistentTokens)
+            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
+            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex, success: success)
 
         case .DeletePersistentToken(let persistentToken):
-            return .DeletePersistentToken(persistentToken, success: Action.UpdatePersistentTokens)
+            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
+            return .DeletePersistentToken(persistentToken, success: success)
         }
     }
 
@@ -166,7 +163,8 @@ extension Root {
 
         case .SaveNewToken(let token):
             modal = .None
-            return .AddToken(token, success: Action.UpdatePersistentTokens)
+            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
+            return .AddToken(token, success: success)
         }
     }
 
@@ -193,7 +191,8 @@ extension Root {
 
         case let .SaveChanges(token, persistentToken):
             modal = .None
-            return .SaveToken(token, persistentToken, success: Action.UpdatePersistentTokens)
+            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
+            return .SaveToken(token, persistentToken, success: success)
         }
     }
 
@@ -210,7 +209,12 @@ extension Root {
 
         case .SaveNewToken(let token):
             modal = .None
-            return .AddToken(token, success: Action.UpdatePersistentTokens)
+            let success = compose(TokenList.Action.UpdateWithPersistentTokens, Action.TokenListAction)
+            return .AddToken(token, success: success)
         }
     }
+}
+
+private func compose<A, B, C>(transform: A -> B, _ handler: B -> C) -> A -> C {
+    return { handler(transform($0)) }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -77,6 +77,8 @@ extension Root {
         case TokenEditFormAction(TokenEditForm.Action)
 
         case TokenScannerEffect(TokenScannerViewController.Effect)
+
+        case UpdatePersistentTokens([PersistentToken])
     }
 
     enum Effect {
@@ -98,6 +100,9 @@ extension Root {
             return handleTokenEditFormAction(action)
         case .TokenScannerEffect(let effect):
             return handleTokenScannerEffect(effect)
+        case .UpdatePersistentTokens(let persistentTokens):
+            tokenList.updateWithPersistentTokens(persistentTokens)
+            return nil
         }
     }
 
@@ -206,10 +211,5 @@ extension Root {
             modal = .None
             return .AddToken(token)
         }
-    }
-
-    @available(*, deprecated)
-    mutating func updateWithPersistentTokens(persistentTokens: [PersistentToken]) {
-        tokenList.updateWithPersistentTokens(persistentTokens)
     }
 }

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -39,11 +39,6 @@ struct TokenList: Component {
         ephemeralMessage = nil
     }
 
-    @available(*, deprecated)
-    mutating func updateWithPersistentTokens(persistentTokens: [PersistentToken]) {
-        self.persistentTokens = persistentTokens
-    }
-
     // MARK: View Model
 
     var viewModel: TokenListViewModel {
@@ -96,6 +91,8 @@ extension TokenList {
         // TODO: remove this action and have the component auto-update the view model on time change
         case UpdateViewModel(DisplayTime)
         case DismissEphemeralMessage
+
+        case UpdateWithPersistentTokens([PersistentToken])
     }
 
     enum Effect {
@@ -131,6 +128,10 @@ extension TokenList {
 
         case .DismissEphemeralMessage:
             ephemeralMessage = nil
+            return nil
+
+        case .UpdateWithPersistentTokens(let persistentTokens):
+            self.persistentTokens = persistentTokens
             return nil
         }
     }
@@ -170,6 +171,9 @@ func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
     case (.DismissEphemeralMessage, .DismissEphemeralMessage):
         return true
 
+    case let (.UpdateWithPersistentTokens(l), .UpdateWithPersistentTokens(r)):
+        return l == r
+
     case (.BeginAddToken, _),
          (.EditPersistentToken, _),
          (.UpdatePersistentToken, _),
@@ -177,7 +181,8 @@ func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
          (.DeletePersistentToken, _),
          (.CopyPassword, _),
          (.UpdateViewModel, _),
-         (.DismissEphemeralMessage, _):
+         (.DismissEphemeralMessage, _),
+         (.UpdateWithPersistentTokens, _):
         // Unlike `default`, this final verbose case will cause an error if a new case is added.
         return false
     }

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -99,9 +99,9 @@ extension TokenList {
         case BeginTokenEntry
         case BeginTokenEdit(PersistentToken)
 
-        case UpdateToken(PersistentToken)
-        case MoveToken(fromIndex: Int, toIndex: Int)
-        case DeletePersistentToken(PersistentToken)
+        case UpdateToken(PersistentToken, success: ([PersistentToken]) -> Action)
+        case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
+        case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
     }
 
     @warn_unused_result
@@ -112,11 +112,11 @@ extension TokenList {
         case .EditPersistentToken(let persistentToken):
             return .BeginTokenEdit(persistentToken)
         case .UpdatePersistentToken(let persistentToken):
-            return .UpdateToken(persistentToken)
+            return .UpdateToken(persistentToken, success: Action.UpdateWithPersistentTokens)
         case let .MoveToken(fromIndex, toIndex):
-            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex)
+            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex, success: Action.UpdateWithPersistentTokens)
         case .DeletePersistentToken(let persistentToken):
-            return .DeletePersistentToken(persistentToken)
+            return .DeletePersistentToken(persistentToken, success: Action.UpdateWithPersistentTokens)
 
         case .CopyPassword(let password):
             copyPassword(password)

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -109,14 +109,20 @@ extension TokenList {
         switch action {
         case .BeginAddToken:
             return .BeginTokenEntry
+
         case .EditPersistentToken(let persistentToken):
             return .BeginTokenEdit(persistentToken)
+
         case .UpdatePersistentToken(let persistentToken):
             return .UpdateToken(persistentToken, success: Action.UpdateWithPersistentTokens)
+
         case let .MoveToken(fromIndex, toIndex):
-            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex, success: Action.UpdateWithPersistentTokens)
+            return .MoveToken(fromIndex: fromIndex, toIndex: toIndex,
+                              success: Action.UpdateWithPersistentTokens)
+
         case .DeletePersistentToken(let persistentToken):
-            return .DeletePersistentToken(persistentToken, success: Action.UpdateWithPersistentTokens)
+            return .DeletePersistentToken(persistentToken,
+                                          success: Action.UpdateWithPersistentTokens)
 
         case .CopyPassword(let password):
             copyPassword(password)

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -39,6 +39,7 @@ struct TokenList: Component {
         ephemeralMessage = nil
     }
 
+    @available(*, deprecated)
     mutating func updateWithPersistentTokens(persistentTokens: [PersistentToken]) {
         self.persistentTokens = persistentTokens
     }


### PR DESCRIPTION
 - Replace `updateWithPersistentTokens(_:)` mutating functions with actions
 - Add success callback actions to effects which modify the `TokenStore`