### PR TITLE
Reloads tableview only when there are changes to token list

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -205,7 +205,7 @@ extension TokenListViewController {
         let filtering = viewModel.isFiltering || self.viewModel.isFiltering
         self.viewModel = viewModel
 
-        if filtering {
+        if filtering && !changes.isEmpty {
             tableView.reloadData()
         } else {
             updateTableViewWithChanges(changes)


### PR DESCRIPTION
Prevents table reloads from other actions that don't change the tokens listed

Fixes #147 