### PR TITLE
Add NSCameraUsageDescription to the Info.plist

### DIFF
--- a/Authenticator/Resources/Info.plist
+++ b/Authenticator/Resources/Info.plist
@@ -35,6 +35,8 @@
 	<string>1.1.2.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Authenticator can import tokens by scanning QR codes.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIStatusBarStyle</key>


### PR DESCRIPTION
From the [App Programming Guide for iOS](https://developer.apple.com/library/content/documentation/iPhone/Conceptual/iPhoneOSProgrammingGuide/ExpectedAppBehaviors/ExpectedAppBehaviors.html#//apple_ref/doc/uid/TP40007072-CH3-SW6):

> **Important:** When your app attempts to use a protected item, the system prompts the user with an alert asking for permission for access. Starting in iOS 10, your Info.plist file must include a purpose string, for display in the permission alert, for each such item. If your app attempts to access a protected item without you having provided a corresponding purpose string, your app exits.

The current build of the app in the app store doesn't crash on iOS 10, but any new build of the app must have an explanation of camera usage to avoid crashing.