### PR TITLE
Refactor Token Scanner

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		C9D6C8461906CD54004F0E08 /* TextFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C8451906CD54004F0E08 /* TextFieldRow.swift */; };
 		C9D6C84C19075044004F0E08 /* OTPProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C84B19075044004F0E08 /* OTPProgressRing.swift */; };
 		C9E3FB9A1E281CBC00EFA8BB /* TokenScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E3FB991E281CBC00EFA8BB /* TokenScanner.swift */; };
+		C9E3FB9C1E2860DD00EFA8BB /* TokenScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E3FB9B1E2860DD00EFA8BB /* TokenScannerTests.swift */; };
 		C9EB448E1C52A74200ACFA87 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EB448D1C52A74200ACFA87 /* Component.swift */; };
 		C9EB44901C52AE4500ACFA87 /* AppController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EB448F1C52AE4500ACFA87 /* AppController.swift */; };
 		C9F7A8611C4D90B50082E5AE /* TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F7A8601C4D90B50082E5AE /* TokenStore.swift */; };
@@ -165,6 +166,7 @@
 		C9D844341D4C576B00D5E343 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		C9D844361D4C59D600D5E343 /* CONDUCT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONDUCT.md; sourceTree = "<group>"; };
 		C9E3FB991E281CBC00EFA8BB /* TokenScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScanner.swift; sourceTree = "<group>"; };
+		C9E3FB9B1E2860DD00EFA8BB /* TokenScannerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScannerTests.swift; sourceTree = "<group>"; };
 		C9EB448D1C52A74200ACFA87 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		C9EB448F1C52AE4500ACFA87 /* AppController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppController.swift; sourceTree = "<group>"; };
 		C9F7A8601C4D90B50082E5AE /* TokenStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenStore.swift; sourceTree = "<group>"; };
@@ -409,6 +411,7 @@
 				CCC409751DB28BFE000A050D /* TableDiffTests.swift */,
 				CC46C4721DB3040300EB4605 /* TokenListTests.swift */,
 				CC471EEA1DC027A6006858AC /* TokenListViewControllerTest.swift */,
+				C9E3FB9B1E2860DD00EFA8BB /* TokenScannerTests.swift */,
 				CC471EEC1DC1377F006858AC /* MockTableView.swift */,
 				CCCD668A1E1C74B4005FE96E /* OneTimePasswordExtensions.swift */,
 				C99112691E2073710006A6C0 /* UITableViewUpdateTests.swift */,
@@ -662,6 +665,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9E3FB9C1E2860DD00EFA8BB /* TokenScannerTests.swift in Sources */,
 				CCCD668B1E1C74B4005FE96E /* OneTimePasswordExtensions.swift in Sources */,
 				C991126A1E2073710006A6C0 /* UITableViewUpdateTests.swift in Sources */,
 				CC471EEB1DC027A6006858AC /* TokenListViewControllerTest.swift in Sources */,

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		C9D6C83F1906BD68004F0E08 /* SegmentedControlRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C83E1906BD68004F0E08 /* SegmentedControlRow.swift */; };
 		C9D6C8461906CD54004F0E08 /* TextFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C8451906CD54004F0E08 /* TextFieldRow.swift */; };
 		C9D6C84C19075044004F0E08 /* OTPProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C84B19075044004F0E08 /* OTPProgressRing.swift */; };
+		C9E3FB9A1E281CBC00EFA8BB /* TokenScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E3FB991E281CBC00EFA8BB /* TokenScanner.swift */; };
 		C9EB448E1C52A74200ACFA87 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EB448D1C52A74200ACFA87 /* Component.swift */; };
 		C9EB44901C52AE4500ACFA87 /* AppController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EB448F1C52AE4500ACFA87 /* AppController.swift */; };
 		C9F7A8611C4D90B50082E5AE /* TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F7A8601C4D90B50082E5AE /* TokenStore.swift */; };
@@ -163,6 +164,7 @@
 		C9D6C84B19075044004F0E08 /* OTPProgressRing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTPProgressRing.swift; sourceTree = "<group>"; };
 		C9D844341D4C576B00D5E343 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		C9D844361D4C59D600D5E343 /* CONDUCT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONDUCT.md; sourceTree = "<group>"; };
+		C9E3FB991E281CBC00EFA8BB /* TokenScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScanner.swift; sourceTree = "<group>"; };
 		C9EB448D1C52A74200ACFA87 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
 		C9EB448F1C52AE4500ACFA87 /* AppController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppController.swift; sourceTree = "<group>"; };
 		C9F7A8601C4D90B50082E5AE /* TokenStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenStore.swift; sourceTree = "<group>"; };
@@ -347,6 +349,7 @@
 		C97CDF2D1BEF10B300D64406 /* Scanner */ = {
 			isa = PBXGroup;
 			children = (
+				C9E3FB991E281CBC00EFA8BB /* TokenScanner.swift */,
 				C97CDF2B1BEEC90100D64406 /* QRScanner.swift */,
 				C99069D0180CBAC900BAEF53 /* TokenScannerViewController.swift */,
 				8B0028B411EB75920092DE18 /* ScannerOverlayView.swift */,
@@ -645,6 +648,7 @@
 				C9CC09551BA91D1C008C54FE /* TableViewModel.swift in Sources */,
 				C92708AC19CFB0750033128B /* TokenListViewController.swift in Sources */,
 				C9A262DA1E176A18004E6CEB /* Demo.swift in Sources */,
+				C9E3FB9A1E281CBC00EFA8BB /* TokenScanner.swift in Sources */,
 				C93BD6291C168EBF00FFFB8F /* RootViewModel.swift in Sources */,
 				C9F7A8611C4D90B50082E5AE /* TokenStore.swift in Sources */,
 				C9CC09511BA903B7008C54FE /* TokenFormViewController.swift in Sources */,

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -75,8 +75,7 @@ extension Root {
         case TokenListAction(TokenList.Action)
         case TokenEntryFormAction(TokenEntryForm.Action)
         case TokenEditFormAction(TokenEditForm.Action)
-
-        case TokenScannerEffect(TokenScannerViewController.Effect)
+        case TokenScannerAction(TokenScanner.Action)
 
         case AddTokenFromURL(Token)
     }
@@ -126,8 +125,8 @@ extension Root {
             return handleTokenEntryFormAction(action)
         case .TokenEditFormAction(let action):
             return handleTokenEditFormAction(action)
-        case .TokenScannerEffect(let effect):
-            return handleTokenScannerEffect(effect)
+        case .TokenScannerAction(let action):
+            return handleTokenScannerAction(action)
 
         case .AddTokenFromURL(let token):
             return .AddToken(token,
@@ -285,7 +284,21 @@ extension Root {
     }
 
     @warn_unused_result
-    private mutating func handleTokenScannerEffect(effect: TokenScannerViewController.Effect) -> Effect? {
+    private mutating func handleTokenScannerAction(action: TokenScanner.Action) -> Effect? {
+        if case .Scanner(let tokenScanner) = modal {
+            var newScanner = tokenScanner
+            let effect = newScanner.update(action)
+            modal = .Scanner(newScanner)
+            // Handle the resulting effect after committing the changes of the initial action
+            if let effect = effect {
+                return handleTokenScannerEffect(effect)
+            }
+        }
+        return nil
+    }
+
+    @warn_unused_result
+    private mutating func handleTokenScannerEffect(effect: TokenScanner.Effect) -> Effect? {
         switch effect {
         case .Cancel:
             modal = .None

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -318,6 +318,9 @@ extension Root {
             return .AddToken(token,
                              success: Event.TokenFormSucceeded,
                              failure: Event.AddTokenFailed)
+
+        case .ShowErrorMessage(let message):
+            return .ShowErrorMessage(message)
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -31,7 +31,7 @@ struct Root: Component {
 
     private enum Modal {
         case None
-        case Scanner
+        case Scanner(TokenScanner)
         case EntryForm(TokenEntryForm)
         case EditForm(TokenEditForm)
 
@@ -39,8 +39,8 @@ struct Root: Component {
             switch self {
             case .None:
                 return .None
-            case .Scanner:
-                return .Scanner
+            case .Scanner(let scanner):
+                return .Scanner(scanner.viewModel)
             case .EntryForm(let form):
                 return .EntryForm(form.viewModel)
             case .EditForm(let form):
@@ -184,12 +184,12 @@ extension Root {
         case .BeginTokenEntry:
             if Process.isDemo {
                 // If this is a demo, show the scanner even in the simulator.
-                modal = .Scanner
+                modal = .Scanner(TokenScanner())
                 return nil
             }
 
             if QRScanner.deviceCanScan {
-                modal = .Scanner
+                modal = .Scanner(TokenScanner())
             } else {
                 modal = .EntryForm(TokenEntryForm())
             }

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -100,7 +100,7 @@ extension RootViewController {
             } else {
                 let scannerViewController = TokenScannerViewController(
                     viewModel: scannerViewModel,
-                    dispatchAction: compose(Root.Action.TokenScannerEffect, dispatchAction)
+                    dispatchAction: compose(Root.Action.TokenScannerAction, dispatchAction)
                 )
                 presentViewController(scannerViewController)
             }

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -93,12 +93,13 @@ extension RootViewController {
         case .None:
             dismissViewController()
 
-        case .Scanner:
+        case .Scanner(let scannerViewModel):
             if case .Scanner = currentViewModel.modal,
-                let _ = modalNavController?.topViewController as? TokenScannerViewController {
-                // The scanner has no view model of its own to update
+                let scannerViewController = modalNavController?.topViewController as? TokenScannerViewController {
+                scannerViewController.updateWithViewModel(scannerViewModel)
             } else {
                 let scannerViewController = TokenScannerViewController(
+                    viewModel: scannerViewModel,
                     dispatchAction: compose(Root.Action.TokenScannerEffect, dispatchAction)
                 )
                 presentViewController(scannerViewController)

--- a/Authenticator/Source/TokenScanner.swift
+++ b/Authenticator/Source/TokenScanner.swift
@@ -23,6 +23,7 @@
 //  SOFTWARE.
 //
 
+import Foundation
 import OneTimePassword
 
 struct TokenScanner: Component {
@@ -40,7 +41,7 @@ struct TokenScanner: Component {
     enum Action {
         case Cancel
         case BeginManualTokenEntry
-        case SaveNewToken(Token)
+        case ScannerDecodedText(String)
         case ShowErrorMessage(String)
     }
 
@@ -57,7 +58,13 @@ struct TokenScanner: Component {
             return .Cancel
         case .BeginManualTokenEntry:
             return .BeginManualTokenEntry
-        case .SaveNewToken(let token):
+        case .ScannerDecodedText(let text):
+            // Attempt to create a token from the decoded text
+            guard let url = NSURL(string: text),
+                let token = Token(url: url) else {
+                    // Show an error message
+                    return .ShowErrorMessage("Invalid Token")
+            }
             return .SaveNewToken(token)
         case .ShowErrorMessage(let message):
             return .ShowErrorMessage(message)

--- a/Authenticator/Source/TokenScanner.swift
+++ b/Authenticator/Source/TokenScanner.swift
@@ -27,13 +27,22 @@ import Foundation
 import OneTimePassword
 
 struct TokenScanner: Component {
+    private var tokenFound: Bool
+
+    // MARK: Initialization
+
+    init() {
+        tokenFound = false
+    }
+
     // MARK: View
 
     struct ViewModel {
+        var isScanning: Bool
     }
 
     var viewModel: ViewModel {
-        return ViewModel()
+        return ViewModel(isScanning: !tokenFound)
     }
 
     // MARK: Update
@@ -65,6 +74,7 @@ struct TokenScanner: Component {
                     // Show an error message
                     return .ShowErrorMessage("Invalid Token")
             }
+            tokenFound = true
             return .SaveNewToken(token)
 
         case .ScannerError(let error):

--- a/Authenticator/Source/TokenScanner.swift
+++ b/Authenticator/Source/TokenScanner.swift
@@ -23,6 +23,8 @@
 //  SOFTWARE.
 //
 
+import OneTimePassword
+
 struct TokenScanner: Component {
     // MARK: View
 
@@ -36,15 +38,25 @@ struct TokenScanner: Component {
     // MARK: Update
 
     enum Action {
+        case Cancel
+        case BeginManualTokenEntry
+        case SaveNewToken(Token)
     }
 
     enum Effect {
+        case Cancel
+        case BeginManualTokenEntry
+        case SaveNewToken(Token)
     }
 
     mutating func update(action: Action) -> Effect? {
         switch action {
-        default:
-            return nil
+        case .Cancel:
+            return .Cancel
+        case .BeginManualTokenEntry:
+            return .BeginManualTokenEntry
+        case .SaveNewToken(let token):
+            return .SaveNewToken(token)
         }
     }
 }

--- a/Authenticator/Source/TokenScanner.swift
+++ b/Authenticator/Source/TokenScanner.swift
@@ -41,12 +41,14 @@ struct TokenScanner: Component {
         case Cancel
         case BeginManualTokenEntry
         case SaveNewToken(Token)
+        case ShowErrorMessage(String)
     }
 
     enum Effect {
         case Cancel
         case BeginManualTokenEntry
         case SaveNewToken(Token)
+        case ShowErrorMessage(String)
     }
 
     mutating func update(action: Action) -> Effect? {
@@ -57,6 +59,8 @@ struct TokenScanner: Component {
             return .BeginManualTokenEntry
         case .SaveNewToken(let token):
             return .SaveNewToken(token)
+        case .ShowErrorMessage(let message):
+            return .ShowErrorMessage(message)
         }
     }
 }

--- a/Authenticator/Source/TokenScanner.swift
+++ b/Authenticator/Source/TokenScanner.swift
@@ -65,8 +65,10 @@ struct TokenScanner: Component {
         switch action {
         case .Cancel:
             return .Cancel
+
         case .BeginManualTokenEntry:
             return .BeginManualTokenEntry
+
         case .ScannerDecodedText(let text):
             // Attempt to create a token from the decoded text
             guard let url = NSURL(string: text),

--- a/Authenticator/Source/TokenScanner.swift
+++ b/Authenticator/Source/TokenScanner.swift
@@ -1,8 +1,8 @@
 //
-//  RootViewModel.swift
+//  TokenScanner.swift
 //  Authenticator
 //
-//  Copyright (c) 2015-2016 Authenticator authors
+//  Copyright (c) 2017 Authenticator authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -23,14 +23,28 @@
 //  SOFTWARE.
 //
 
-struct RootViewModel {
-    let tokenList: TokenList.ViewModel
-    let modal: ModalViewModel
+struct TokenScanner: Component {
+    // MARK: View
 
-    enum ModalViewModel {
-        case None
-        case Scanner(TokenScanner.ViewModel)
-        case EntryForm(TokenEntryForm.ViewModel)
-        case EditForm(TokenEditForm.ViewModel)
+    struct ViewModel {
+    }
+
+    var viewModel: ViewModel {
+        return ViewModel()
+    }
+
+    // MARK: Update
+
+    enum Action {
+    }
+
+    enum Effect {
+    }
+
+    mutating func update(action: Action) -> Effect? {
+        switch action {
+        default:
+            return nil
+        }
     }
 }

--- a/Authenticator/Source/TokenScanner.swift
+++ b/Authenticator/Source/TokenScanner.swift
@@ -42,7 +42,7 @@ struct TokenScanner: Component {
         case Cancel
         case BeginManualTokenEntry
         case ScannerDecodedText(String)
-        case ShowErrorMessage(String)
+        case ScannerError(ErrorType)
     }
 
     enum Effect {
@@ -66,8 +66,10 @@ struct TokenScanner: Component {
                     return .ShowErrorMessage("Invalid Token")
             }
             return .SaveNewToken(token)
-        case .ShowErrorMessage(let message):
-            return .ShowErrorMessage(message)
+
+        case .ScannerError(let error):
+            print("Error: \(error)")
+            return .ShowErrorMessage("Capture Failed")
         }
     }
 }

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -33,11 +33,11 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     private let videoLayer = AVCaptureVideoPreviewLayer()
 
     private var viewModel: TokenScanner.ViewModel
-    private let dispatchAction: (Effect) -> Void
+    private let dispatchAction: (TokenScanner.Action) -> Void
 
     // MARK: Initialization
 
-    init(viewModel: TokenScanner.ViewModel, dispatchAction: (Effect) -> Void) {
+    init(viewModel: TokenScanner.ViewModel, dispatchAction: (TokenScanner.Action) -> Void) {
         self.viewModel = viewModel
         self.dispatchAction = dispatchAction
         super.init(nibName: nil, bundle: nil)
@@ -101,12 +101,6 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     }
 
     // MARK: Target Actions
-
-    enum Effect {
-        case Cancel
-        case BeginManualTokenEntry
-        case SaveNewToken(Token)
-    }
 
     func cancel() {
         dispatchAction(.Cancel)

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -117,7 +117,6 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     }
 
     func handleError(error: ErrorType) {
-        print("Error: \(error)")
-        dispatchAction(.ShowErrorMessage("Capture Failed"))
+        dispatchAction(.ScannerError(error))
     }
 }

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -112,7 +112,9 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     // MARK: QRScannerDelegate
 
     func handleDecodedText(text: String) {
-        // TODO: Ensure the scanning stops after the first successful capture
+        guard viewModel.isScanning else {
+            return
+        }
         dispatchAction(.ScannerDecodedText(text))
     }
 

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -26,7 +26,6 @@
 import UIKit
 import AVFoundation
 import OneTimePassword
-import SVProgressHUD
 
 class TokenScannerViewController: UIViewController, QRScannerDelegate {
     private let scanner = QRScanner()
@@ -117,7 +116,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
         guard let url = NSURL(string: text),
             let token = Token(url: url) else {
                 // Show an error message
-                SVProgressHUD.showErrorWithStatus("Invalid Token")
+                dispatchAction(.ShowErrorMessage("Invalid Token"))
                 return
         }
 
@@ -129,6 +128,6 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
 
     func handleError(error: ErrorType) {
         print("Error: \(error)")
-        SVProgressHUD.showErrorWithStatus("Capture Failed")
+        dispatchAction(.ShowErrorMessage("Capture Failed"))
     }
 }

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -112,18 +112,8 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     // MARK: QRScannerDelegate
 
     func handleDecodedText(text: String) {
-        // Attempt to create a token from the decoded text
-        guard let url = NSURL(string: text),
-            let token = Token(url: url) else {
-                // Show an error message
-                dispatchAction(.ShowErrorMessage("Invalid Token"))
-                return
-        }
-
-        // Halt the video capture
-        scanner.stop()
-        // Inform the delegate that an auth URL was captured
-        dispatchAction(.SaveNewToken(token))
+        // TODO: Ensure the scanning stops after the first successful capture
+        dispatchAction(.ScannerDecodedText(text))
     }
 
     func handleError(error: ErrorType) {

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -32,17 +32,23 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     private let scanner = QRScanner()
     private let videoLayer = AVCaptureVideoPreviewLayer()
 
+    private var viewModel: TokenScanner.ViewModel
     private let dispatchAction: (Effect) -> Void
 
     // MARK: Initialization
 
-    init(dispatchAction: (Effect) -> Void) {
+    init(viewModel: TokenScanner.ViewModel, dispatchAction: (Effect) -> Void) {
+        self.viewModel = viewModel
         self.dispatchAction = dispatchAction
         super.init(nibName: nil, bundle: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func updateWithViewModel(viewModel: TokenScanner.ViewModel) {
+        self.viewModel = viewModel
     }
 
     // MARK: View Lifecycle

--- a/AuthenticatorTests/TokenScannerTests.swift
+++ b/AuthenticatorTests/TokenScannerTests.swift
@@ -1,0 +1,131 @@
+//
+//  TokenScannerTests.swift
+//  Authenticator
+//
+//  Copyright (c) 2017 Authenticator authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import XCTest
+@testable import Authenticator
+import OneTimePassword
+
+class TokenScannerTests: XCTestCase {
+    func testCancel() {
+        var tokenScanner = TokenScanner()
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+
+        let action = TokenScanner.Action.Cancel
+        let effect = tokenScanner.update(action)
+        guard let requiredEffect = effect,
+            case .Cancel = requiredEffect else {
+                XCTFail("Expected effect .Cancel, got \(effect)")
+                return
+        }
+
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+    }
+
+    func testCompose() {
+        var tokenScanner = TokenScanner()
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+
+        let action = TokenScanner.Action.BeginManualTokenEntry
+        let effect = tokenScanner.update(action)
+        guard let requiredEffect = effect,
+            case .BeginManualTokenEntry = requiredEffect else {
+                XCTFail("Expected effect .BeginManualTokenEntry, got \(effect)")
+                return
+        }
+
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+    }
+
+    func testScannerDecodedBadText() {
+        var tokenScanner = TokenScanner()
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+
+        let action = TokenScanner.Action.ScannerDecodedText("something...")
+        let effect = tokenScanner.update(action)
+        guard let requiredEffect = effect,
+            case .ShowErrorMessage(let message) = requiredEffect else {
+                XCTFail("Expected effect .ShowErrorMessage, got \(effect)")
+                return
+        }
+        XCTAssertEqual(message, "Invalid Token")
+
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+    }
+
+    func testScannerDecodedBadURL() {
+        var tokenScanner = TokenScanner()
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+
+        let urlString = "http://example.com"
+        let action = TokenScanner.Action.ScannerDecodedText(urlString)
+        let effect = tokenScanner.update(action)
+        guard let requiredEffect = effect,
+            case .ShowErrorMessage(let message) = requiredEffect else {
+                XCTFail("Expected effect .ShowErrorMessage, got \(effect)")
+                return
+        }
+        XCTAssertEqual(message, "Invalid Token")
+
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+    }
+
+    func testScannerDecodedGoodURL() {
+        var tokenScanner = TokenScanner()
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+
+        let urlString = "otpauth://totp/Authenticator?secret=ABCDEFGHIJKLMNOP"
+        let action = TokenScanner.Action.ScannerDecodedText(urlString)
+        let effect = tokenScanner.update(action)
+        guard let requiredEffect = effect,
+            case .SaveNewToken(let token) = requiredEffect else {
+                XCTFail("Expected effect .SaveNewToken, got \(effect)")
+                return
+        }
+        // swiftlint:disable:next force_unwrapping
+        let expectedToken = Token(url: NSURL(string: urlString)!)
+        XCTAssertEqual(token, expectedToken)
+
+        // The scanner should stop after the first successful token capture.
+        XCTAssertFalse(tokenScanner.viewModel.isScanning)
+    }
+
+    struct ScannerError: ErrorType {}
+
+    func testScannerError() {
+        var tokenScanner = TokenScanner()
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+
+        let action = TokenScanner.Action.ScannerError(ScannerError())
+        let effect = tokenScanner.update(action)
+        guard let requiredEffect = effect,
+            case .ShowErrorMessage(let message) = requiredEffect else {
+                XCTFail("Expected effect .ShowErrorMessage, got \(effect)")
+                return
+        }
+        XCTAssertEqual(message, "Capture Failed")
+
+        XCTAssertTrue(tokenScanner.viewModel.isScanning)
+    }
+}


### PR DESCRIPTION
Refactor the `TokenScannerViewController` to add a `TokenScanner` component. This brings the token scanner in line with the pattern used for the rest of the view controllers, and also makes some of the scanner's behavior testable.