### PR TITLE
Remove the Move case from the table diff Change enum

### DIFF
--- a/Authenticator/Source/TableDiff.swift
+++ b/Authenticator/Source/TableDiff.swift
@@ -33,8 +33,6 @@ enum Change {
     case Insert(index: Int)
     case Update(oldIndex: Int, newIndex: Int)
     case Delete(index: Int)
-    // TODO: Consolidate matching Inserts and Deletes into Moves
-    case Move(fromIndex: Int, toIndex: Int)
 }
 
 func changesFrom<T: Identifiable>(oldItems: [T], to newItems: [T]) -> [Change] {

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -50,10 +50,6 @@ class TokenFormViewController<Form: TableViewModelRepresentable where Form.Heade
                     case .Delete(let rowIndex):
                         let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                         tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-                    case let .Move(fromRowIndex, toRowIndex):
-                        let origin = NSIndexPath(forRow: fromRowIndex, inSection: sectionIndex)
-                        let destination = NSIndexPath(forRow: toRowIndex, inSection: sectionIndex)
-                        tableView.moveRowAtIndexPath(origin, toIndexPath: destination)
                     }
                 }
             }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -210,10 +210,6 @@ extension TokenListViewController {
             case .Delete(let rowIndex):
                 let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                 tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-            case let .Move(fromRowIndex, toRowIndex):
-                let origin = NSIndexPath(forRow: fromRowIndex, inSection: sectionIndex)
-                let destination = NSIndexPath(forRow: toRowIndex, inSection: sectionIndex)
-                tableView.moveRowAtIndexPath(origin, toIndexPath: destination)
             }
         }
         tableView.endUpdates()


### PR DESCRIPTION
The current diffing algorithm doesn't consolidate matching Inserts and Deletes into Moves, so this case was unused. Since the current uses of the diff-and-update don't involve any moves, adding complexity to support the Move case seems unnecessary at this point in time.