### PR TITLE
Remove unnecessary UITextFieldDelegate shim

### DIFF
--- a/Authenticator/Source/TextFieldRow.swift
+++ b/Authenticator/Source/TextFieldRow.swift
@@ -120,7 +120,9 @@ class TextFieldRowCell<Action>: UITableViewCell, UITextFieldDelegate {
     // MARK: - UITextFieldDelegate
 
     func textFieldShouldReturn(textField: UITextField) -> Bool {
-        delegate?.textFieldCellDidReturn(self)
+        if textField === self.textField {
+            delegate?.textFieldCellDidReturn(self)
+        }
         return false
     }
 }


### PR DESCRIPTION
The Swift limitation that `TextFieldRowCellDelegateAdapter` was used to work around seems to no longer be present in Swift 2.2.