### PR TITLE
Move the device-can-scan logic out of the Root component

### DIFF
--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -68,7 +68,13 @@ class AppController {
             fatalError("Failed to load token store: \(error)")
         }
 
-        component = Root(persistentTokens: store.persistentTokens, displayTime: .currentDisplayTime())
+        // If this is a demo, show the scanner even in the simulator.
+        let deviceCanScan = QRScanner.deviceCanScan || Process.isDemo
+        component = Root(
+            persistentTokens: store.persistentTokens,
+            displayTime: .currentDisplayTime(),
+            deviceCanScan: deviceCanScan
+        )
 
         startTick()
     }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -28,6 +28,7 @@ import OneTimePassword
 struct Root: Component {
     private var tokenList: TokenList
     private var modal: Modal
+    private let deviceCanScan: Bool
 
     private enum Modal {
         case None
@@ -49,9 +50,10 @@ struct Root: Component {
         }
     }
 
-    init(persistentTokens: [PersistentToken], displayTime: DisplayTime) {
+    init(persistentTokens: [PersistentToken], displayTime: DisplayTime, deviceCanScan: Bool) {
         tokenList = TokenList(persistentTokens: persistentTokens, displayTime: displayTime)
         modal = .None
+        self.deviceCanScan = deviceCanScan
     }
 }
 
@@ -181,13 +183,7 @@ extension Root {
     private mutating func handleTokenListEffect(effect: TokenList.Effect) -> Effect? {
         switch effect {
         case .BeginTokenEntry:
-            if Process.isDemo {
-                // If this is a demo, show the scanner even in the simulator.
-                modal = .Scanner(TokenScanner())
-                return nil
-            }
-
-            if QRScanner.deviceCanScan {
+            if deviceCanScan {
                 modal = .Scanner(TokenScanner())
             } else {
                 modal = .EntryForm(TokenEntryForm())


### PR DESCRIPTION
This moves logic which depends on the device and the process arguments arguments out of the functional component, with the goal of improving testability.