### PR TITLE
Build numbers

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -465,13 +465,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "Authenticator" */;
 			buildPhases = (
-				C99112651E1CBDEF0006A6C0 /* Set Build Number */,
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
 				C910ADBF1BF00ABF00C988F5 /* Lint */,
 				1D60588F0D05DD3D006BFB54 /* Frameworks */,
 				C944A5531A7ECA5000E08B1E /* Copy Frameworks */,
-				C99112661E1CC02E0006A6C0 /* Clear Build Number */,
 			);
 			buildRules = (
 			);
@@ -597,34 +595,6 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		C99112651E1CBDEF0006A6C0 /* Set Build Number */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Set Build Number";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name |wc -l | sed 's/^ *//;s/ *$//'`\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $git_count\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $git_count\"\n";
-		};
-		C99112661E1CC02E0006A6C0 /* Clear Build Number */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Clear Build Number";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion ''\" \"${PRODUCT_SETTINGS_PATH}\"\necho \"Cleared build number in ${PRODUCT_SETTINGS_PATH}\"\n";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -710,7 +680,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_DISPLAY_NAME = "${PRODUCT_NAME} ∆";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 205;
 				DEVELOPMENT_TEAM = WD7ETSN9J9;
 				INFOPLIST_FILE = Authenticator/Resources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = me.mattrubin.authenticator.dev;
@@ -726,7 +695,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_DISPLAY_NAME = "${PRODUCT_NAME}";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 205;
 				DEVELOPMENT_TEAM = WD7ETSN9J9;
 				INFOPLIST_FILE = Authenticator/Resources/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = me.mattrubin.authenticator;

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -465,11 +465,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "Authenticator" */;
 			buildPhases = (
+				C99112651E1CBDEF0006A6C0 /* Set Build Number */,
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
 				C910ADBF1BF00ABF00C988F5 /* Lint */,
 				1D60588F0D05DD3D006BFB54 /* Frameworks */,
 				C944A5531A7ECA5000E08B1E /* Copy Frameworks */,
+				C99112661E1CC02E0006A6C0 /* Clear Build Number */,
 			);
 			buildRules = (
 			);
@@ -594,6 +596,34 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint\nelse\n    echo \"SwiftLint does not exist, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		C99112651E1CBDEF0006A6C0 /* Set Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name |wc -l | sed 's/^ *//;s/ *$//'`\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $git_count\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $git_count\"\n";
+		};
+		C99112661E1CC02E0006A6C0 /* Clear Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Clear Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion ''\" \"${PRODUCT_SETTINGS_PATH}\"\necho \"Cleared build number in ${PRODUCT_SETTINGS_PATH}\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Authenticator/Resources/Info.plist
+++ b/Authenticator/Resources/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>205</string>
+	<string></string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Authenticator/Resources/Info.plist
+++ b/Authenticator/Resources/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string></string>
+	<string>0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,11 +52,8 @@ platform :ios do
     # Ensure that the git repo is not dirty.
     ensure_git_status_clean
 
-    # Generate a build number from the number of git commits.
-    build_number = number_of_commits
-    increment_build_number(
-      build_number: build_number
-    )
+    # Set a generated build number.
+    build_number = set_build_number
 
     # Build the app with the Release configuration.
     gym(
@@ -66,6 +63,9 @@ platform :ios do
 
     # Upload the new binary to TestFlight.
     pilot
+
+    # Clear the generated build number.
+    clear_build_number
 
     # Add a git tag for this build.
     add_git_tag(
@@ -82,11 +82,8 @@ platform :ios do
     # This step will fail if the screenshots were not already up-to-date and committed.
     ensure_git_status_clean
 
-    # Generate a build number from the number of git commits.
-    build_number = number_of_commits
-    increment_build_number(
-      build_number: build_number
-    )
+    # Set a generated build number.
+    set_build_number
 
     # Build the app with the Release configuration.
     gym(
@@ -99,9 +96,12 @@ platform :ios do
       force: true
     )
 
+    # Clear the generated build number.
+    clear_build_number
+
     # Add a git tag for this build.
     add_git_tag(
-      tag: new_version_number
+      tag: get_version_number
     )
 
     # After committing and tagging, bump the version number.
@@ -124,6 +124,19 @@ platform :ios do
     #   success: false
     # )
   end
+end
+
+def set_build_number
+  # Generate a build number from the number of git commits.
+  build_number = number_of_commits
+  increment_build_number(
+    build_number: build_number
+  )
+  return build_number
+end
+
+def clear_build_number
+  increment_build_number(build_number: 0)
 end
 
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,10 +52,10 @@ platform :ios do
     # Ensure that the git repo is not dirty.
     ensure_git_status_clean
 
-    # Increment the build number (not the version number).
-    new_build_number = latest_testflight_build_number + 1
+    # Generate a build number from the number of git commits.
+    build_number = number_of_commits
     increment_build_number(
-      build_number: new_build_number
+      build_number: build_number
     )
 
     # Build the app with the Release configuration.
@@ -67,14 +67,10 @@ platform :ios do
     # Upload the new binary to TestFlight.
     pilot
 
-    # Commit the updated build number.
-    commit_version_bump(
-      message: "Build #{new_build_number}",
-      xcodeproj: "Authenticator.xcodeproj"
-    )
-
     # Add a git tag for this build.
-    add_git_tag
+    add_git_tag(
+      tag: "build/#{build_number}"
+    )
   end
 
   desc "Deploy a new version to the App Store"
@@ -86,10 +82,10 @@ platform :ios do
     # This step will fail if the screenshots were not already up-to-date and committed.
     ensure_git_status_clean
 
-    # Increment the build number (not the version number).
-    new_build_number = latest_testflight_build_number + 1
+    # Generate a build number from the number of git commits.
+    build_number = number_of_commits
     increment_build_number(
-      build_number: new_build_number
+      build_number: build_number
     )
 
     # Build the app with the Release configuration.
@@ -101,13 +97,6 @@ platform :ios do
     # Upload the app metadata and binary to iTunes Connect.
     deliver(
       force: true
-    )
-
-    # Commit the updated build number.
-    new_version_number = get_version_number
-    commit_version_bump(
-      message: "Release #{new_version_number}",
-      xcodeproj: "Authenticator.xcodeproj"
     )
 
     # Add a git tag for this build.


### PR DESCRIPTION
For fastlane `beta` and `release`, generate a build number based on the number of git commits, and then clear this build number after the build is uploaded. The build number is still used to tag betas, but is not committed.