### PR TITLE
Token list empty state improvements

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -66,7 +66,7 @@ class TokenListViewController: UITableViewController {
         return label
     }()
 
-    fileprivate let warningLabel: UILabel = {
+    fileprivate let backupWarningLabel: UILabel = {
         let linkTitle = "Learn More →"
         let message = "For security reasons, tokens will be stored only on this \(UIDevice.current.model), and will not be included in iCloud or unencrypted backups.  \(linkTitle)"
         let paragraphStyle = NSMutableParagraphStyle()
@@ -89,8 +89,14 @@ class TokenListViewController: UITableViewController {
         return label
     }()
 
-    private let warningButton: UIButton = {
+    fileprivate lazy var backupWarning: UIButton = {
         let button = UIButton(type: .custom)
+        button.addTarget(self, action: #selector(showBackupInfo), for: .touchUpInside)
+
+        self.backupWarningLabel.frame = button.bounds
+        self.backupWarningLabel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        button.addSubview(self.backupWarningLabel)
+
         return button
     }()
 
@@ -138,17 +144,11 @@ class TokenListViewController: UITableViewController {
         self.view.addSubview(self.noTokensLabel)
 
         let labelMargin: CGFloat = 20
-        let labelSize = warningLabel.sizeThatFits(view.bounds.insetBy(dx: labelMargin, dy: labelMargin).size)
+        let labelSize = backupWarningLabel.sizeThatFits(view.bounds.insetBy(dx: labelMargin, dy: labelMargin).size)
         let labelOrigin = CGPoint(x: labelMargin, y: view.bounds.maxY - labelMargin - labelSize.height)
-        warningLabel.frame = CGRect(origin: labelOrigin, size: labelSize)
-        warningLabel.autoresizingMask = [.flexibleTopMargin, .flexibleWidth]
-        view.addSubview(warningLabel)
-
-        let warningButton = UIButton()
-        warningButton.frame = warningLabel.frame
-        warningButton.autoresizingMask = warningLabel.autoresizingMask
-        warningButton.addTarget(self, action: #selector(showBackupInfo), for: .touchUpInside)
-        view.addSubview(warningButton)
+        backupWarning.frame = CGRect(origin: labelOrigin, size: labelSize)
+        backupWarning.autoresizingMask = [.flexibleTopMargin, .flexibleWidth]
+        view.addSubview(backupWarning)
 
         infoButton.addTarget(self, action: #selector(TokenListViewController.showLicenseInfo), for: .touchUpInside)
 
@@ -263,7 +263,7 @@ extension TokenListViewController {
         tableView.isScrollEnabled = viewModel.hasTokens
         editButtonItem.isEnabled = viewModel.hasTokens
         noTokensLabel.isHidden = viewModel.hasTokens
-        warningLabel.isHidden = viewModel.hasTokens
+        backupWarning.isHidden = viewModel.hasTokens
 
         // Exit editing mode if no tokens remain
         if self.isEditing && viewModel.rowModels.isEmpty {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -135,19 +135,7 @@ class TokenListViewController: UITableViewController {
         self.navigationController?.isToolbarHidden = false
 
         // Configure "no tokens" label
-        self.noTokensLabel.frame = CGRect(
-            x: 0,
-            y: 0,
-            width: self.view.bounds.size.width,
-            height: self.view.bounds.size.height * 0.6
-        )
-        self.view.addSubview(self.noTokensLabel)
-
-        let labelMargin: CGFloat = 20
-        let labelSize = backupWarningLabel.sizeThatFits(view.bounds.insetBy(dx: labelMargin, dy: labelMargin).size)
-        let labelOrigin = CGPoint(x: labelMargin, y: view.bounds.maxY - labelMargin - labelSize.height)
-        backupWarning.frame = CGRect(origin: labelOrigin, size: labelSize)
-        backupWarning.autoresizingMask = [.flexibleTopMargin, .flexibleWidth]
+        view.addSubview(noTokensLabel)
         view.addSubview(backupWarning)
 
         infoButton.addTarget(self, action: #selector(TokenListViewController.showLicenseInfo), for: .touchUpInside)
@@ -167,6 +155,21 @@ class TokenListViewController: UITableViewController {
         super.viewWillDisappear(animated)
 
         self.isEditing = false
+    }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        let labelMargin: CGFloat = 20
+        let insetBounds = view.bounds.insetBy(dx: labelMargin, dy: labelMargin)
+        let noTokensLabelSize = noTokensLabel.sizeThatFits(insetBounds.size)
+        let noTokensLabelOrigin = CGPoint(x: (view.bounds.width - noTokensLabelSize.width) / 2,
+                                          y: (view.bounds.height * 0.6 - noTokensLabelSize.height) / 2)
+        noTokensLabel.frame = CGRect(origin: noTokensLabelOrigin, size: noTokensLabelSize)
+
+        let labelSize = backupWarningLabel.sizeThatFits(insetBounds.size)
+        let labelOrigin = CGPoint(x: labelMargin, y: view.bounds.maxY - labelMargin - labelSize.height)
+        backupWarning.frame = CGRect(origin: labelOrigin, size: labelSize)
     }
 
     // MARK: Target Actions

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -66,6 +66,17 @@ class TokenListViewController: UITableViewController {
         return label
     }()
 
+    fileprivate lazy var noTokensButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.addTarget(self, action: #selector(addToken), for: .touchUpInside)
+
+        self.noTokensLabel.frame = button.bounds
+        self.noTokensLabel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        button.addSubview(self.noTokensLabel)
+
+        return button
+    }()
+
     fileprivate let backupWarningLabel: UILabel = {
         let linkTitle = "Learn More →"
         let message = "For security reasons, tokens will be stored only on this \(UIDevice.current.model), and will not be included in iCloud or unencrypted backups.  \(linkTitle)"
@@ -134,8 +145,8 @@ class TokenListViewController: UITableViewController {
         ]
         self.navigationController?.isToolbarHidden = false
 
-        // Configure "no tokens" label
-        view.addSubview(noTokensLabel)
+        // Configure empty state
+        view.addSubview(noTokensButton)
         view.addSubview(backupWarning)
 
         infoButton.addTarget(self, action: #selector(TokenListViewController.showLicenseInfo), for: .touchUpInside)
@@ -165,7 +176,7 @@ class TokenListViewController: UITableViewController {
         let noTokensLabelSize = noTokensLabel.sizeThatFits(insetBounds.size)
         let noTokensLabelOrigin = CGPoint(x: (view.bounds.width - noTokensLabelSize.width) / 2,
                                           y: (view.bounds.height * 0.6 - noTokensLabelSize.height) / 2)
-        noTokensLabel.frame = CGRect(origin: noTokensLabelOrigin, size: noTokensLabelSize)
+        noTokensButton.frame = CGRect(origin: noTokensLabelOrigin, size: noTokensLabelSize)
 
         let labelSize = backupWarningLabel.sizeThatFits(insetBounds.size)
         let labelOrigin = CGPoint(x: labelMargin, y: view.bounds.maxY - labelMargin - labelSize.height)
@@ -265,7 +276,7 @@ extension TokenListViewController {
 
         tableView.isScrollEnabled = viewModel.hasTokens
         editButtonItem.isEnabled = viewModel.hasTokens
-        noTokensLabel.isHidden = viewModel.hasTokens
+        noTokensButton.isHidden = viewModel.hasTokens
         backupWarning.isHidden = viewModel.hasTokens
 
         // Exit editing mode if no tokens remain


### PR DESCRIPTION
Adds a button to the "no tokens" label, allowing it to be tapped to perform the same action as tapping the "+" in the toolbar. Also, fixes a bug where the backup warning button would invisibly remain when the label was hidden.