### PR TITLE
Generalize table view updates

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		C98B1ECC1AB3CF0700C59E53 /* TokenRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */; };
 		C99069D1180CBAC900BAEF53 /* TokenScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99069D0180CBAC900BAEF53 /* TokenScannerViewController.swift */; };
 		C99112681E202B860006A6C0 /* UITableView+Updates.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99112671E202B860006A6C0 /* UITableView+Updates.swift */; };
+		C991126A1E2073710006A6C0 /* UITableViewUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99112691E2073710006A6C0 /* UITableViewUpdateTests.swift */; };
 		C9919CDD1BA64EED006237C1 /* TokenEntryForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */; };
 		C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */; };
 		C9919CE21BA733FD006237C1 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CE11BA733FD006237C1 /* Section.swift */; };
@@ -137,6 +138,7 @@
 		C99069D0180CBAC900BAEF53 /* TokenScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScannerViewController.swift; sourceTree = "<group>"; };
 		C9906A2E1812522100BAEF53 /* AuthenticatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AuthenticatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C99112671E202B860006A6C0 /* UITableView+Updates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Updates.swift"; sourceTree = "<group>"; };
+		C99112691E2073710006A6C0 /* UITableViewUpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewUpdateTests.swift; sourceTree = "<group>"; };
 		C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenEntryForm.swift; sourceTree = "<group>"; };
 		C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonHeaderView.swift; sourceTree = "<group>"; };
 		C9919CE11BA733FD006237C1 /* Section.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
@@ -406,6 +408,7 @@
 				CC471EEA1DC027A6006858AC /* TokenListViewControllerTest.swift */,
 				CC471EEC1DC1377F006858AC /* MockTableView.swift */,
 				CCCD668A1E1C74B4005FE96E /* OneTimePasswordExtensions.swift */,
+				C99112691E2073710006A6C0 /* UITableViewUpdateTests.swift */,
 			);
 			path = AuthenticatorTests;
 			sourceTree = "<group>";
@@ -656,6 +659,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CCCD668B1E1C74B4005FE96E /* OneTimePasswordExtensions.swift in Sources */,
+				C991126A1E2073710006A6C0 /* UITableViewUpdateTests.swift in Sources */,
 				CC471EEB1DC027A6006858AC /* TokenListViewControllerTest.swift in Sources */,
 				C983AB74197F98FC00975003 /* OTPAuthenticatorTests.m in Sources */,
 				CCC409761DB28BFE000A050D /* TableDiffTests.swift in Sources */,

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1EC91AB2CEC300C59E53 /* TokenRowModel.swift */; };
 		C98B1ECC1AB3CF0700C59E53 /* TokenRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */; };
 		C99069D1180CBAC900BAEF53 /* TokenScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99069D0180CBAC900BAEF53 /* TokenScannerViewController.swift */; };
+		C99112681E202B860006A6C0 /* UITableViewController+Updates.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99112671E202B860006A6C0 /* UITableViewController+Updates.swift */; };
 		C9919CDD1BA64EED006237C1 /* TokenEntryForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */; };
 		C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */; };
 		C9919CE21BA733FD006237C1 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CE11BA733FD006237C1 /* Section.swift */; };
@@ -132,6 +133,7 @@
 		C98C7F331C5E888100DB1478 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		C99069D0180CBAC900BAEF53 /* TokenScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScannerViewController.swift; sourceTree = "<group>"; };
 		C9906A2E1812522100BAEF53 /* AuthenticatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AuthenticatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C99112671E202B860006A6C0 /* UITableViewController+Updates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Updates.swift"; sourceTree = "<group>"; };
 		C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenEntryForm.swift; sourceTree = "<group>"; };
 		C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonHeaderView.swift; sourceTree = "<group>"; };
 		C9919CE11BA733FD006237C1 /* Section.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 				C9A262D91E176A18004E6CEB /* Demo.swift */,
 				C9B7328C1C09495D0076F77E /* TableDiff.swift */,
 				C9BA64E91C0C4FBC00610C7C /* UITableView+ReusableCells.swift */,
+				C99112671E202B860006A6C0 /* UITableViewController+Updates.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -606,6 +609,7 @@
 				C93BD6251C16841D00FFFB8F /* RootViewController.swift in Sources */,
 				C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */,
 				C9EB44901C52AE4500ACFA87 /* AppController.swift in Sources */,
+				C99112681E202B860006A6C0 /* UITableViewController+Updates.swift in Sources */,
 				C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */,
 				C9BA64EA1C0C4FBC00610C7C /* UITableView+ReusableCells.swift in Sources */,
 				CC46C4711DB3007D00EB4605 /* SearchField.swift in Sources */,

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1EC91AB2CEC300C59E53 /* TokenRowModel.swift */; };
 		C98B1ECC1AB3CF0700C59E53 /* TokenRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B1ECB1AB3CF0700C59E53 /* TokenRowCell.swift */; };
 		C99069D1180CBAC900BAEF53 /* TokenScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99069D0180CBAC900BAEF53 /* TokenScannerViewController.swift */; };
-		C99112681E202B860006A6C0 /* UITableViewController+Updates.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99112671E202B860006A6C0 /* UITableViewController+Updates.swift */; };
+		C99112681E202B860006A6C0 /* UITableView+Updates.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99112671E202B860006A6C0 /* UITableView+Updates.swift */; };
 		C9919CDD1BA64EED006237C1 /* TokenEntryForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */; };
 		C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */; };
 		C9919CE21BA733FD006237C1 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9919CE11BA733FD006237C1 /* Section.swift */; };
@@ -133,7 +133,7 @@
 		C98C7F331C5E888100DB1478 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		C99069D0180CBAC900BAEF53 /* TokenScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScannerViewController.swift; sourceTree = "<group>"; };
 		C9906A2E1812522100BAEF53 /* AuthenticatorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AuthenticatorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		C99112671E202B860006A6C0 /* UITableViewController+Updates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableViewController+Updates.swift"; sourceTree = "<group>"; };
+		C99112671E202B860006A6C0 /* UITableView+Updates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Updates.swift"; sourceTree = "<group>"; };
 		C9919CDC1BA64EED006237C1 /* TokenEntryForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenEntryForm.swift; sourceTree = "<group>"; };
 		C9919CDF1BA721A1006237C1 /* ButtonHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonHeaderView.swift; sourceTree = "<group>"; };
 		C9919CE11BA733FD006237C1 /* Section.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
@@ -386,7 +386,7 @@
 				C9A262D91E176A18004E6CEB /* Demo.swift */,
 				C9B7328C1C09495D0076F77E /* TableDiff.swift */,
 				C9BA64E91C0C4FBC00610C7C /* UITableView+ReusableCells.swift */,
-				C99112671E202B860006A6C0 /* UITableViewController+Updates.swift */,
+				C99112671E202B860006A6C0 /* UITableView+Updates.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -609,7 +609,7 @@
 				C93BD6251C16841D00FFFB8F /* RootViewController.swift in Sources */,
 				C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */,
 				C9EB44901C52AE4500ACFA87 /* AppController.swift in Sources */,
-				C99112681E202B860006A6C0 /* UITableViewController+Updates.swift in Sources */,
+				C99112681E202B860006A6C0 /* UITableView+Updates.swift in Sources */,
 				C98B1ECA1AB2CEC300C59E53 /* TokenRowModel.swift in Sources */,
 				C9BA64EA1C0C4FBC00610C7C /* UITableView+ReusableCells.swift in Sources */,
 				CC46C4711DB3007D00EB4605 /* SearchField.swift in Sources */,

--- a/Authenticator/Source/TokenEntryForm.swift
+++ b/Authenticator/Source/TokenEntryForm.swift
@@ -198,7 +198,6 @@ extension TokenEntryForm {
             self.algorithm = algorithm
         case .ShowAdvancedOptions:
             showsAdvancedOptions = true
-            // TODO: Scroll to the newly-expanded section
         case .Cancel:
             return .Cancel
         case .Submit:

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -35,12 +35,14 @@ class TokenFormViewController<Form: TableViewModelRepresentable where Form.Heade
                 return
             }
 
-            let changes = viewModel.sections.indices.flatMap { sectionIndex -> [UITableView.Change] in
+            let changes = viewModel.sections.indices.flatMap { sectionIndex -> [Change<NSIndexPath>] in
                 let oldSection = oldValue.sections[sectionIndex]
                 let newSection = viewModel.sections[sectionIndex]
                 let changes = changesFrom(oldSection.rows, to: newSection.rows)
-                return changes.map({
-                    UITableView.Change(fromChange: $0, inSection: sectionIndex)
+                return changes.map({ change in
+                    change.map({ row in
+                        NSIndexPath(forRow: row, inSection: sectionIndex)
+                    })
                 })
             }
             tableView.applyChanges(changes, updateRow: updateRowAtIndexPath)

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -151,7 +151,10 @@ class TokenFormViewController<Form: TableViewModelRepresentable where Form.Heade
     // MARK: - UITableViewDelegate
 
     override func tableView(tableView: UITableView, willDisplayCell cell: UITableViewCell, forRowAtIndexPath indexPath: NSIndexPath) {
-        cell.backgroundColor = .clearColor()
+        // An apparent rendering error can occur when the form is scrolled programaticallty, causing a cell scrolled off
+        // of the screen to appear with a black background when scrolled back onto the screen. Setting the background
+        // color of the cell to the table view's background color, instead of to clearColor(), fixes the issue.
+        cell.backgroundColor = .otpBackgroundColor
         cell.selectionStyle = .None
 
         cell.textLabel?.textColor = .otpForegroundColor

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -34,26 +34,16 @@ class TokenFormViewController<Form: TableViewModelRepresentable where Form.Heade
                 tableView.reloadData()
                 return
             }
-            tableView.beginUpdates()
-            for sectionIndex in oldValue.sections.indices {
+
+            let changes = viewModel.sections.indices.flatMap { sectionIndex -> [UITableView.Change] in
                 let oldSection = oldValue.sections[sectionIndex]
                 let newSection = viewModel.sections[sectionIndex]
                 let changes = changesFrom(oldSection.rows, to: newSection.rows)
-                for change in changes {
-                    switch change {
-                    case .Insert(let rowIndex):
-                        let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
-                        tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-                    case let .Update(_, rowIndex):
-                        let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
-                        updateRowAtIndexPath(indexPath)
-                    case .Delete(let rowIndex):
-                        let indexPath = NSIndexPath(forRow: rowIndex, inSection: sectionIndex)
-                        tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
-                    }
-                }
+                return changes.map({
+                    UITableView.Change(fromChange: $0, inSection: sectionIndex)
+                })
             }
-            tableView.endUpdates()
+            tableView.applyChanges(changes, updateRow: updateRowAtIndexPath)
         }
     }
 

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -214,7 +214,7 @@ extension TokenListViewController {
             tableView.reloadData()
         } else if !ignoreTableViewUpdates {
             let sectionIndex = 0
-            let updates: [UITableViewController.Change] = changes.map {
+            let updates: [UITableView.Change] = changes.map {
                 switch $0 {
                 case let .Insert(row):
                     let indexPath = NSIndexPath(forRow: row, inSection: sectionIndex)
@@ -228,7 +228,7 @@ extension TokenListViewController {
                     return .Delete(index: indexPath)
                 }
             }
-            updateTableViewWithChanges(updates, updateRow: { indexPath in
+            tableView.updateWithChanges(updates, updateRow: { indexPath in
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)
                 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -214,7 +214,7 @@ extension TokenListViewController {
             tableView.reloadData()
         } else if !ignoreTableViewUpdates {
             let sectionIndex = 0
-            let updates: [UITableView.Change] = changes.map {
+            let tableViewChanges: [UITableView.Change] = changes.map {
                 switch $0 {
                 case let .Insert(row):
                     let indexPath = NSIndexPath(forRow: row, inSection: sectionIndex)
@@ -228,7 +228,7 @@ extension TokenListViewController {
                     return .Delete(index: indexPath)
                 }
             }
-            tableView.updateWithChanges(updates, updateRow: { indexPath in
+            tableView.applyChanges(tableViewChanges, updateRow: { indexPath in
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)
                 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -214,8 +214,10 @@ extension TokenListViewController {
             tableView.reloadData()
         } else if !ignoreTableViewUpdates {
             let sectionIndex = 0
-            let tableViewChanges = changes.map({
-                UITableView.Change(fromChange: $0, inSection: sectionIndex)
+            let tableViewChanges = changes.map({ change in
+                change.map({ row in
+                    NSIndexPath(forRow: row, inSection: sectionIndex)
+                })
             })
             tableView.applyChanges(tableViewChanges, updateRow: { indexPath in
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -214,19 +214,8 @@ extension TokenListViewController {
             tableView.reloadData()
         } else if !ignoreTableViewUpdates {
             let sectionIndex = 0
-            let tableViewChanges: [UITableView.Change] = changes.map {
-                switch $0 {
-                case let .Insert(row):
-                    let indexPath = NSIndexPath(forRow: row, inSection: sectionIndex)
-                    return .Insert(index: indexPath)
-                case let .Update(oldRow, newRow):
-                    let oldIndexPath = NSIndexPath(forRow: oldRow, inSection: sectionIndex)
-                    let newIndexPath = NSIndexPath(forRow: newRow, inSection: sectionIndex)
-                    return .Update(oldIndex: oldIndexPath, newIndex: newIndexPath)
-                case let .Delete(row):
-                    let indexPath = NSIndexPath(forRow: row, inSection: sectionIndex)
-                    return .Delete(index: indexPath)
-                }
+            let tableViewChanges = changes.map {
+                UITableView.Change(fromChange: $0, inSection: sectionIndex)
             }
             tableView.applyChanges(tableViewChanges, updateRow: { indexPath in
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -212,7 +212,7 @@ extension TokenListViewController {
 
         if filtering && !changes.isEmpty {
             tableView.reloadData()
-        } else {
+        } else if !ignoreTableViewUpdates {
             let sectionIndex = 0
             let updates: [UITableViewController.Change] = changes.map {
                 switch $0 {
@@ -228,27 +228,13 @@ extension TokenListViewController {
                     return .Delete(index: indexPath)
                 }
             }
-            updateTableViewWithChanges(updates)
-        }
-        updatePeripheralViews()
-    }
-
-    private func updateTableViewWithChanges(changes: [Change]) {
-        if changes.isEmpty || ignoreTableViewUpdates {
-            return
-        }
-
-        // In a single animated group, apply any changes which alter the ordering of the table.
-        applyOrderChanges(fromChanges: changes)
-        // After applying the changes which require animations, update in place any visible cells
-        // whose contents have changed.
-        applyRowUpdates(fromChanges: changes, updateRow: { indexPath in
+            updateTableViewWithChanges(updates, updateRow: { indexPath in
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)
                 }
-        })
-        // If any tokens were inserted, scroll to the first inserted row.
-        scrollToFirstInsertedRow(fromChanges: changes)
+            })
+        }
+        updatePeripheralViews()
     }
 
     private func updatePeripheralViews() {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -213,7 +213,22 @@ extension TokenListViewController {
         if filtering && !changes.isEmpty {
             tableView.reloadData()
         } else {
-            updateTableViewWithChanges(changes)
+            let sectionIndex = 0
+            let updates: [UITableViewController.Change] = changes.map {
+                switch $0 {
+                case let .Insert(row):
+                    let indexPath = NSIndexPath(forRow: row, inSection: sectionIndex)
+                    return .Insert(index: indexPath)
+                case let .Update(oldRow, newRow):
+                    let oldIndexPath = NSIndexPath(forRow: oldRow, inSection: sectionIndex)
+                    let newIndexPath = NSIndexPath(forRow: newRow, inSection: sectionIndex)
+                    return .Update(oldIndex: oldIndexPath, newIndex: newIndexPath)
+                case let .Delete(row):
+                    let indexPath = NSIndexPath(forRow: row, inSection: sectionIndex)
+                    return .Delete(index: indexPath)
+                }
+            }
+            updateTableViewWithChanges(updates)
         }
         updatePeripheralViews()
     }
@@ -223,19 +238,17 @@ extension TokenListViewController {
             return
         }
 
-        let sectionIndex = 0
-
         // In a single animated group, apply any changes which alter the ordering of the table.
-        applyOrderChanges(fromChanges: changes, inSection: sectionIndex)
+        applyOrderChanges(fromChanges: changes)
         // After applying the changes which require animations, update in place any visible cells
         // whose contents have changed.
-        applyRowUpdates(fromChanges: changes, inSection: sectionIndex, updateRow: { indexPath in
+        applyRowUpdates(fromChanges: changes, updateRow: { indexPath in
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)
                 }
         })
         // If any tokens were inserted, scroll to the first inserted row.
-        scrollToFirstInsertedRow(fromChanges: changes, inSection: sectionIndex)
+        scrollToFirstInsertedRow(fromChanges: changes)
     }
 
     private func updatePeripheralViews() {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -214,9 +214,9 @@ extension TokenListViewController {
             tableView.reloadData()
         } else if !ignoreTableViewUpdates {
             let sectionIndex = 0
-            let tableViewChanges = changes.map {
+            let tableViewChanges = changes.map({
                 UITableView.Change(fromChange: $0, inSection: sectionIndex)
-            }
+            })
             tableView.applyChanges(tableViewChanges, updateRow: { indexPath in
                 if let cell = tableView.cellForRowAtIndexPath(indexPath) as? TokenRowCell {
                     updateCell(cell, forRowAtIndexPath: indexPath)

--- a/Authenticator/Source/UITableView+Updates.swift
+++ b/Authenticator/Source/UITableView+Updates.swift
@@ -26,31 +26,10 @@
 import UIKit
 
 extension UITableView {
-    enum Change {
-        case Insert(index: NSIndexPath)
-        case Update(oldIndex: NSIndexPath, newIndex: NSIndexPath)
-        case Delete(index: NSIndexPath)
-
-        init(fromChange change: Authenticator.Change, inSection section: Int) {
-            switch change {
-            case let .Insert(row):
-                let indexPath = NSIndexPath(forRow: row, inSection: section)
-                self = .Insert(index: indexPath)
-            case let .Update(oldRow, newRow):
-                let oldIndexPath = NSIndexPath(forRow: oldRow, inSection: section)
-                let newIndexPath = NSIndexPath(forRow: newRow, inSection: section)
-                self = .Update(oldIndex: oldIndexPath, newIndex: newIndexPath)
-            case let .Delete(row):
-                let indexPath = NSIndexPath(forRow: row, inSection: section)
-                self = .Delete(index: indexPath)
-            }
-        }
-    }
-
     /// Applies the given `Change`s to the table view, then scrolls to show the first inserted row.
     /// - parameter changes: An `Array` of `Change`s to apply.
     /// - parameter updateRow: A closure which takes an `NSIndexPath` and updates the corresponding row.
-    func applyChanges(changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
+    func applyChanges(changes: [Change<NSIndexPath>], @noescape updateRow: (NSIndexPath) -> Void) {
         if changes.isEmpty {
             return
         }
@@ -69,7 +48,7 @@ extension UITableView {
     /// animated table view updates group. If there are no changes which require animations, this
     /// method will not perform an empty updates group.
     /// - parameter changes: An `Array` of `Change`s, from which animated changes will be applied.
-    private func applyOrderChanges(fromChanges changes: [Change]) {
+    private func applyOrderChanges(fromChanges changes: [Change<NSIndexPath>]) {
         // Determine if there are any changes that require insert/delete/move animations.
         // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
         let changesNeedAnimations = changes.contains { change in
@@ -103,7 +82,7 @@ extension UITableView {
     /// have been applied.
     /// - parameter changes: An `Array` of `Change`s, from which `Update`s will be applied.
     /// - parameter updateRow: A closure which takes an `NSIndexPath` and updates the corresponding row.
-    private func applyRowUpdates(fromChanges changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
+    private func applyRowUpdates(fromChanges changes: [Change<NSIndexPath>], @noescape updateRow: (NSIndexPath) -> Void) {
         for change in changes {
             switch change {
             case let .Update(_, indexPath):
@@ -117,7 +96,7 @@ extension UITableView {
     /// From among the given `Change`s, finds the first `Insert` and scrolls to that row in the
     /// table view. This method should be used only *after* the changes have been applied.
     /// - parameter changes: An `Array` of `Change`s, in which the first `Insert` will be found.
-    private func scrollToFirstInsertedRow(fromChanges changes: [Change]) {
+    private func scrollToFirstInsertedRow(fromChanges changes: [Change<NSIndexPath>]) {
         let firstInsertedRow = changes.reduce(nil, combine: { (firstInsertedRow, change) -> NSIndexPath? in
             switch change {
             case let .Insert(row):

--- a/Authenticator/Source/UITableView+Updates.swift
+++ b/Authenticator/Source/UITableView+Updates.swift
@@ -36,17 +36,15 @@ extension UITableView {
 
         // In a single animated group, apply any changes which alter the ordering of the table.
         applyOrderChanges(fromChanges: changes)
-        // After applying the changes which require animations, update in place any visible cells
-        // whose contents have changed.
+        // After applying the changes which require animations, update in place any cells whose contents have changed.
         applyRowUpdates(fromChanges: changes, updateRow: updateRow)
         // If any tokens were inserted, scroll to the first inserted row.
         scrollToFirstInsertedRow(fromChanges: changes)
     }
 
-    /// From among the given `Change`s, applies any changes which modify the order of cells in the
-    /// table view. These insertions, deletions, and moves will be performed in a single
-    /// animated table view updates group. If there are no changes which require animations, this
-    /// method will not perform an empty updates group.
+    /// From among the given `Change`s, applies any changes which modify the order of cells in the table view. These
+    /// insertions, deletions, and moves will be performed in a single animated table view updates group. If there are
+    /// no changes which require animations, this method will not perform an empty updates group.
     /// - parameter changes: An `Array` of `Change`s, from which animated changes will be applied.
     private func applyOrderChanges(fromChanges changes: [Change<NSIndexPath>]) {
         // Determine if there are any changes that require insert/delete/move animations.
@@ -77,12 +75,12 @@ extension UITableView {
         }
     }
 
-    /// From among the given `Change`s, applies the `Update`s to cells at the new row indexes in the
-    /// table view. This method should be used only *after* insertions, deletions, and moves
-    /// have been applied.
+    /// From among the given `Change`s, applies the `Update`s to cells at the new row indexes in the table view. This
+    /// method should be used only *after* insertions, deletions, and moves have been applied.
     /// - parameter changes: An `Array` of `Change`s, from which `Update`s will be applied.
     /// - parameter updateRow: A closure which takes an `NSIndexPath` and updates the corresponding row.
-    private func applyRowUpdates(fromChanges changes: [Change<NSIndexPath>], @noescape updateRow: (NSIndexPath) -> Void) {
+    private func applyRowUpdates(fromChanges changes: [Change<NSIndexPath>],
+                                             @noescape updateRow: (NSIndexPath) -> Void) {
         for change in changes {
             switch change {
             case let .Update(_, indexPath):
@@ -93,8 +91,8 @@ extension UITableView {
         }
     }
 
-    /// From among the given `Change`s, finds the first `Insert` and scrolls to that row in the
-    /// table view. This method should be used only *after* the changes have been applied.
+    /// From among the given `Change`s, finds the first `Insert` and scrolls to that row in the table view. This method
+    /// should be used only *after* the changes have been applied.
     /// - parameter changes: An `Array` of `Change`s, in which the first `Insert` will be found.
     private func scrollToFirstInsertedRow(fromChanges changes: [Change<NSIndexPath>]) {
         let firstInsertedRow = changes.reduce(nil, combine: { (firstInsertedRow, change) -> NSIndexPath? in
@@ -110,8 +108,8 @@ extension UITableView {
         })
 
         if let indexPath = firstInsertedRow {
-            // Scrolls to the newly inserted token at the smallest row index in the tableView
-            // using the minimum amount of scrolling necessary (.None)
+            // Scrolls to the newly inserted token at the smallest row index in the tableView using the minimum amount
+            // of scrolling necessary (.None)
             scrollToRowAtIndexPath(indexPath, atScrollPosition: .None, animated: true)
         }
     }

--- a/Authenticator/Source/UITableView+Updates.swift
+++ b/Authenticator/Source/UITableView+Updates.swift
@@ -47,6 +47,9 @@ extension UITableView {
         }
     }
 
+    /// Applies the given `Change`s to the table view, then scrolls to show the first inserted row.
+    /// - parameter changes: An `Array` of `Change`s to apply.
+    /// - parameter updateRow: A closure which takes an `NSIndexPath` and updates the corresponding row.
     func applyChanges(changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
         if changes.isEmpty {
             return
@@ -99,7 +102,7 @@ extension UITableView {
     /// table view. This method should be used only *after* insertions, deletions, and moves
     /// have been applied.
     /// - parameter changes: An `Array` of `Change`s, from which `Update`s will be applied.
-    /// - parameter updateRow: A closure which takes an NSIndexPath and updates the corresponding row.
+    /// - parameter updateRow: A closure which takes an `NSIndexPath` and updates the corresponding row.
     private func applyRowUpdates(fromChanges changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
         for change in changes {
             switch change {

--- a/Authenticator/Source/UITableView+Updates.swift
+++ b/Authenticator/Source/UITableView+Updates.swift
@@ -30,6 +30,21 @@ extension UITableView {
         case Insert(index: NSIndexPath)
         case Update(oldIndex: NSIndexPath, newIndex: NSIndexPath)
         case Delete(index: NSIndexPath)
+
+        init(fromChange change: Authenticator.Change, inSection section: Int) {
+            switch change {
+            case let .Insert(row):
+                let indexPath = NSIndexPath(forRow: row, inSection: section)
+                self = .Insert(index: indexPath)
+            case let .Update(oldRow, newRow):
+                let oldIndexPath = NSIndexPath(forRow: oldRow, inSection: section)
+                let newIndexPath = NSIndexPath(forRow: newRow, inSection: section)
+                self = .Update(oldIndex: oldIndexPath, newIndex: newIndexPath)
+            case let .Delete(row):
+                let indexPath = NSIndexPath(forRow: row, inSection: section)
+                self = .Delete(index: indexPath)
+            }
+        }
     }
 
     func applyChanges(changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {

--- a/Authenticator/Source/UITableView+Updates.swift
+++ b/Authenticator/Source/UITableView+Updates.swift
@@ -1,5 +1,5 @@
 //
-//  UITableViewController+Updates.swift
+//  UITableView+Updates.swift
 //  Authenticator
 //
 //  Copyright (c) 2017 Authenticator authors
@@ -25,14 +25,14 @@
 
 import UIKit
 
-extension UITableViewController {
+extension UITableView {
     enum Change {
         case Insert(index: NSIndexPath)
         case Update(oldIndex: NSIndexPath, newIndex: NSIndexPath)
         case Delete(index: NSIndexPath)
     }
 
-    func updateTableViewWithChanges(changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
+    func updateWithChanges(changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
         if changes.isEmpty {
             return
         }
@@ -51,7 +51,7 @@ extension UITableViewController {
     /// animated table view updates group. If there are no changes which require animations, this
     /// method will not perform an empty updates group.
     /// - parameter changes: An `Array` of `Change`s, from which animated changes will be applied.
-    func applyOrderChanges(fromChanges changes: [Change]) {
+    private func applyOrderChanges(fromChanges changes: [Change]) {
         // Determine if there are any changes that require insert/delete/move animations.
         // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
         let changesNeedAnimations = changes.contains { change in
@@ -65,18 +65,18 @@ extension UITableViewController {
 
         // Only perform a table view updates group if there are changes which require animations.
         if changesNeedAnimations {
-            tableView.beginUpdates()
+            beginUpdates()
             for change in changes {
                 switch change {
                 case let .Insert(indexPath):
-                    tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                    insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
                 case let .Delete(indexPath):
-                    tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                    deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
                 case .Update:
                     break
                 }
             }
-            tableView.endUpdates()
+            endUpdates()
         }
     }
 
@@ -85,7 +85,7 @@ extension UITableViewController {
     /// have been applied.
     /// - parameter changes: An `Array` of `Change`s, from which `Update`s will be applied.
     /// - parameter updateRow: A closure which takes an NSIndexPath and updates the corresponding row.
-    func applyRowUpdates(fromChanges changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
+    private func applyRowUpdates(fromChanges changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
         for change in changes {
             switch change {
             case let .Update(_, indexPath):
@@ -99,7 +99,7 @@ extension UITableViewController {
     /// From among the given `Change`s, finds the first `Insert` and scrolls to that row in the
     /// table view. This method should be used only *after* the changes have been applied.
     /// - parameter changes: An `Array` of `Change`s, in which the first `Insert` will be found.
-    func scrollToFirstInsertedRow(fromChanges changes: [Change]) {
+    private func scrollToFirstInsertedRow(fromChanges changes: [Change]) {
         let firstInsertedRow = changes.reduce(nil, combine: { (firstInsertedRow, change) -> NSIndexPath? in
             switch change {
             case let .Insert(row):
@@ -115,9 +115,7 @@ extension UITableViewController {
         if let indexPath = firstInsertedRow {
             // Scrolls to the newly inserted token at the smallest row index in the tableView
             // using the minimum amount of scrolling necessary (.None)
-            tableView.scrollToRowAtIndexPath(indexPath,
-                                             atScrollPosition: .None,
-                                             animated: true)
+            scrollToRowAtIndexPath(indexPath, atScrollPosition: .None, animated: true)
         }
     }
 }

--- a/Authenticator/Source/UITableView+Updates.swift
+++ b/Authenticator/Source/UITableView+Updates.swift
@@ -32,7 +32,7 @@ extension UITableView {
         case Delete(index: NSIndexPath)
     }
 
-    func updateWithChanges(changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
+    func applyChanges(changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
         if changes.isEmpty {
             return
         }

--- a/Authenticator/Source/UITableViewController+Updates.swift
+++ b/Authenticator/Source/UITableViewController+Updates.swift
@@ -1,0 +1,112 @@
+//
+//  UITableViewController+Updates.swift
+//  Authenticator
+//
+//  Copyright (c) 2017 Authenticator authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import UIKit
+
+extension UITableViewController {
+    /// From among the given `Change`s, applies any changes which modify the order of cells in the
+    /// given `section`. These insertions, deletions, and moves will be performed in a single
+    /// animated table view updates group. If there are no changes which require animations, this
+    /// method will not perform an empty updates group.
+    /// - parameter changes: An `Array` of `Change`s, from which animated changes will be applied.
+    /// - parameter section: The index of the table view section which contains the changes.
+    func applyOrderChanges(fromChanges changes: [Change], inSection section: Int) {
+        // Determine if there are any changes that require insert/delete/move animations.
+        // If there are none, tableView.beginUpdates and tableView.endUpdates are not required.
+        let changesNeedAnimations = changes.contains { change in
+            switch change {
+            case .Insert, .Delete:
+                return true
+            case .Update:
+                return false
+            }
+        }
+
+        // Only perform a table view updates group if there are changes which require animations.
+        if changesNeedAnimations {
+            tableView.beginUpdates()
+            for change in changes {
+                switch change {
+                case let .Insert(row):
+                    let indexPath = NSIndexPath(forRow: row, inSection: section)
+                    tableView.insertRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                case let .Delete(row):
+                    let indexPath = NSIndexPath(forRow: row, inSection: section)
+                    tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+                case .Update:
+                    break
+                }
+            }
+            tableView.endUpdates()
+        }
+    }
+
+    /// From among the given `Change`s, applies the `Update`s to cells at the new row indexes in the
+    /// given `section`. This method should be used only *after* insertions, deletions, and moves
+    /// have been applied.
+    /// - parameter changes: An `Array` of `Change`s, from which `Update`s will be applied.
+    /// - parameter section: The index of the table view section which contains the changes.
+    /// - parameter updateRow: A closure which takes an NSIndexPath and updates the corresponding row.
+    func applyRowUpdates(fromChanges changes: [Change], inSection section: Int,
+                                     @noescape updateRow: (NSIndexPath) -> Void) {
+        for change in changes {
+            switch change {
+            case let .Update(_, row):
+                let indexPath = NSIndexPath(forRow: row, inSection: section)
+                updateRow(indexPath)
+            case .Insert, .Delete:
+                break
+            }
+        }
+    }
+
+    /// From among the given `Change`s, finds the first `Insert` and scrolls to that row in the
+    /// given `section` in the table view. This method should be used only *after* the changes have
+    /// been applied.
+    /// - parameter changes: An `Array` of `Change`s, in which the first `Insert` will be found.
+    /// - parameter section: The index of the table view section which contains the changes.
+    func scrollToFirstInsertedRow(fromChanges changes: [Change], inSection section: Int) {
+        let firstInsertedRow = changes.reduce(nil, combine: { (firstInsertedRow, change) -> Int? in
+            switch change {
+            case let .Insert(row):
+                guard let prevFirstInsertedRow = firstInsertedRow else {
+                    return row
+                }
+                return min(row, prevFirstInsertedRow)
+            case .Delete, .Update:
+                return firstInsertedRow
+            }
+        })
+
+        if let firstInsertedRow = firstInsertedRow {
+            let indexPath = NSIndexPath(forRow: firstInsertedRow, inSection: section)
+            // Scrolls to the newly inserted token at the smallest row index in the tableView
+            // using the minimum amount of scrolling necessary (.None)
+            tableView.scrollToRowAtIndexPath(indexPath,
+                                             atScrollPosition: .None,
+                                             animated: true)
+        }
+    }
+}

--- a/Authenticator/Source/UITableViewController+Updates.swift
+++ b/Authenticator/Source/UITableViewController+Updates.swift
@@ -32,6 +32,20 @@ extension UITableViewController {
         case Delete(index: NSIndexPath)
     }
 
+    func updateTableViewWithChanges(changes: [Change], @noescape updateRow: (NSIndexPath) -> Void) {
+        if changes.isEmpty {
+            return
+        }
+
+        // In a single animated group, apply any changes which alter the ordering of the table.
+        applyOrderChanges(fromChanges: changes)
+        // After applying the changes which require animations, update in place any visible cells
+        // whose contents have changed.
+        applyRowUpdates(fromChanges: changes, updateRow: updateRow)
+        // If any tokens were inserted, scroll to the first inserted row.
+        scrollToFirstInsertedRow(fromChanges: changes)
+    }
+
     /// From among the given `Change`s, applies any changes which modify the order of cells in the
     /// table view. These insertions, deletions, and moves will be performed in a single
     /// animated table view updates group. If there are no changes which require animations, this

--- a/AuthenticatorTests/MockTableView.swift
+++ b/AuthenticatorTests/MockTableView.swift
@@ -33,6 +33,7 @@ class MockTableView: UITableView {
         case Remove(indexPath: NSIndexPath)
         case Reload(indexPath: NSIndexPath)
         case Move(fromIndexPath: NSIndexPath, toIndexPath: NSIndexPath)
+        case Scroll(indexPath: NSIndexPath)
     }
 
     var changes: [ChangeType] = []
@@ -72,6 +73,12 @@ class MockTableView: UITableView {
         super.moveRowAtIndexPath(indexPath, toIndexPath: newIndexPath)
         changes.append(.Move(fromIndexPath: indexPath, toIndexPath: newIndexPath))
     }
+
+    override func scrollToRowAtIndexPath(indexPath: NSIndexPath,
+                                         atScrollPosition scrollPosition: UITableViewScrollPosition, animated: Bool) {
+        super.scrollToRowAtIndexPath(indexPath, atScrollPosition: scrollPosition, animated: animated)
+        changes.append((.Scroll(indexPath: indexPath)))
+    }
 }
 
 extension MockTableView.ChangeType: Equatable {}
@@ -85,10 +92,12 @@ func == (lhs: MockTableView.ChangeType, rhs: MockTableView.ChangeType) -> Bool {
         return l == r
     case let (.Move(l), .Move(r)):
         return l == r
+    case let (.Scroll(l), .Scroll(r)):
+        return l == r
     case (.BeginUpdates, .BeginUpdates),
          (.EndUpdates, .EndUpdates):
         return true
-    case (.Insert, _), (.Remove, _), (.Reload, _), (.Move, _), (.BeginUpdates, _), (.EndUpdates, _):
+    case (.Insert, _), (.Remove, _), (.Reload, _), (.Move, _), (.Scroll, _), (.BeginUpdates, _), (.EndUpdates, _):
         return false
     }
 }

--- a/AuthenticatorTests/TokenListViewControllerTest.swift
+++ b/AuthenticatorTests/TokenListViewControllerTest.swift
@@ -57,6 +57,7 @@ class TokenListViewControllerTest: XCTestCase {
             .BeginUpdates,
             .Insert(indexPath: NSIndexPath(forRow: 0, inSection: 0)),
             .EndUpdates,
+            .Scroll(indexPath: NSIndexPath(forRow: 0, inSection: 0)),
         ]
         XCTAssertEqual(tableView.changes, expectedChanges)
     }

--- a/AuthenticatorTests/UITableViewUpdateTests.swift
+++ b/AuthenticatorTests/UITableViewUpdateTests.swift
@@ -1,0 +1,127 @@
+//
+//  UITableViewUpdateTests.swift
+//  Authenticator
+//
+//  Copyright (c) 2017 Authenticator authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import XCTest
+@testable import Authenticator
+
+class UITableViewUpdateTests: XCTestCase {
+    func testInsert() {
+        // Set up a table view and empty data source.
+        let tableView = MockTableView()
+        let dataSource = MockTableViewDataSource()
+        tableView.dataSource = dataSource
+
+        // Test the inital state of the table view.
+        XCTAssertEqual(tableView.numberOfSections, 1)
+        XCTAssertEqual(tableView.numberOfRowsInSection(0), 0)
+
+        // Update the table view.
+        dataSource.titles = [["A"]]
+        let changes: [Change<NSIndexPath>] = [
+            .Insert(index: NSIndexPath(forRow: 0, inSection: 0)),
+        ]
+        tableView.applyChanges(changes, updateRow: { indexPath in
+            tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+            XCTFail("Unexpected update of row at \(indexPath)")
+        })
+
+        // Test the changes applied the table view.
+        let expectedChanges: [MockTableView.ChangeType] = [
+            .BeginUpdates,
+            .Insert(indexPath: NSIndexPath(forRow: 0, inSection: 0)),
+            .EndUpdates,
+        ]
+        XCTAssertEqual(tableView.changes, expectedChanges)
+
+        // Test the updated state of the table view.
+        XCTAssertEqual(tableView.numberOfSections, 1)
+        XCTAssertEqual(tableView.numberOfRowsInSection(0), 1)
+        let indexPath = NSIndexPath(forRow: 0, inSection: 0)
+        guard let cell = tableView.cellForRowAtIndexPath(indexPath) else {
+            XCTFail("Expected cell at index path \(indexPath)")
+            return
+        }
+        XCTAssertEqual(cell.textLabel?.text, "A")
+    }
+
+    func testDelete() {
+        // Set up a table view and empty data source.
+        let tableView = MockTableView()
+        let dataSource = MockTableViewDataSource()
+        dataSource.titles = [["B"]]
+        tableView.dataSource = dataSource
+        tableView.reloadData()
+
+        // Test the inital state of the table view.
+        XCTAssertEqual(tableView.numberOfSections, 1)
+        XCTAssertEqual(tableView.numberOfRowsInSection(0), 1)
+        let indexPath = NSIndexPath(forRow: 0, inSection: 0)
+        guard let cell = tableView.cellForRowAtIndexPath(indexPath) else {
+            XCTFail("Expected cell at index path \(indexPath)")
+            return
+        }
+        XCTAssertEqual(cell.textLabel?.text, "B")
+
+        // Update the table view.
+        dataSource.titles = [[]]
+        let changes: [Change<NSIndexPath>] = [
+            .Delete(index: NSIndexPath(forRow: 0, inSection: 0)),
+        ]
+        tableView.applyChanges(changes, updateRow: { indexPath in
+            tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+            XCTFail("Unexpected update of row at \(indexPath)")
+        })
+
+        // Test the changes applied the table view.
+        let expectedChanges: [MockTableView.ChangeType] = [
+            .BeginUpdates,
+            .Remove(indexPath: NSIndexPath(forRow: 0, inSection: 0)),
+            .EndUpdates,
+        ]
+        XCTAssertEqual(tableView.changes, expectedChanges)
+
+        // Test the updated state of the table view.
+        XCTAssertEqual(tableView.numberOfSections, 1)
+        XCTAssertEqual(tableView.numberOfRowsInSection(0), 0)
+    }
+}
+
+class MockTableViewDataSource: NSObject, UITableViewDataSource {
+    var titles: [[String]] = [[]]
+
+    func numberOfSectionsInTableView(tableView: UITableView) -> Int {
+        return titles.count
+    }
+
+    func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return titles[section].count
+    }
+
+    func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCellWithClass(UITableViewCell)
+        cell.textLabel?.text = titles[indexPath.section][indexPath.row]
+        return cell
+    }
+}


### PR DESCRIPTION
Generalize methods for updating a `UITableView` from an array of `Change`s, allowing the same update method to be used for the token list and the entry/edit forms. This avoids potential crashes caused by naive assumptions in `TokenFormViewController`'s old update code.

This PR also tweaks the behavior of scrolling to inserted rows, causing the whole "Advanced Options" section to scroll onscreen when it is expanded.