### PR TITLE
Update ring while scrolling and avoid unnecessary table animations

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -193,25 +193,22 @@ extension TokenListViewController {
             return
         }
 
-        // Check if there are any updates that require insert/delete/move of existing cell
-        // if there are none, tableView.beginUpdates and tableView.endUpdates are not required
-        let changedPositions: Bool = changes.reduce(false) { (positionChanged, change) -> Bool in
+        // Determine if there are any updates that require insert/delete/move animations.
+        // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
+        let updatesNeedAnimations = changes.reduce(false) { (positionChanged, change) -> Bool in
             if positionChanged { return positionChanged }
             switch change {
-                case let .Update(oldIndex, newIndex):
-                    return oldIndex != newIndex
-                case .Insert:
-                    return true
-                case .Delete:
-                    return true
+            case .Insert, .Delete:
+                return true
+            case .Update:
+                return false
             }
-
         }
 
         let sectionIndex = 0
 
         // Only perform a table view updates group if there are changes which require animations.
-        if changedPositions {
+        if updatesNeedAnimations {
             tableView.beginUpdates()
             for change in changes {
                 switch change {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -193,20 +193,23 @@ extension TokenListViewController {
             return
         }
 
-        // TODO: if the changes require no changes in position, just update the visible cells
+        // Check if there are any updates that require insert/delete/move of existing cell
+        // if there are none, tableView.beginUpdates and tableView.endUpdates are not required
         let changedPositions: Bool = changes.reduce(false) { (positionChanged, change) -> Bool in
-            if ( positionChanged ) { return positionChanged }
+            if positionChanged { return positionChanged }
             switch change {
                 case let .Update(oldIndex, newIndex):
                     return oldIndex != newIndex
                 case .Insert:
-                    return true;
+                    return true
                 case .Delete:
                     return true
             }
 
         }
 
+        // no positions were changed so just update visible/allocated TokenRowCell
+        // instances and return early
         if !changedPositions {
             changes.forEach({ (change) in
                 switch change {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -208,43 +208,39 @@ extension TokenListViewController {
 
         }
 
-        // no positions were changed so just update visible/allocated TokenRowCell
-        // instances and return early
-        if !changedPositions {
+        let sectionIndex = 0
+
+        // Only perform a table view updates group if there are changes which require animations.
+        if changedPositions {
+            tableView.beginUpdates()
             for change in changes {
                 switch change {
-                case let .Update(_, row):
-                    let indexPath = NSIndexPath(forRow: row, inSection: 0)
-                    if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
-                        updateCell(cell, forRowAtIndexPath: indexPath)
-                    }
-                case .Insert:
-                    break
-                case .Delete:
+                case .Insert(let rowIndex):
+                    let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
+                    tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                case .Delete(let rowIndex):
+                    let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
+                    tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                case .Update:
                     break
                 }
             }
-            return
+            tableView.endUpdates()
         }
 
-        tableView.beginUpdates()
-        let sectionIndex = 0
+        // After applying the changes which require animations, update any visible cells whose 
+        // contents have changed.
         for change in changes {
             switch change {
-            case .Insert(let rowIndex):
-                let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
-                tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
             case let .Update(_, rowIndex):
                 let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)
                 }
-            case .Delete(let rowIndex):
-                let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
-                tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+            case .Insert, .Delete:
+                break
             }
         }
-        tableView.endUpdates()
     }
 
     private func updatePeripheralViews() {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -105,7 +105,7 @@ class TokenListViewController: UITableViewController {
 
         let selector = #selector(TokenListViewController.tick)
         self.displayLink = CADisplayLink(target: self, selector: selector)
-        self.displayLink?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
+        self.displayLink?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
     }
 
     override func viewWillDisappear(animated: Bool) {
@@ -190,6 +190,39 @@ extension TokenListViewController {
     private func updateTableViewWithChanges(changes: [Change]) {
         // TODO: Scroll to a newly added token (added at the bottom)
         if changes.isEmpty || preventTableViewAnimations {
+            return
+        }
+
+        // TODO: if the changes require no changes in position, just update the visible cells
+        let changedPositions: Bool = changes.reduce(false) { (positionChanged, change) -> Bool in
+            if ( positionChanged ) { return positionChanged }
+            switch change {
+                case let .Update(oldIndex, newIndex):
+                    return oldIndex != newIndex
+                case .Insert:
+                    return true;
+                case .Delete:
+                    return true
+            }
+
+        }
+
+        if !changedPositions {
+            changes.forEach({ (change) in
+                switch change {
+                case let .Update( _, row ):
+                    let indexPath = NSIndexPath(forRow: row, inSection: 0)
+                    guard let cell = tableView.cellForRowAtIndexPath(indexPath)
+                        as? TokenRowCell else {
+                        return
+                    }
+                    updateCell(cell, forRowAtIndexPath: indexPath)
+                case .Insert:
+                    break
+                case .Delete:
+                    break
+                }
+            })
             return
         }
 

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -225,7 +225,7 @@ extension TokenListViewController {
             tableView.endUpdates()
         }
 
-        // After applying the changes which require animations, update any visible cells whose 
+        // After applying the changes which require animations, update any visible cells whose
         // contents have changed.
         for change in changes {
             switch change {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -211,21 +211,19 @@ extension TokenListViewController {
         // no positions were changed so just update visible/allocated TokenRowCell
         // instances and return early
         if !changedPositions {
-            changes.forEach({ (change) in
+            for change in changes {
                 switch change {
-                case let .Update( _, row ):
+                case let .Update(_, row):
                     let indexPath = NSIndexPath(forRow: row, inSection: 0)
-                    guard let cell = tableView.cellForRowAtIndexPath(indexPath)
-                        as? TokenRowCell else {
-                        return
+                    if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
+                        updateCell(cell, forRowAtIndexPath: indexPath)
                     }
-                    updateCell(cell, forRowAtIndexPath: indexPath)
                 case .Insert:
                     break
                 case .Delete:
                     break
                 }
-            })
+            }
             return
         }
 


### PR DESCRIPTION
This PR modifies #137 to *always* apply row `Update`s outside of the animated table view updates group. This reduces code complexity while also ensuring the "after" row indexes used for updates are referencing the correct rows after any insertions and deletions are completed.

Fixes #136.