### PR TITLE
Route ephemeral messages via effects

### DIFF
--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -100,6 +100,9 @@ class AppController {
 
         case let .ShowErrorMessage(errorMessage):
             SVProgressHUD.showErrorWithStatus(errorMessage)
+
+        case let .ShowSuccessMessage(message):
+            SVProgressHUD.showSuccessWithStatus(message)
         }
     }
 

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -98,8 +98,8 @@ class AppController {
                 handleAction(failure(error))
             }
 
-        case let .ShowErrorMessage(errorMessage):
-            SVProgressHUD.showErrorWithStatus(errorMessage)
+        case let .ShowErrorMessage(message):
+            SVProgressHUD.showErrorWithStatus(message)
 
         case let .ShowSuccessMessage(message):
             SVProgressHUD.showSuccessWithStatus(message)

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -200,6 +200,9 @@ extension Root {
             return .AddToken(token,
                              success: Action.TokenFormSucceeded,
                              failure: Action.TokenFormFailed)
+
+        case .ShowErrorMessage(let message):
+            return .ShowErrorMessage(message)
         }
     }
 
@@ -228,6 +231,9 @@ extension Root {
             return .SaveToken(token, persistentToken,
                               success: Action.TokenFormSucceeded,
                               failure: Action.TokenFormFailed)
+
+        case .ShowErrorMessage(let message):
+            return .ShowErrorMessage(message)
         }
     }
 

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -103,6 +103,7 @@ extension Root {
             failure: (ErrorType) -> Action)
 
         case ShowErrorMessage(String)
+        case ShowSuccessMessage(String)
     }
 
     @warn_unused_result
@@ -166,8 +167,11 @@ extension Root {
                                           success: compose(success, Action.TokenListAction),
                                           failure: compose(failure, Action.TokenListAction))
 
-        case .ShowErrorMessage(let error):
-            return .ShowErrorMessage(error)
+        case .ShowErrorMessage(let message):
+            return .ShowErrorMessage(message)
+
+        case .ShowSuccessMessage(let message):
+            return .ShowSuccessMessage(message)
         }
     }
 

--- a/Authenticator/Source/TableViewModel.swift
+++ b/Authenticator/Source/TableViewModel.swift
@@ -37,23 +37,17 @@ struct TableViewModel<Models: TableViewModelRepresentable> {
     var rightBarButton: BarButtonViewModel<Models.Action>?
     var sections: [Section<Models.HeaderModel, Models.RowModel>]
     var doneKeyAction: Models.Action
-    var dismissMessageAction: Models.Action
-    var errorMessage: String?
 
     init(title: String,
         leftBarButton: BarButtonViewModel<Models.Action>? = nil,
         rightBarButton: BarButtonViewModel<Models.Action>? = nil,
         sections: [Section<Models.HeaderModel, Models.RowModel>],
-        doneKeyAction: Models.Action,
-        dismissMessageAction: Models.Action,
-        errorMessage: String? = nil) {
+        doneKeyAction: Models.Action) {
             self.title = title
             self.leftBarButton = leftBarButton
             self.rightBarButton = rightBarButton
             self.sections = sections
             self.doneKeyAction = doneKeyAction
-            self.dismissMessageAction = dismissMessageAction
-            self.errorMessage = errorMessage
     }
 }
 

--- a/Authenticator/Source/TokenEditForm.swift
+++ b/Authenticator/Source/TokenEditForm.swift
@@ -31,8 +31,6 @@ struct TokenEditForm: Component {
     private var issuer: String
     private var name: String
 
-    private var submitFailed: Bool = false
-
     private var isValid: Bool {
         return !(issuer.isEmpty && name.isEmpty)
     }
@@ -54,8 +52,6 @@ extension TokenEditForm: TableViewModelRepresentable {
         case Name(String)
         case Cancel
         case Submit
-
-        case DismissEphemeralMessage
     }
 
     typealias HeaderModel = TokenFormHeaderModel<Action>
@@ -78,9 +74,7 @@ extension TokenEditForm {
                     nameRowModel,
                 ]
             ],
-            doneKeyAction: .Submit,
-            dismissMessageAction: .DismissEphemeralMessage,
-            errorMessage: submitFailed ? "Invalid Token" : nil
+            doneKeyAction: .Submit
         )
     }
 
@@ -112,6 +106,7 @@ extension TokenEditForm {
     enum Effect {
         case Cancel
         case SaveChanges(Token, PersistentToken)
+        case ShowErrorMessage(String)
     }
 
     @warn_unused_result
@@ -125,8 +120,6 @@ extension TokenEditForm {
             return .Cancel
         case .Submit:
             return submit()
-        case .DismissEphemeralMessage:
-            submitFailed = false
         }
         return nil
     }
@@ -134,8 +127,7 @@ extension TokenEditForm {
     @warn_unused_result
     private mutating func submit() -> Effect? {
         guard isValid else {
-            submitFailed = true
-            return nil
+            return .ShowErrorMessage("Invalid Token")
         }
 
         let token = Token(

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -24,7 +24,6 @@
 //
 
 import UIKit
-import SVProgressHUD
 
 class TokenFormViewController<Form: TableViewModelRepresentable where Form.HeaderModel == TokenFormHeaderModel<Form.Action>, Form.RowModel == TokenFormRowModel<Form.Action>>: UITableViewController {
     private let dispatchAction: (Form.Action) -> ()
@@ -302,10 +301,6 @@ extension TokenFormViewController {
     func updateWithViewModel(viewModel: TableViewModel<Form>) {
         self.viewModel = viewModel
         updateBarButtonItems()
-        if let errorMessage = viewModel.errorMessage {
-            SVProgressHUD.showErrorWithStatus(errorMessage)
-            dispatchAction(viewModel.dismissMessageAction)
-        }
     }
 }
 

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -31,12 +31,10 @@ import OneTimePassword
 struct TokenList: Component {
     private var persistentTokens: [PersistentToken]
     private var displayTime: DisplayTime
-    private var ephemeralMessage: EphemeralMessage?
 
     init(persistentTokens: [PersistentToken], displayTime: DisplayTime) {
         self.persistentTokens = persistentTokens
         self.displayTime = displayTime
-        ephemeralMessage = nil
     }
 
     // MARK: View Model
@@ -47,8 +45,7 @@ struct TokenList: Component {
         })
         return TokenListViewModel(
             rowModels: rowModels,
-            ringProgress: ringProgress,
-            ephemeralMessage: ephemeralMessage
+            ringProgress: ringProgress
         )
     }
 
@@ -90,7 +87,6 @@ extension TokenList {
         case CopyPassword(String)
         // TODO: remove this action and have the component auto-update the view model on time change
         case UpdateViewModel(DisplayTime)
-        case DismissEphemeralMessage
 
         case TokenChangeSucceeded([PersistentToken])
         case TokenChangeFailed(ErrorType)
@@ -112,6 +108,7 @@ extension TokenList {
             failure: (ErrorType) -> Action)
 
         case ShowErrorMessage(String)
+        case ShowSuccessMessage(String)
     }
 
     @warn_unused_result
@@ -137,15 +134,10 @@ extension TokenList {
                                           failure: Action.TokenChangeFailed)
 
         case .CopyPassword(let password):
-            copyPassword(password)
-            return nil
+            return copyPassword(password)
 
         case .UpdateViewModel(let displayTime):
             self.displayTime = displayTime
-            return nil
-
-        case .DismissEphemeralMessage:
-            ephemeralMessage = nil
             return nil
 
         case .TokenChangeSucceeded(let persistentTokens):
@@ -158,11 +150,11 @@ extension TokenList {
         }
     }
 
-    private mutating func copyPassword(password: String) {
+    private mutating func copyPassword(password: String) -> Effect {
         let pasteboard = UIPasteboard.generalPasteboard()
         pasteboard.setValue(password, forPasteboardType: kUTTypeUTF8PlainText as String)
         // Show an ephemeral success message in the view
-        ephemeralMessage = .Success("Copied")
+        return .ShowSuccessMessage("Copied")
     }
 }
 
@@ -190,9 +182,6 @@ func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
     case let (.UpdateViewModel(l), .UpdateViewModel(r)):
         return l == r
 
-    case (.DismissEphemeralMessage, .DismissEphemeralMessage):
-        return true
-
     case let (.TokenChangeSucceeded(l), .TokenChangeSucceeded(r)):
         return l == r
 
@@ -206,7 +195,6 @@ func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
          (.DeletePersistentToken, _),
          (.CopyPassword, _),
          (.UpdateViewModel, _),
-         (.DismissEphemeralMessage, _),
          (.TokenChangeSucceeded, _),
          (.TokenChangeFailed, _):
         // Unlike `default`, this final verbose case will cause an error if a new case is added.

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -153,7 +153,7 @@ extension TokenList {
     private mutating func copyPassword(password: String) -> Effect {
         let pasteboard = UIPasteboard.generalPasteboard()
         pasteboard.setValue(password, forPasteboardType: kUTTypeUTF8PlainText as String)
-        // Show an ephemeral success message in the view
+        // Show an ephemeral success message.
         return .ShowSuccessMessage("Copied")
     }
 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -24,7 +24,6 @@
 //
 
 import UIKit
-import SVProgressHUD
 
 class TokenListViewController: UITableViewController {
     private let dispatchAction: (TokenList.Action) -> ()
@@ -186,16 +185,6 @@ extension TokenListViewController {
         self.viewModel = viewModel
         updateTableViewWithChanges(changes)
         updatePeripheralViews()
-        // Show ephemeral message
-        if let ephemeralMessage = viewModel.ephemeralMessage {
-            switch ephemeralMessage {
-            case .Success(let message):
-                SVProgressHUD.showSuccessWithStatus(message)
-            case .Error(let message):
-                SVProgressHUD.showErrorWithStatus(message)
-            }
-            dispatchAction(.DismissEphemeralMessage)
-        }
     }
 
     private func updateTableViewWithChanges(changes: [Change]) {

--- a/Authenticator/Source/TokenListViewModel.swift
+++ b/Authenticator/Source/TokenListViewModel.swift
@@ -28,10 +28,4 @@ import Foundation
 struct TokenListViewModel {
     let rowModels: [TokenRowModel]
     let ringProgress: Double?
-    let ephemeralMessage: EphemeralMessage?
-}
-
-enum EphemeralMessage {
-    case Success(String)
-    case Error(String)
 }


### PR DESCRIPTION
Instead of handling the display of ephemeral success/failure messages separately in each component/view controller, route ephemeral messages via effects to the `AppController`.