### PR TITLE
Separate Action and Event enums

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -25,7 +25,6 @@ opt_in_rules:
   - vertical_whitespace
 disabled_rules:
   - closure_parameter_position
-  - cyclomatic_complexity
   - line_length
   - todo
   - unused_closure_parameter

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -72,8 +72,8 @@ class AppController {
         }
     }
 
-    private func handleEvent(action: Root.Event) {
-        let sideEffect = component.update(action)
+    private func handleEvent(event: Root.Event) {
+        let sideEffect = component.update(event)
         if let effect = sideEffect {
             handleEffect(effect)
         }

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -72,42 +72,49 @@ class AppController {
         }
     }
 
+    private func handleEvent(action: Root.Event) {
+        let sideEffect = component.update(action)
+        if let effect = sideEffect {
+            handleEffect(effect)
+        }
+    }
+
     private func handleEffect(effect: Root.Effect) {
         switch effect {
         case let .AddToken(token, success, failure):
             do {
                 try store.addToken(token)
-                handleAction(success(store.persistentTokens))
+                handleEvent(success(store.persistentTokens))
             } catch {
-                handleAction(failure(error))
+                handleEvent(failure(error))
             }
 
         case let .SaveToken(token, persistentToken, success, failure):
             do {
                 try store.saveToken(token, toPersistentToken: persistentToken)
-                handleAction(success(store.persistentTokens))
+                handleEvent(success(store.persistentTokens))
             } catch {
-                handleAction(failure(error))
+                handleEvent(failure(error))
             }
 
         case let .UpdatePersistentToken(persistentToken, success, failure):
             do {
                 try store.updatePersistentToken(persistentToken)
-                handleAction(success(store.persistentTokens))
+                handleEvent(success(store.persistentTokens))
             } catch {
-                handleAction(failure(error))
+                handleEvent(failure(error))
             }
 
         case let .MoveToken(fromIndex, toIndex, success):
             store.moveTokenFromIndex(fromIndex, toIndex: toIndex)
-            handleAction(success(store.persistentTokens))
+            handleEvent(success(store.persistentTokens))
 
         case let .DeletePersistentToken(persistentToken, success, failure):
             do {
                 try store.deletePersistentToken(persistentToken)
-                handleAction(success(store.persistentTokens))
+                handleEvent(success(store.persistentTokens))
             } catch {
-                handleAction(failure(error))
+                handleEvent(failure(error))
             }
 
         case let .ShowErrorMessage(message):

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -73,13 +73,17 @@ extension Root {
 extension Root {
     enum Action {
         case TokenListAction(TokenList.Action)
-        case TokenListEvent(TokenList.Event)
         case TokenEntryFormAction(TokenEntryForm.Action)
         case TokenEditFormAction(TokenEditForm.Action)
 
         case TokenScannerEffect(TokenScannerViewController.Effect)
 
         case AddTokenFromURL(Token)
+    }
+
+    enum Event {
+        case TokenListEvent(TokenList.Event)
+
         case AddTokenFromURLSucceeded([PersistentToken])
 
         case TokenFormSucceeded([PersistentToken])
@@ -90,23 +94,23 @@ extension Root {
 
     enum Effect {
         case AddToken(Token,
-            success: ([PersistentToken]) -> Action,
-            failure: (ErrorType) -> Action)
+            success: ([PersistentToken]) -> Event,
+            failure: (ErrorType) -> Event)
 
         case SaveToken(Token, PersistentToken,
-            success: ([PersistentToken]) -> Action,
-            failure: (ErrorType) -> Action)
+            success: ([PersistentToken]) -> Event,
+            failure: (ErrorType) -> Event)
 
         case UpdatePersistentToken(PersistentToken,
-            success: ([PersistentToken]) -> Action,
-            failure: (ErrorType) -> Action)
+            success: ([PersistentToken]) -> Event,
+            failure: (ErrorType) -> Event)
 
         case MoveToken(fromIndex: Int, toIndex: Int,
-            success: ([PersistentToken]) -> Action)
+            success: ([PersistentToken]) -> Event)
 
         case DeletePersistentToken(PersistentToken,
-            success: ([PersistentToken]) -> Action,
-            failure: (ErrorType) -> Action)
+            success: ([PersistentToken]) -> Event,
+            failure: (ErrorType) -> Event)
 
         case ShowErrorMessage(String)
         case ShowSuccessMessage(String)
@@ -117,8 +121,6 @@ extension Root {
         switch action {
         case .TokenListAction(let action):
             return handleTokenListAction(action)
-        case .TokenListEvent(let event):
-            return handleTokenListEvent(event)
         case .TokenEntryFormAction(let action):
             return handleTokenEntryFormAction(action)
         case .TokenEditFormAction(let action):
@@ -128,8 +130,17 @@ extension Root {
 
         case .AddTokenFromURL(let token):
             return .AddToken(token,
-                             success: Action.AddTokenFromURLSucceeded,
-                             failure: Action.AddTokenFailed)
+                             success: Event.AddTokenFromURLSucceeded,
+                             failure: Event.AddTokenFailed)
+        }
+    }
+
+    @warn_unused_result
+    mutating func update(event: Event) -> Effect? {
+        switch event {
+        case .TokenListEvent(let event):
+            return handleTokenListEvent(event)
+
         case .AddTokenFromURLSucceeded(let persistentTokens):
             return handleTokenListEvent(.TokenChangeSucceeded(persistentTokens))
 
@@ -187,17 +198,17 @@ extension Root {
 
         case let .UpdateToken(persistentToken, success, failure):
             return .UpdatePersistentToken(persistentToken,
-                                          success: compose(success, Action.TokenListEvent),
-                                          failure: compose(failure, Action.TokenListEvent))
+                                          success: compose(success, Event.TokenListEvent),
+                                          failure: compose(failure, Event.TokenListEvent))
 
         case let .MoveToken(fromIndex, toIndex, success):
             return .MoveToken(fromIndex: fromIndex, toIndex: toIndex,
-                              success: compose(success, Action.TokenListEvent))
+                              success: compose(success, Event.TokenListEvent))
 
         case let .DeletePersistentToken(persistentToken, success, failure):
             return .DeletePersistentToken(persistentToken,
-                                          success: compose(success, Action.TokenListEvent),
-                                          failure: compose(failure, Action.TokenListEvent))
+                                          success: compose(success, Event.TokenListEvent),
+                                          failure: compose(failure, Event.TokenListEvent))
 
         case .ShowErrorMessage(let message):
             return .ShowErrorMessage(message)
@@ -230,8 +241,8 @@ extension Root {
 
         case .SaveNewToken(let token):
             return .AddToken(token,
-                             success: Action.TokenFormSucceeded,
-                             failure: Action.AddTokenFailed)
+                             success: Event.TokenFormSucceeded,
+                             failure: Event.AddTokenFailed)
 
         case .ShowErrorMessage(let message):
             return .ShowErrorMessage(message)
@@ -261,8 +272,8 @@ extension Root {
 
         case let .SaveChanges(token, persistentToken):
             return .SaveToken(token, persistentToken,
-                              success: Action.TokenFormSucceeded,
-                              failure: Action.SaveTokenFailed)
+                              success: Event.TokenFormSucceeded,
+                              failure: Event.SaveTokenFailed)
 
         case .ShowErrorMessage(let message):
             return .ShowErrorMessage(message)
@@ -288,8 +299,8 @@ extension Root {
 
         case .SaveNewToken(let token):
             return .AddToken(token,
-                             success: Action.TokenFormSucceeded,
-                             failure: Action.AddTokenFailed)
+                             success: Event.TokenFormSucceeded,
+                             failure: Event.AddTokenFailed)
         }
     }
 }


### PR DESCRIPTION
This is an experimental (but easily reversible) change to the Elm-inspired architectural pattern used by Authenticator.

The `TokenList.Action` enum had grown to have 12 different cases. I don't think this many cases is inherently bad if there truly are 12 different possible user actions for the Component, but it was troubling, returning to that code several months after last working on it, that I found it difficult to grok the meaning of all of the actions. After examining each of the cases, I think the source of my confusion was that the actions fell into two semantically distinct groups:

- **Actions** are triggered *by the user* from the Component's own UI. They are constructed by the Component as part of its View Model, then user interaction with the View causes them to be dispatched back to the Component.
- **Events** represent changes to the Component from an external source, created by either a parent Component, or by the App Controller to signify environmental changes outside of the functional core. When a Component has an Effect with a success or failure callback, these callbacks are routed back to the Component as Events.

This PR splits events out from the existing `Action` enums. The implementations and handling of `Action`s and `Event`s are nearly identical, but separating them into distinct types clarifies their different roles.

---
The `TokenList.Action.UpdateViewModel` value represents an external event, not a user action, but will remain a part of the `Action` enum until DisplayTime updates are refactored in [a future PR](https://github.com/mattrubin/Authenticator/pull/174).