### PR TITLE
Token load failure

### DIFF
--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -43,10 +43,15 @@ class AppController {
     }()
 
     init() {
-        store = TokenStore(
-            keychain: Keychain.sharedInstance,
-            userDefaults: NSUserDefaults.standardUserDefaults()
-        )
+        do {
+            store = try TokenStore(
+                keychain: Keychain.sharedInstance,
+                userDefaults: NSUserDefaults.standardUserDefaults()
+            )
+        } catch {
+            // If the TokenStore could not be created, the app is unusable.
+            fatalError("Failed to load token store: \(error)")
+        }
         let currentTime = DisplayTime(date: NSDate())
         component = Root(persistentTokens: store.persistentTokens, displayTime: currentTime)
     }

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -117,6 +117,5 @@ private extension NSUserDefaults {
 
     func savePersistentIdentifiers(identifiers: [NSData]) {
         setObject(identifiers, forKey: kOTPKeychainEntriesArray)
-        synchronize() // TODO: Remove call to deprecated synchronize()
     }
 }

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -31,32 +31,30 @@ class TokenStore {
     private let userDefaults: NSUserDefaults
     private(set) var persistentTokens: [PersistentToken]
 
-    init(keychain: Keychain, userDefaults: NSUserDefaults) {
+    // Throws an error if the initial state could not be loaded from the keychain.
+    init(keychain: Keychain, userDefaults: NSUserDefaults) throws {
         self.keychain = keychain
         self.userDefaults = userDefaults
-        do {
-            let persistentTokenSet = try keychain.allPersistentTokens()
-            let sortedIdentifiers = userDefaults.persistentIdentifiers()
 
-            persistentTokens = persistentTokenSet.sort({ (A, B) in
-                let indexOfA = sortedIdentifiers.indexOf(A.identifier)
-                let indexOfB = sortedIdentifiers.indexOf(B.identifier)
+        // Try to load persistent tokens.
+        let persistentTokenSet = try keychain.allPersistentTokens()
+        let sortedIdentifiers = userDefaults.persistentIdentifiers()
 
-                switch (indexOfA, indexOfB) {
-                case (.Some(let iA), .Some(let iB)) where iA < iB:
-                    return true
-                default:
-                    return false
-                }
-            })
+        persistentTokens = persistentTokenSet.sort({ (A, B) in
+            let indexOfA = sortedIdentifiers.indexOf(A.identifier)
+            let indexOfB = sortedIdentifiers.indexOf(B.identifier)
 
-            if persistentTokens.count > sortedIdentifiers.count {
-                // If lost tokens were found and appended, save the full list of tokens
-                saveTokenOrder()
+            switch (indexOfA, indexOfB) {
+            case (.Some(let iA), .Some(let iB)) where iA < iB:
+                return true
+            default:
+                return false
             }
-        } catch {
-            persistentTokens = []
-            // TODO: Handle the token loading error
+        })
+
+        if persistentTokens.count > sortedIdentifiers.count {
+            // If lost tokens were found and appended, save the full list of tokens
+            saveTokenOrder()
         }
     }
 


### PR DESCRIPTION
If the token store fails to load, the app will be unusable.

With this change, if persistent tokens cannot be loaded from the keychain, the `TokenStore` initializer will throw an error and the `AppController` will respond with a `fatalError`. Crashing the app is not ideal, but it is preferable to presenting the user with an unusable interface, and it should result in crash reports being sent to iTunes Connect.