### PR TITLE
Prevent scrolling when the table view is empty

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -258,9 +258,9 @@ extension TokenListViewController {
     }
 
     fileprivate func updatePeripheralViews() {
-
         searchBar.updateWithViewModel(viewModel)
 
+        tableView.isScrollEnabled = viewModel.hasTokens
         editButtonItem.isEnabled = viewModel.hasTokens
         noTokensLabel.isHidden = viewModel.hasTokens
         warningLabel.isHidden = viewModel.hasTokens


### PR DESCRIPTION
This prevents the odd behavior of letting the user scroll the empty state labels off-screen.