### PR TITLE
Updates ring while scrolling the table view

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -193,9 +193,9 @@ extension TokenListViewController {
             return
         }
 
-        // Determine if there are any updates that require insert/delete/move animations.
+        // Determine if there are any changes that require insert/delete/move animations.
         // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
-        let updatesNeedAnimations = changes.contains { change in
+        let changesNeedAnimations = changes.contains { change in
             switch change {
             case .Insert, .Delete:
                 return true
@@ -203,10 +203,11 @@ extension TokenListViewController {
                 return false
             }
         }
+
         let sectionIndex = 0
 
         // Only perform a table view updates group if there are changes which require animations.
-        if updatesNeedAnimations {
+        if changesNeedAnimations {
             tableView.beginUpdates()
             for change in changes {
                 switch change {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -195,7 +195,7 @@ extension TokenListViewController {
 
         // Determine if there are any updates that require insert/delete/move animations.
         // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
-        let updatesNeedAnimations = changes.containsInsertOrDelete()
+        let updatesNeedAnimations = changes.contains { !$0.isUpdate() }
         let sectionIndex = 0
 
         // Only perform a table view updates group if there are changes which require animations.
@@ -249,14 +249,9 @@ extension TokenListViewController {
     }
 }
 
-// Allows an extension on CollectionType containing ChangeType
-protocol ChangeType {
-    func isUpdate() -> Bool
-}
 
-// Change conforms to ChangeType so [Change] will contain extensions
-// to CollectionType
-extension Change : ChangeType {
+// Helper method to see if a change is a .Update type
+extension Change {
     func isUpdate() -> Bool {
         switch self {
         case .Update:
@@ -264,13 +259,5 @@ extension Change : ChangeType {
         default:
             return false
         }
-    }
-}
-
-// Extension on collection type that determines if a list of changes contain a
-// .Insert or .Delete type
-extension CollectionType where Generator.Element : ChangeType {
-    func containsInsertOrDelete() -> Bool {
-        return contains { !$0.isUpdate() }
     }
 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -193,25 +193,22 @@ extension TokenListViewController {
             return
         }
 
-        // Check if there are any updates that require insert/delete/move of existing cell
-        // if there are none, tableView.beginUpdates and tableView.endUpdates are not required
-        let changedPositions: Bool = changes.reduce(false) { (positionChanged, change) -> Bool in
+        // Determine if there are any updates that require insert/delete/move animations.
+        // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
+        let updatesNeedAnimations = changes.reduce(false) { (positionChanged, change) -> Bool in
             if positionChanged { return positionChanged }
             switch change {
-                case let .Update(oldIndex, newIndex):
-                    return oldIndex != newIndex
-                case .Insert:
-                    return true
-                case .Delete:
-                    return true
+            case .Insert, .Delete:
+                return true
+            case .Update:
+                return false
             }
-
         }
 
         let sectionIndex = 0
 
         // Only perform a table view updates group if there are changes which require animations.
-        if changedPositions {
+        if updatesNeedAnimations {
             tableView.beginUpdates()
             for change in changes {
                 switch change {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -193,20 +193,23 @@ extension TokenListViewController {
             return
         }
 
-        // TODO: if the changes require no changes in position, just update the visible cells
+        // Check if there are any updates that require insert/delete/move of existing cell
+        // if there are none, tableView.beginUpdates and tableView.endUpdates are not required
         let changedPositions: Bool = changes.reduce(false) { (positionChanged, change) -> Bool in
-            if ( positionChanged ) { return positionChanged }
+            if positionChanged { return positionChanged }
             switch change {
                 case let .Update(oldIndex, newIndex):
                     return oldIndex != newIndex
                 case .Insert:
-                    return true;
+                    return true
                 case .Delete:
                     return true
             }
 
         }
 
+        // no positions were changed so just update visible/allocated TokenRowCell
+        // instances and return early
         if !changedPositions {
             changes.forEach({ (change) in
                 switch change {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -208,43 +208,39 @@ extension TokenListViewController {
 
         }
 
-        // no positions were changed so just update visible/allocated TokenRowCell
-        // instances and return early
-        if !changedPositions {
+        let sectionIndex = 0
+
+        // Only perform a table view updates group if there are changes which require animations.
+        if changedPositions {
+            tableView.beginUpdates()
             for change in changes {
                 switch change {
-                case let .Update(_, row):
-                    let indexPath = NSIndexPath(forRow: row, inSection: 0)
-                    if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
-                        updateCell(cell, forRowAtIndexPath: indexPath)
-                    }
-                case .Insert:
-                    break
-                case .Delete:
+                case .Insert(let rowIndex):
+                    let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
+                    tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                case .Delete(let rowIndex):
+                    let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
+                    tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                case .Update:
                     break
                 }
             }
-            return
+            tableView.endUpdates()
         }
 
-        tableView.beginUpdates()
-        let sectionIndex = 0
+        // After applying the changes which require animations, update any visible cells whose 
+        // contents have changed.
         for change in changes {
             switch change {
-            case .Insert(let rowIndex):
-                let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
-                tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             case let .Update(_, rowIndex):
                 let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)
                 }
-            case .Delete(let rowIndex):
-                let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
-                tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+            case .Insert, .Delete:
+                break
             }
         }
-        tableView.endUpdates()
     }
 
     private func updatePeripheralViews() {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -195,7 +195,14 @@ extension TokenListViewController {
 
         // Determine if there are any updates that require insert/delete/move animations.
         // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
-        let updatesNeedAnimations = changes.contains { !$0.isUpdate() }
+        let updatesNeedAnimations = changes.contains { change in
+            switch change {
+            case .Insert, .Delete:
+                return true
+            case .Update:
+                return false
+            }
+        }
         let sectionIndex = 0
 
         // Only perform a table view updates group if there are changes which require animations.
@@ -245,19 +252,6 @@ extension TokenListViewController {
         // Exit editing mode if no tokens remain
         if self.editing && viewModel.rowModels.isEmpty {
             self.setEditing(false, animated: true)
-        }
-    }
-}
-
-
-// Helper method to see if a change is a .Update type
-extension Change {
-    func isUpdate() -> Bool {
-        switch self {
-        case .Update:
-            return true
-        default:
-            return false
         }
     }
 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -105,7 +105,7 @@ class TokenListViewController: UITableViewController {
 
         let selector = #selector(TokenListViewController.tick)
         self.displayLink = CADisplayLink(target: self, selector: selector)
-        self.displayLink?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
+        self.displayLink?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
     }
 
     override func viewWillDisappear(animated: Bool) {
@@ -190,6 +190,39 @@ extension TokenListViewController {
     private func updateTableViewWithChanges(changes: [Change]) {
         // TODO: Scroll to a newly added token (added at the bottom)
         if changes.isEmpty || preventTableViewAnimations {
+            return
+        }
+
+        // TODO: if the changes require no changes in position, just update the visible cells
+        let changedPositions: Bool = changes.reduce(false) { (positionChanged, change) -> Bool in
+            if ( positionChanged ) { return positionChanged }
+            switch change {
+                case let .Update(oldIndex, newIndex):
+                    return oldIndex != newIndex
+                case .Insert:
+                    return true;
+                case .Delete:
+                    return true
+            }
+
+        }
+
+        if !changedPositions {
+            changes.forEach({ (change) in
+                switch change {
+                case let .Update( _, row ):
+                    let indexPath = NSIndexPath(forRow: row, inSection: 0)
+                    guard let cell = tableView.cellForRowAtIndexPath(indexPath)
+                        as? TokenRowCell else {
+                        return
+                    }
+                    updateCell(cell, forRowAtIndexPath: indexPath)
+                case .Insert:
+                    break
+                case .Delete:
+                    break
+                }
+            })
             return
         }
 

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -195,16 +195,7 @@ extension TokenListViewController {
 
         // Determine if there are any updates that require insert/delete/move animations.
         // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
-        let updatesNeedAnimations = changes.reduce(false) { (positionChanged, change) -> Bool in
-            if positionChanged { return positionChanged }
-            switch change {
-            case .Insert, .Delete:
-                return true
-            case .Update:
-                return false
-            }
-        }
-
+        let updatesNeedAnimations = changes.containsInsertOrDelete()
         let sectionIndex = 0
 
         // Only perform a table view updates group if there are changes which require animations.
@@ -255,5 +246,31 @@ extension TokenListViewController {
         if self.editing && viewModel.rowModels.isEmpty {
             self.setEditing(false, animated: true)
         }
+    }
+}
+
+// Allows an extension on CollectionType containing ChangeType
+protocol ChangeType {
+    func isUpdate() -> Bool
+}
+
+// Change conforms to ChangeType so [Change] will contain extensions
+// to CollectionType
+extension Change : ChangeType {
+    func isUpdate() -> Bool {
+        switch self {
+        case .Update:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+// Extension on collection type that determines if a list of changes contain a
+// .Insert or .Delete type
+extension CollectionType where Generator.Element : ChangeType {
+    func containsInsertOrDelete() -> Bool {
+        return contains { !$0.isUpdate() }
     }
 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -225,7 +225,7 @@ extension TokenListViewController {
             tableView.endUpdates()
         }
 
-        // After applying the changes which require animations, update any visible cells whose 
+        // After applying the changes which require animations, update any visible cells whose
         // contents have changed.
         for change in changes {
             switch change {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -211,21 +211,19 @@ extension TokenListViewController {
         // no positions were changed so just update visible/allocated TokenRowCell
         // instances and return early
         if !changedPositions {
-            changes.forEach({ (change) in
+            for change in changes {
                 switch change {
-                case let .Update( _, row ):
+                case let .Update(_, row):
                     let indexPath = NSIndexPath(forRow: row, inSection: 0)
-                    guard let cell = tableView.cellForRowAtIndexPath(indexPath)
-                        as? TokenRowCell else {
-                        return
+                    if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
+                        updateCell(cell, forRowAtIndexPath: indexPath)
                     }
-                    updateCell(cell, forRowAtIndexPath: indexPath)
                 case .Insert:
                     break
                 case .Delete:
                     break
                 }
-            })
+            }
             return
         }
 


### PR DESCRIPTION
See #136

Not necessarily the ideal fix but shows where the problem is, namely updating
the UITableView with animated cell changes while scrolling the table view.

This reduces the changes to see if any of them require inserts, updates, or changes in cell positions. If none of the cell positions actually change we don't need to do the table animations.

From `UITableView` docs (emphasis mine):

> Reloading a row causes the table view to ask its data source for a new cell for that row. The table animates that new cell in as it animates the old row out. Call this method if you want to alert the user that the value of a cell is changing. *If, however, notifying the user is not important—that is, you just want to change the value that a cell is displaying—you can get the cell for a particular row and set its new value.*

It seems just calling `updateCell` for visible cells is all that is necessary. This gets rid of the UIScrollView scrolling weirdness when using `NSRunLoopCommonModes`.