### PR TITLE
Remove view model equatability

### DIFF
--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -44,7 +44,7 @@ class TokenFormViewController<Form: TableViewModelRepresentable where Form.Heade
                     case .Insert(let rowIndex):
                         let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                         tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-                    case let .Update(rowIndex, _):
+                    case let .Update(_, rowIndex):
                         let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                         updateRowAtIndexPath(indexPath)
                     case .Delete(let rowIndex):

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -76,7 +76,7 @@ struct TokenList: Component {
 }
 
 extension TokenList {
-    enum Action: Equatable {
+    enum Action {
         case BeginAddToken
         case EditPersistentToken(PersistentToken)
 
@@ -155,49 +155,5 @@ extension TokenList {
         pasteboard.setValue(password, forPasteboardType: kUTTypeUTF8PlainText as String)
         // Show an ephemeral success message.
         return .ShowSuccessMessage("Copied")
-    }
-}
-
-func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
-    switch (lhs, rhs) {
-    case (.BeginAddToken, .BeginAddToken):
-        return true
-
-    case let (.EditPersistentToken(l), .EditPersistentToken(r)):
-        return l == r
-
-    case let (.UpdatePersistentToken(l), .UpdatePersistentToken(r)):
-        return l == r
-
-    case let (.MoveToken(l), .MoveToken(r)):
-        return l.fromIndex == r.fromIndex
-            && l.toIndex == r.toIndex
-
-    case let (.DeletePersistentToken(l), .DeletePersistentToken(r)):
-        return l == r
-
-    case let (.CopyPassword(l), .CopyPassword(r)):
-        return l == r
-
-    case let (.UpdateViewModel(l), .UpdateViewModel(r)):
-        return l == r
-
-    case let (.TokenChangeSucceeded(l), .TokenChangeSucceeded(r)):
-        return l == r
-
-    case (.TokenChangeFailed(_), .TokenChangeFailed(_)):
-        return false // FIXME
-
-    case (.BeginAddToken, _),
-         (.EditPersistentToken, _),
-         (.UpdatePersistentToken, _),
-         (.MoveToken, _),
-         (.DeletePersistentToken, _),
-         (.CopyPassword, _),
-         (.UpdateViewModel, _),
-         (.TokenChangeSucceeded, _),
-         (.TokenChangeFailed, _):
-        // Unlike `default`, this final verbose case will cause an error if a new case is added.
-        return false
     }
 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -200,7 +200,7 @@ extension TokenListViewController {
             case .Insert(let rowIndex):
                 let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                 tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-            case let .Update(rowIndex, _):
+            case let .Update(_, rowIndex):
                 let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)

--- a/Authenticator/Source/TokenRowCell.swift
+++ b/Authenticator/Source/TokenRowCell.swift
@@ -94,10 +94,8 @@ class TokenRowCell: UITableViewCell {
     // MARK: - Update
 
     func updateWithRowModel(rowModel: TokenRowModel) {
-        if self.rowModel != rowModel {
-            updateAppearanceWithRowModel(rowModel)
-            self.rowModel = rowModel
-        }
+        updateAppearanceWithRowModel(rowModel)
+        self.rowModel = rowModel
     }
 
     private func updateAppearanceWithRowModel(rowModel: TokenRowModel?) {

--- a/Authenticator/Source/TokenRowModel.swift
+++ b/Authenticator/Source/TokenRowModel.swift
@@ -26,7 +26,7 @@
 import Foundation
 import OneTimePassword
 
-struct TokenRowModel: Equatable, Identifiable {
+struct TokenRowModel: Identifiable {
     typealias Action = TokenList.Action
 
     let name, issuer, password: String
@@ -58,16 +58,4 @@ struct TokenRowModel: Equatable, Identifiable {
     func hasSameIdentity(other: TokenRowModel) -> Bool {
         return self.identifier.isEqualToData(other.identifier)
     }
-}
-
-func == (lhs: TokenRowModel, rhs: TokenRowModel) -> Bool {
-    return (lhs.name == rhs.name)
-        && (lhs.issuer == rhs.issuer)
-        && (lhs.password == rhs.password)
-        && (lhs.showsButton == rhs.showsButton)
-        && (lhs.buttonAction == rhs.buttonAction)
-        && (lhs.selectAction == rhs.selectAction)
-        && (lhs.editAction == rhs.editAction)
-        && (lhs.deleteAction == rhs.deleteAction)
-        && (lhs.identifier == rhs.identifier)
 }


### PR DESCRIPTION
Remove `Equatable` conformance from `TokenList.Action` and `TokenRowModel`. These `==` implementations were verbose, difficult to maintain, and incorrect for enum cases with non-equatable associated values.

The equality comparisons provided a small optimization to diffing and updating the token list table view, but performance of the new code is not measurably worse than the old.