### PR TITLE
Add code coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+# Configuration for Codecov (https://codecov.io)
+
+ignore:
+  - AuthenticatorTests

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ before_install:
   - git submodule update --init --recursive
 
 script: set -o pipefail && xcodebuild -workspace $TRAVIS_XCODE_WORKSPACE -scheme $TRAVIS_XCODE_SCHEME -sdk $TRAVIS_XCODE_SDK -destination "$DESTINATION" build test | xcpretty -c
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 		C959A63C190A69120042DEC0 /* Icon.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Icon.svg; sourceTree = "<group>"; };
 		C959A63E190A69E60042DEC0 /* GenerateIcons.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = GenerateIcons.sh; sourceTree = "<group>"; };
 		C968D1141CB4C639004ED7BB /* DisplayTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DisplayTime.swift; sourceTree = "<group>"; };
+		C96E60561DBC5F1B00484823 /* .codecov.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .codecov.yml; sourceTree = "<group>"; };
 		C9776E3318518801003D53CB /* LICENSE.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE.txt; sourceTree = "<group>"; };
 		C97B68C617D9226D005D1FE0 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		C97CDF041BEE927200D64406 /* AUTHORS */ = {isa = PBXFileReference; lastKnownFileType = text; path = AUTHORS; sourceTree = "<group>"; };
@@ -237,6 +238,7 @@
 			children = (
 				C931A6021BFF707E00706A1C /* Cartfile */,
 				C94765081C646E5E00C7527E /* Cartfile.private */,
+				C96E60561DBC5F1B00484823 /* .codecov.yml */,
 				C931A5FC1BFF6F9D00706A1C /* .hound.yml */,
 				C931A5FE1BFF6FA600706A1C /* .swiftlint.yml */,
 				C931A5FF1BFF6FA600706A1C /* .travis.yml */,

--- a/Authenticator.xcodeproj/xcshareddata/xcschemes/Authenticator.xcscheme
+++ b/Authenticator.xcodeproj/xcshareddata/xcschemes/Authenticator.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 ### Two-Factor Authentication Client for iOS.
 
 [![Build Status](https://api.travis-ci.org/mattrubin/Authenticator.svg?branch=master)](https://travis-ci.org/mattrubin/Authenticator)
+[![Codecov](https://codecov.io/gh/mattrubin/Authenticator/branch/master/graph/badge.svg)](https://codecov.io/gh/mattrubin/Authenticator)
 [![Latest Release](http://img.shields.io/github/release/mattrubin/authenticator.svg?style=flat)](https://github.com/mattrubin/authenticator/releases)
 [![MIT License](http://img.shields.io/badge/license-mit-blue.svg?style=flat)](https://github.com/mattrubin/authenticator/blob/master/LICENSE.txt)
 


### PR DESCRIPTION
Generate code coverage reports when testing, send them from Travis CI to Codecov, ignore coverage of the test code itself, and display a coverage badge in the Readme.