### PR TITLE
Removes reloads for cell updates

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -204,8 +204,6 @@ extension TokenListViewController {
                 let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)
-                } else {
-                    tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
                 }
             case .Delete(let rowIndex):
                 let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)


### PR DESCRIPTION
Prevents the cell from having two animations scheduled during a tableView.beginUpdates pass.

In the case where a `Change` is just an update and the cell doesn't actually move positions, it's not necessary to call `reloadRowsAtIndexPaths`. When reordering a cell can potentially have two different animations scheduled which causes the crash in #135.

```
2016-10-10 09:40:52.195995 Authenticator[3852:1015298] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Attempt to create two animations for cell'
```