### PR TITLE
Handle Keychain errors

### DIFF
--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -90,9 +90,13 @@ class AppController {
             store.moveTokenFromIndex(fromIndex, toIndex: toIndex)
             handleAction(success(store.persistentTokens))
 
-        case let .DeletePersistentToken(persistentToken, success):
-            store.deletePersistentToken(persistentToken)
-            handleAction(success(store.persistentTokens))
+        case let .DeletePersistentToken(persistentToken, success, failure):
+            do {
+                try store.deletePersistentToken(persistentToken)
+                handleAction(success(store.persistentTokens))
+            } catch {
+                handleAction(failure(error))
+            }
 
         case let .ShowErrorMessage(error):
             SVProgressHUD.showErrorWithStatus("Error: \(error)")

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -70,9 +70,13 @@ class AppController {
                 handleAction(failure(error))
             }
 
-        case let .SaveToken(token, persistentToken, success):
-            store.saveToken(token, toPersistentToken: persistentToken)
-            handleAction(success(store.persistentTokens))
+        case let .SaveToken(token, persistentToken, success, failure):
+            do {
+                try store.saveToken(token, toPersistentToken: persistentToken)
+                handleAction(success(store.persistentTokens))
+            } catch {
+                handleAction(failure(error))
+            }
 
         case let .UpdatePersistentToken(persistentToken, success):
             store.updatePersistentToken(persistentToken)

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -78,9 +78,13 @@ class AppController {
                 handleAction(failure(error))
             }
 
-        case let .UpdatePersistentToken(persistentToken, success):
-            store.updatePersistentToken(persistentToken)
-            handleAction(success(store.persistentTokens))
+        case let .UpdatePersistentToken(persistentToken, success, failure):
+            do {
+                try store.updatePersistentToken(persistentToken)
+                handleAction(success(store.persistentTokens))
+            } catch {
+                handleAction(failure(error))
+            }
 
         case let .MoveToken(fromIndex, toIndex, success):
             store.moveTokenFromIndex(fromIndex, toIndex: toIndex)

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -111,7 +111,7 @@ class AppController {
 
     func addTokenFromURL(token: Token) {
         // TODO: Add Root.Action.AddTokenFromURL
-        handleEffect(.AddToken(token, success: Root.Action.UpdateWithPersistentTokens,
-            failure: Root.Action._AddTokenFailed))
+        handleEffect(.AddToken(token, success: Root.Action.TokenEntrySucceeded,
+            failure: Root.Action.TokenEntryFailed))
     }
 }

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -111,7 +111,7 @@ class AppController {
 
     func addTokenFromURL(token: Token) {
         // TODO: Add Root.Action.AddTokenFromURL
-        handleEffect(.AddToken(token, success: Root.Action.TokenEntrySucceeded,
-            failure: Root.Action.TokenEntryFailed))
+        handleEffect(.AddToken(token, success: Root.Action.TokenFormSucceeded,
+            failure: Root.Action.TokenFormFailed))
     }
 }

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -98,8 +98,8 @@ class AppController {
                 handleAction(failure(error))
             }
 
-        case let .ShowErrorMessage(error):
-            SVProgressHUD.showErrorWithStatus("Error: \(error)")
+        case let .ShowErrorMessage(errorMessage):
+            SVProgressHUD.showErrorWithStatus(errorMessage)
         }
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -92,7 +92,7 @@ extension Root {
         case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
         case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
 
-        case ShowErrorMessage(ErrorType)
+        case ShowErrorMessage(String)
     }
 
     @warn_unused_result
@@ -113,14 +113,16 @@ extension Root {
             // TODO: Scroll to the new token (added at the bottom)
             return handleTokenListAction(.TokenChangeSucceeded(persistentTokens))
         case .TokenEntryFailed(let error):
-            return .ShowErrorMessage(error)
+            // TODO: Better error messages
+            return .ShowErrorMessage("Error: \(error)")
 
         case .TokenEditSucceeded(let persistentTokens):
             // Dismiss the modal edit form.
             modal = .None
             return handleTokenListAction(.TokenChangeSucceeded(persistentTokens))
         case .TokenEditFailed(let error):
-            return .ShowErrorMessage(error)
+            // TODO: Better error messages
+            return .ShowErrorMessage("Error: \(error)")
         }
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -79,14 +79,18 @@ extension Root {
         case TokenScannerEffect(TokenScannerViewController.Effect)
 
         case UpdateWithPersistentTokens([PersistentToken])
+
+        case _AddTokenFailed(ErrorType)
     }
 
     enum Effect {
-        case AddToken(Token, success: ([PersistentToken]) -> Action)
+        case AddToken(Token, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
         case SaveToken(Token, PersistentToken, success: ([PersistentToken]) -> Action)
         case UpdatePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
         case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
         case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
+
+        case ShowErrorMessage(ErrorType)
     }
 
     @warn_unused_result
@@ -103,6 +107,9 @@ extension Root {
 
         case .UpdateWithPersistentTokens(let persistentTokens):
             return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
+
+        case ._AddTokenFailed(let error):
+            return .ShowErrorMessage(error)
         }
     }
 
@@ -169,7 +176,8 @@ extension Root {
         case .SaveNewToken(let token):
             // TODO: Only dismiss the modal if the action succeeds.
             modal = .None
-            return .AddToken(token, success: Action.UpdateWithPersistentTokens)
+            return .AddToken(token, success: Action.UpdateWithPersistentTokens,
+                             failure: Action._AddTokenFailed)
         }
     }
 
@@ -215,7 +223,7 @@ extension Root {
         case .SaveNewToken(let token):
             // TODO: Only dismiss the modal if the action succeeds.
             modal = .None
-            return .AddToken(token, success: Action.UpdateWithPersistentTokens)
+            return .AddToken(token, success: Action.UpdateWithPersistentTokens, failure: Action._AddTokenFailed)
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -81,8 +81,8 @@ extension Root {
         case TokenEntrySucceeded([PersistentToken])
         case TokenEntryFailed(ErrorType)
 
-        case _SaveTokenSucceeded([PersistentToken])
-        case _SaveTokenFailed(ErrorType)
+        case TokenEditSucceeded([PersistentToken])
+        case TokenEditFailed(ErrorType)
     }
 
     enum Effect {
@@ -115,11 +115,11 @@ extension Root {
         case .TokenEntryFailed(let error):
             return .ShowErrorMessage(error)
 
-        case ._SaveTokenSucceeded(let persistentTokens):
+        case .TokenEditSucceeded(let persistentTokens):
             // Dismiss the modal edit form.
             modal = .None
             return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
-        case ._SaveTokenFailed(let error):
+        case .TokenEditFailed(let error):
             return .ShowErrorMessage(error)
         }
     }
@@ -219,8 +219,8 @@ extension Root {
 
         case let .SaveChanges(token, persistentToken):
             return .SaveToken(token, persistentToken,
-                              success: Action._SaveTokenSucceeded,
-                              failure: Action._SaveTokenFailed)
+                              success: Action.TokenEditSucceeded,
+                              failure: Action.TokenEditFailed)
         }
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -239,7 +239,9 @@ extension Root {
             return nil
 
         case .SaveNewToken(let token):
-            return .AddToken(token, success: Action.TokenFormSucceeded, failure: Action.TokenFormFailed)
+            return .AddToken(token,
+                             success: Action.TokenFormSucceeded,
+                             failure: Action.TokenFormFailed)
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -92,7 +92,7 @@ extension Root {
         case SaveToken(Token, PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
         case UpdatePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
         case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
-        case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
+        case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
 
         case ShowErrorMessage(ErrorType)
     }
@@ -163,9 +163,10 @@ extension Root {
             return .MoveToken(fromIndex: fromIndex, toIndex: toIndex,
                               success: compose(success, Action.TokenListAction))
 
-        case let .DeletePersistentToken(persistentToken, success):
+        case let .DeletePersistentToken(persistentToken, success, failure):
             return .DeletePersistentToken(persistentToken,
-                                          success: compose(success, Action.TokenListAction))
+                                          success: compose(success, Action.TokenListAction),
+                                          failure: compose(failure, Action.TokenListAction))
 
         case .ShowErrorMessage(let error):
             return .ShowErrorMessage(error)

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -83,11 +83,24 @@ extension Root {
     }
 
     enum Effect {
-        case AddToken(Token, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
-        case SaveToken(Token, PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
-        case UpdatePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
-        case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
-        case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
+        case AddToken(Token,
+            success: ([PersistentToken]) -> Action,
+            failure: (ErrorType) -> Action)
+
+        case SaveToken(Token, PersistentToken,
+            success: ([PersistentToken]) -> Action,
+            failure: (ErrorType) -> Action)
+
+        case UpdatePersistentToken(PersistentToken,
+            success: ([PersistentToken]) -> Action,
+            failure: (ErrorType) -> Action)
+
+        case MoveToken(fromIndex: Int, toIndex: Int,
+            success: ([PersistentToken]) -> Action)
+
+        case DeletePersistentToken(PersistentToken,
+            success: ([PersistentToken]) -> Action,
+            failure: (ErrorType) -> Action)
 
         case ShowErrorMessage(String)
     }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -90,7 +90,7 @@ extension Root {
     enum Effect {
         case AddToken(Token, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
         case SaveToken(Token, PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
-        case UpdatePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
+        case UpdatePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
         case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
         case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
 
@@ -154,9 +154,10 @@ extension Root {
             modal = .EditForm(form)
             return nil
 
-        case let .UpdateToken(persistentToken, success):
+        case let .UpdateToken(persistentToken, success, failure):
             return .UpdatePersistentToken(persistentToken,
-                                          success: compose(success, Action.TokenListAction))
+                                          success: compose(success, Action.TokenListAction),
+                                          failure: compose(failure, Action.TokenListAction))
 
         case let .MoveToken(fromIndex, toIndex, success):
             return .MoveToken(fromIndex: fromIndex, toIndex: toIndex,
@@ -165,6 +166,9 @@ extension Root {
         case let .DeletePersistentToken(persistentToken, success):
             return .DeletePersistentToken(persistentToken,
                                           success: compose(success, Action.TokenListAction))
+
+        case .ShowErrorMessage(let error):
+            return .ShowErrorMessage(error)
         }
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -78,10 +78,8 @@ extension Root {
 
         case TokenScannerEffect(TokenScannerViewController.Effect)
 
-        case UpdateWithPersistentTokens([PersistentToken])
-
-        case _AddTokenSucceeded([PersistentToken])
-        case _AddTokenFailed(ErrorType)
+        case TokenEntrySucceeded([PersistentToken])
+        case TokenEntryFailed(ErrorType)
 
         case _SaveTokenSucceeded([PersistentToken])
         case _SaveTokenFailed(ErrorType)
@@ -109,15 +107,12 @@ extension Root {
         case .TokenScannerEffect(let effect):
             return handleTokenScannerEffect(effect)
 
-        case .UpdateWithPersistentTokens(let persistentTokens):
-            return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
-
-        case ._AddTokenSucceeded(let persistentTokens):
+        case .TokenEntrySucceeded(let persistentTokens):
             // Dismiss the modal entry form.
             modal = .None
             // TODO: Scroll to the new token (added at the bottom)
             return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
-        case ._AddTokenFailed(let error):
+        case .TokenEntryFailed(let error):
             return .ShowErrorMessage(error)
 
         case ._SaveTokenSucceeded(let persistentTokens):
@@ -196,8 +191,8 @@ extension Root {
 
         case .SaveNewToken(let token):
             return .AddToken(token,
-                             success: Action._AddTokenSucceeded,
-                             failure: Action._AddTokenFailed)
+                             success: Action.TokenEntrySucceeded,
+                             failure: Action.TokenEntryFailed)
         }
     }
 
@@ -241,9 +236,7 @@ extension Root {
             return nil
 
         case .SaveNewToken(let token):
-            // TODO: Only dismiss the modal if the action succeeds.
-            modal = .None
-            return .AddToken(token, success: Action.UpdateWithPersistentTokens, failure: Action._AddTokenFailed)
+            return .AddToken(token, success: Action.TokenEntrySucceeded, failure: Action.TokenEntryFailed)
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -111,14 +111,14 @@ extension Root {
             // Dismiss the modal entry form.
             modal = .None
             // TODO: Scroll to the new token (added at the bottom)
-            return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
+            return handleTokenListAction(.TokenChangeSucceeded(persistentTokens))
         case .TokenEntryFailed(let error):
             return .ShowErrorMessage(error)
 
         case .TokenEditSucceeded(let persistentTokens):
             // Dismiss the modal edit form.
             modal = .None
-            return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
+            return handleTokenListAction(.TokenChangeSucceeded(persistentTokens))
         case .TokenEditFailed(let error):
             return .ShowErrorMessage(error)
         }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -80,6 +80,7 @@ extension Root {
 
         case UpdateWithPersistentTokens([PersistentToken])
 
+        case _AddTokenSucceeded([PersistentToken])
         case _AddTokenFailed(ErrorType)
     }
 
@@ -108,6 +109,11 @@ extension Root {
         case .UpdateWithPersistentTokens(let persistentTokens):
             return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
 
+        case ._AddTokenSucceeded(let persistentTokens):
+            // Dismiss the modal entry form.
+            modal = .None
+            // TODO: Scroll to the new token (added at the bottom)
+            return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
         case ._AddTokenFailed(let error):
             return .ShowErrorMessage(error)
         }
@@ -174,9 +180,8 @@ extension Root {
             return nil
 
         case .SaveNewToken(let token):
-            // TODO: Only dismiss the modal if the action succeeds.
-            modal = .None
-            return .AddToken(token, success: Action.UpdateWithPersistentTokens,
+            return .AddToken(token,
+                             success: Action._AddTokenSucceeded,
                              failure: Action._AddTokenFailed)
         }
     }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -78,11 +78,8 @@ extension Root {
 
         case TokenScannerEffect(TokenScannerViewController.Effect)
 
-        case TokenEntrySucceeded([PersistentToken])
-        case TokenEntryFailed(ErrorType)
-
-        case TokenEditSucceeded([PersistentToken])
-        case TokenEditFailed(ErrorType)
+        case TokenFormSucceeded([PersistentToken])
+        case TokenFormFailed(ErrorType)
     }
 
     enum Effect {
@@ -107,19 +104,11 @@ extension Root {
         case .TokenScannerEffect(let effect):
             return handleTokenScannerEffect(effect)
 
-        case .TokenEntrySucceeded(let persistentTokens):
-            // Dismiss the modal entry form.
+        case .TokenFormSucceeded(let persistentTokens):
+            // Dismiss the modal form.
             modal = .None
             return handleTokenListAction(.TokenChangeSucceeded(persistentTokens))
-        case .TokenEntryFailed(let error):
-            // TODO: Better error messages
-            return .ShowErrorMessage("Error: \(error)")
-
-        case .TokenEditSucceeded(let persistentTokens):
-            // Dismiss the modal edit form.
-            modal = .None
-            return handleTokenListAction(.TokenChangeSucceeded(persistentTokens))
-        case .TokenEditFailed(let error):
+        case .TokenFormFailed(let error):
             // TODO: Better error messages
             return .ShowErrorMessage("Error: \(error)")
         }
@@ -192,8 +181,8 @@ extension Root {
 
         case .SaveNewToken(let token):
             return .AddToken(token,
-                             success: Action.TokenEntrySucceeded,
-                             failure: Action.TokenEntryFailed)
+                             success: Action.TokenFormSucceeded,
+                             failure: Action.TokenFormFailed)
         }
     }
 
@@ -220,8 +209,8 @@ extension Root {
 
         case let .SaveChanges(token, persistentToken):
             return .SaveToken(token, persistentToken,
-                              success: Action.TokenEditSucceeded,
-                              failure: Action.TokenEditFailed)
+                              success: Action.TokenFormSucceeded,
+                              failure: Action.TokenFormFailed)
         }
     }
 
@@ -237,7 +226,7 @@ extension Root {
             return nil
 
         case .SaveNewToken(let token):
-            return .AddToken(token, success: Action.TokenEntrySucceeded, failure: Action.TokenEntryFailed)
+            return .AddToken(token, success: Action.TokenFormSucceeded, failure: Action.TokenFormFailed)
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -82,11 +82,14 @@ extension Root {
 
         case _AddTokenSucceeded([PersistentToken])
         case _AddTokenFailed(ErrorType)
+
+        case _SaveTokenSucceeded([PersistentToken])
+        case _SaveTokenFailed(ErrorType)
     }
 
     enum Effect {
         case AddToken(Token, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
-        case SaveToken(Token, PersistentToken, success: ([PersistentToken]) -> Action)
+        case SaveToken(Token, PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
         case UpdatePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
         case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
         case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
@@ -115,6 +118,13 @@ extension Root {
             // TODO: Scroll to the new token (added at the bottom)
             return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
         case ._AddTokenFailed(let error):
+            return .ShowErrorMessage(error)
+
+        case ._SaveTokenSucceeded(let persistentTokens):
+            // Dismiss the modal edit form.
+            modal = .None
+            return handleTokenListAction(.UpdateWithPersistentTokens(persistentTokens))
+        case ._SaveTokenFailed(let error):
             return .ShowErrorMessage(error)
         }
     }
@@ -208,9 +218,9 @@ extension Root {
             return nil
 
         case let .SaveChanges(token, persistentToken):
-            // TODO: Only dismiss the modal if the action succeeds.
-            modal = .None
-            return .SaveToken(token, persistentToken, success: Action.UpdateWithPersistentTokens)
+            return .SaveToken(token, persistentToken,
+                              success: Action._SaveTokenSucceeded,
+                              failure: Action._SaveTokenFailed)
         }
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -110,7 +110,6 @@ extension Root {
         case .TokenEntrySucceeded(let persistentTokens):
             // Dismiss the modal entry form.
             modal = .None
-            // TODO: Scroll to the new token (added at the bottom)
             return handleTokenListAction(.TokenChangeSucceeded(persistentTokens))
         case .TokenEntryFailed(let error):
             // TODO: Better error messages

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -102,7 +102,7 @@ extension TokenList {
 
         case UpdateToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
         case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
-        case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action)
+        case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
 
         case ShowErrorMessage(ErrorType)
     }
@@ -126,7 +126,8 @@ extension TokenList {
 
         case .DeletePersistentToken(let persistentToken):
             return .DeletePersistentToken(persistentToken,
-                                          success: Action.UpdateWithPersistentTokens)
+                                          success: Action.UpdateWithPersistentTokens,
+                                          failure: Action._TokenChangeFailed)
 
         case .CopyPassword(let password):
             copyPassword(password)

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -104,7 +104,7 @@ extension TokenList {
         case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
         case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
 
-        case ShowErrorMessage(ErrorType)
+        case ShowErrorMessage(String)
     }
 
     @warn_unused_result
@@ -146,7 +146,8 @@ extension TokenList {
             return nil
 
         case .TokenChangeFailed(let error):
-            return .ShowErrorMessage(error)
+            // TODO: Better error messages
+            return .ShowErrorMessage("Error: \(error)")
         }
     }
 

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -100,9 +100,16 @@ extension TokenList {
         case BeginTokenEntry
         case BeginTokenEdit(PersistentToken)
 
-        case UpdateToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
-        case MoveToken(fromIndex: Int, toIndex: Int, success: ([PersistentToken]) -> Action)
-        case DeletePersistentToken(PersistentToken, success: ([PersistentToken]) -> Action, failure: (ErrorType) -> Action)
+        case UpdateToken(PersistentToken,
+            success: ([PersistentToken]) -> Action,
+            failure: (ErrorType) -> Action)
+
+        case MoveToken(fromIndex: Int, toIndex: Int,
+            success: ([PersistentToken]) -> Action)
+
+        case DeletePersistentToken(PersistentToken,
+            success: ([PersistentToken]) -> Action,
+            failure: (ErrorType) -> Action)
 
         case ShowErrorMessage(String)
     }

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -92,8 +92,8 @@ extension TokenList {
         case UpdateViewModel(DisplayTime)
         case DismissEphemeralMessage
 
-        case UpdateWithPersistentTokens([PersistentToken])
-        case _TokenChangeFailed(ErrorType)
+        case TokenChangeSucceeded([PersistentToken])
+        case TokenChangeFailed(ErrorType)
     }
 
     enum Effect {
@@ -117,17 +117,17 @@ extension TokenList {
             return .BeginTokenEdit(persistentToken)
 
         case .UpdatePersistentToken(let persistentToken):
-            return .UpdateToken(persistentToken, success: Action.UpdateWithPersistentTokens,
-                                failure: Action._TokenChangeFailed)
+            return .UpdateToken(persistentToken, success: Action.TokenChangeSucceeded,
+                                failure: Action.TokenChangeFailed)
 
         case let .MoveToken(fromIndex, toIndex):
             return .MoveToken(fromIndex: fromIndex, toIndex: toIndex,
-                              success: Action.UpdateWithPersistentTokens)
+                              success: Action.TokenChangeSucceeded)
 
         case .DeletePersistentToken(let persistentToken):
             return .DeletePersistentToken(persistentToken,
-                                          success: Action.UpdateWithPersistentTokens,
-                                          failure: Action._TokenChangeFailed)
+                                          success: Action.TokenChangeSucceeded,
+                                          failure: Action.TokenChangeFailed)
 
         case .CopyPassword(let password):
             copyPassword(password)
@@ -141,11 +141,11 @@ extension TokenList {
             ephemeralMessage = nil
             return nil
 
-        case .UpdateWithPersistentTokens(let persistentTokens):
+        case .TokenChangeSucceeded(let persistentTokens):
             self.persistentTokens = persistentTokens
             return nil
 
-        case ._TokenChangeFailed(let error):
+        case .TokenChangeFailed(let error):
             return .ShowErrorMessage(error)
         }
     }
@@ -185,10 +185,10 @@ func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
     case (.DismissEphemeralMessage, .DismissEphemeralMessage):
         return true
 
-    case let (.UpdateWithPersistentTokens(l), .UpdateWithPersistentTokens(r)):
+    case let (.TokenChangeSucceeded(l), .TokenChangeSucceeded(r)):
         return l == r
 
-    case (._TokenChangeFailed(_), ._TokenChangeFailed(_)):
+    case (.TokenChangeFailed(_), .TokenChangeFailed(_)):
         return false // FIXME
 
     case (.BeginAddToken, _),
@@ -199,8 +199,8 @@ func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
          (.CopyPassword, _),
          (.UpdateViewModel, _),
          (.DismissEphemeralMessage, _),
-         (.UpdateWithPersistentTokens, _),
-         (._TokenChangeFailed, _):
+         (.TokenChangeSucceeded, _),
+         (.TokenChangeFailed, _):
         // Unlike `default`, this final verbose case will cause an error if a new case is added.
         return false
     }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -199,6 +199,7 @@ extension TokenListViewController {
     }
 
     private func updateTableViewWithChanges(changes: [Change]) {
+        // TODO: Scroll to a newly added token (added at the bottom)
         if changes.isEmpty || preventTableViewAnimations {
             return
         }

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -75,25 +75,25 @@ extension TokenStore {
         saveTokenOrder()
     }
 
-    func saveToken(token: Token, toPersistentToken persistentToken: PersistentToken) {
-        do {
-            let updatedPersistentToken = try keychain.updatePersistentToken(persistentToken,
-                withToken: token)
-            // Update the in-memory token, which is still the origin of the table view's data
-            persistentTokens = persistentTokens.map {
-                if $0.identifier == updatedPersistentToken.identifier {
-                    return updatedPersistentToken
-                }
-                return $0
+    func saveToken(token: Token, toPersistentToken persistentToken: PersistentToken) throws {
+        let updatedPersistentToken = try keychain.updatePersistentToken(persistentToken,
+                                                                        withToken: token)
+        // Update the in-memory token, which is still the origin of the table view's data
+        persistentTokens = persistentTokens.map {
+            if $0.identifier == updatedPersistentToken.identifier {
+                return updatedPersistentToken
             }
-        } catch {
-            // TODO: Handle the updatePersistentToken(_:withToken:) failure
+            return $0
         }
     }
 
     func updatePersistentToken(persistentToken: PersistentToken) {
         let newToken = persistentToken.token.updatedToken()
-        saveToken(newToken, toPersistentToken: persistentToken)
+        do {
+            try saveToken(newToken, toPersistentToken: persistentToken)
+        } catch {
+            // FIXME: handle errors
+        }
     }
 
     func moveTokenFromIndex(origin: Int, toIndex destination: Int) {

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -99,16 +99,12 @@ extension TokenStore {
         saveTokenOrder()
     }
 
-    func deletePersistentToken(persistentToken: PersistentToken) {
-        do {
-            try keychain.deletePersistentToken(persistentToken)
-            if let index = persistentTokens.indexOf(persistentToken) {
-                persistentTokens.removeAtIndex(index)
-            }
-            saveTokenOrder()
-        } catch {
-            // TODO: Handle the deletePersistentToken(_:) failure
+    func deletePersistentToken(persistentToken: PersistentToken) throws {
+        try keychain.deletePersistentToken(persistentToken)
+        if let index = persistentTokens.indexOf(persistentToken) {
+            persistentTokens.removeAtIndex(index)
         }
+        saveTokenOrder()
     }
 }
 

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -73,7 +73,6 @@ extension TokenStore {
         let newPersistentToken = try keychain.addToken(token)
         persistentTokens.append(newPersistentToken)
         saveTokenOrder()
-        // TODO: Scroll to the new token (added at the bottom)
     }
 
     func saveToken(token: Token, toPersistentToken persistentToken: PersistentToken) {

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -69,15 +69,11 @@ class TokenStore {
 extension TokenStore {
     // MARK: Actions
 
-    func addToken(token: Token) {
-        do {
-            let newPersistentToken = try keychain.addToken(token)
-            persistentTokens.append(newPersistentToken)
-            saveTokenOrder()
-            // TODO: Scroll to the new token (added at the bottom)
-        } catch {
-            // TODO: Handle the addToken(_:) failure
-        }
+    func addToken(token: Token) throws {
+        let newPersistentToken = try keychain.addToken(token)
+        persistentTokens.append(newPersistentToken)
+        saveTokenOrder()
+        // TODO: Scroll to the new token (added at the bottom)
     }
 
     func saveToken(token: Token, toPersistentToken persistentToken: PersistentToken) {

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -87,13 +87,9 @@ extension TokenStore {
         }
     }
 
-    func updatePersistentToken(persistentToken: PersistentToken) {
+    func updatePersistentToken(persistentToken: PersistentToken) throws {
         let newToken = persistentToken.token.updatedToken()
-        do {
-            try saveToken(newToken, toPersistentToken: persistentToken)
-        } catch {
-            // FIXME: handle errors
-        }
+        try saveToken(newToken, toPersistentToken: persistentToken)
     }
 
     func moveTokenFromIndex(origin: Int, toIndex destination: Int) {

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -119,6 +119,6 @@ private extension NSUserDefaults {
 
     func savePersistentIdentifiers(identifiers: [NSData]) {
         setObject(identifiers, forKey: kOTPKeychainEntriesArray)
-        synchronize()
+        synchronize() // TODO: Remove call to deprecated synchronize()
     }
 }


### PR DESCRIPTION
 - Add failure callback actions to effects which mutate the keychain.
 - Catch errors thrown from the keychain and handle them with the failure actions.
 - Add error message effects and present ephemeral error messages from the `AppController`.