### PR TITLE
Handle missing camera permissions

### DIFF
--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -182,6 +182,13 @@ class AppController {
                 feedbackGenerator.notificationOccurred(.success)
             }
 
+        case .showApplicationSettings:
+            guard let applicationSettingsURL = URL(string: UIApplicationOpenSettingsURLString) else {
+                handleEffect(.showErrorMessage("Failed to open application settings."))
+                return
+            }
+            UIApplication.shared.openURL(applicationSettingsURL)
+
         case let .openURL(url):
             if #available(iOS 9.0, *) {
                 let safariViewController = SFSafariViewController(url: url)

--- a/Authenticator/Source/QRScanner.swift
+++ b/Authenticator/Source/QRScanner.swift
@@ -92,6 +92,14 @@ class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         return (AVCaptureDevice.defaultDevice(withMediaType: AVMediaTypeVideo) != nil)
     }
 
+    class var authorizationStatus: AVAuthorizationStatus {
+        return AVCaptureDevice.authorizationStatus(forMediaType: AVMediaTypeVideo)
+    }
+
+    class func requestAccess(_ completionHandler: @escaping (Bool) -> Void) {
+        AVCaptureDevice.requestAccess(forMediaType: AVMediaTypeVideo, completionHandler: completionHandler)
+    }
+
     // MARK: AVCaptureMetadataOutputObjectsDelegate
 
     func captureOutput(_ captureOutput: AVCaptureOutput?, didOutputMetadataObjects metadataObjects: [Any]?, from connection: AVCaptureConnection?) {

--- a/Authenticator/Source/QRScanner.swift
+++ b/Authenticator/Source/QRScanner.swift
@@ -62,17 +62,17 @@ class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     // MARK: Capture
 
     enum CaptureSessionError: Error {
-        case inputError
-        case outputError
+        case noCaptureDevice
+        case noQRCodeMetadataType
     }
 
     private class func createCaptureSessionWithDelegate(_ delegate: AVCaptureMetadataOutputObjectsDelegate) throws -> AVCaptureSession {
         let captureSession = AVCaptureSession()
 
-        guard let captureDevice = AVCaptureDevice.defaultDevice(withMediaType: AVMediaTypeVideo),
-            let captureInput = try? AVCaptureDeviceInput(device: captureDevice) else {
-                throw CaptureSessionError.inputError
+        guard let captureDevice = AVCaptureDevice.defaultDevice(withMediaType: AVMediaTypeVideo) else {
+            throw CaptureSessionError.noCaptureDevice
         }
+        let captureInput = try AVCaptureDeviceInput(device: captureDevice)
         captureSession.addInput(captureInput)
 
         let captureOutput = AVCaptureMetadataOutput()
@@ -80,7 +80,7 @@ class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         captureSession.addOutput(captureOutput)
         guard let availableTypes = captureOutput.availableMetadataObjectTypes,
             (availableTypes as NSArray).contains(AVMetadataObjectTypeQRCode) else {
-                throw CaptureSessionError.outputError
+                throw CaptureSessionError.noQRCodeMetadataType
         }
         captureOutput.metadataObjectTypes = [AVMetadataObjectTypeQRCode]
         captureOutput.setMetadataObjectsDelegate(delegate, queue: DispatchQueue.main)

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -119,6 +119,7 @@ extension Root {
 
         case showErrorMessage(String)
         case showSuccessMessage(String)
+        case showApplicationSettings
         case openURL(URL)
     }
 
@@ -282,6 +283,9 @@ extension Root {
 
             modal = .entryForm(TokenEntryForm())
             return nil
+
+        case .showApplicationSettings:
+            return .showApplicationSettings
 
         case .saveNewToken(let token):
             return .addToken(token,

--- a/Authenticator/Source/TokenScanner.swift
+++ b/Authenticator/Source/TokenScanner.swift
@@ -50,6 +50,7 @@ struct TokenScanner: Component {
     enum Action {
         case cancel
         case beginManualTokenEntry
+        case showApplicationSettings
         case scannerDecodedText(String)
         case scannerError(Error)
     }
@@ -57,6 +58,7 @@ struct TokenScanner: Component {
     enum Effect {
         case cancel
         case beginManualTokenEntry
+        case showApplicationSettings
         case saveNewToken(Token)
         case showErrorMessage(String)
     }
@@ -68,6 +70,9 @@ struct TokenScanner: Component {
 
         case .beginManualTokenEntry:
             return .beginManualTokenEntry
+
+        case .showApplicationSettings:
+            return .showApplicationSettings
 
         case .scannerDecodedText(let text):
             // Attempt to create a token from the decoded text

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -57,7 +57,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
 
     private lazy var permissionButton: UIButton = {
         let button = UIButton(frame: UIScreen.main.bounds)
-        button.backgroundColor = .otpBackgroundColor
+        button.backgroundColor = .black
         button.addTarget(self, action: #selector(TokenScannerViewController.editPermissions), for: .touchUpInside)
 
         self.permissionLabel.frame = button.bounds.insetBy(dx: 35, dy: 35)
@@ -143,7 +143,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
             showMissingAccessMessage()
         case .restricted:
             // There's nothing we can do if camera access is restricted.
-            // This should only ever be reached is camera restrictions are changed while the app is running, because if
+            // This should only ever be reached if camera restrictions are changed while the app is running, because if
             // the app is launched with restrictions already enabled, the deviceCanScan check will retrun false.
             dispatchAction(.beginManualTokenEntry)
             break

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -30,12 +30,11 @@ import OneTimePassword
 class TokenScannerViewController: UIViewController, QRScannerDelegate {
     private let scanner = QRScanner()
     private let videoLayer = AVCaptureVideoPreviewLayer()
-    private let messageView = UIButton()
 
     private var viewModel: TokenScanner.ViewModel
     private let dispatchAction: (TokenScanner.Action) -> Void
 
-    fileprivate let permissionLabel: UILabel = {
+    private let permissionLabel: UILabel = {
         let linkTitle = "Go to Settings →"
         let message = "To add a new token via QR code, Authenticator needs permission to access the camera.\n\(linkTitle)"
         let paragraphStyle = NSMutableParagraphStyle()
@@ -54,6 +53,18 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
         label.textAlignment = .center
         label.textColor = UIColor.otpForegroundColor
         return label
+    }()
+
+    private lazy var permissionButton: UIButton = {
+        let button = UIButton(frame: UIScreen.main.bounds)
+        button.backgroundColor = .otpBackgroundColor
+        button.addTarget(self, action: #selector(TokenScannerViewController.editPermissions), for: .touchUpInside)
+
+        self.permissionLabel.frame = button.bounds.insetBy(dx: 35, dy: 35)
+        self.permissionLabel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        button.addSubview(self.permissionLabel)
+
+        return button
     }()
 
     // MARK: Initialization
@@ -95,16 +106,10 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
         videoLayer.frame = view.layer.bounds
         view.layer.addSublayer(videoLayer)
 
-        messageView.backgroundColor = UIColor.otpBackgroundColor
-        messageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        messageView.frame = view.bounds
-        messageView.isHidden = true
-        messageView.addTarget(self, action: #selector(TokenScannerViewController.editPermissions), for: .touchUpInside)
-        view.addSubview(messageView)
-
-        permissionLabel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        permissionLabel.frame = messageView.bounds.insetBy(dx: 35, dy: 35)
-        messageView.addSubview(permissionLabel)
+        permissionButton.frame = view.bounds
+        permissionButton.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        permissionButton.isHidden = true
+        view.addSubview(permissionButton)
 
         if CommandLine.isDemo {
             // If this is a demo, display an image in place of the AVCaptureVideoPreviewLayer.
@@ -150,7 +155,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     }
 
     private func showMissingAccessMessage() {
-        messageView.isHidden = false
+        permissionButton.isHidden = false
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -143,6 +143,9 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
             showMissingAccessMessage()
         case .restricted:
             // There's nothing we can do if camera access is restricted.
+            // This should only ever be reached is camera restrictions are changed while the app is running, because if
+            // the app is launched with restrictions already enabled, the deviceCanScan check will retrun false.
+            dispatchAction(.beginManualTokenEntry)
             break
         }
     }

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -174,9 +174,7 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
     }
 
     func editPermissions() {
-        if let applicationSettingsURL = URL(string: UIApplicationOpenSettingsURLString) {
-            UIApplication.shared.openURL(applicationSettingsURL)
-        }
+        dispatchAction(.showApplicationSettings)
     }
 
     // MARK: QRScannerDelegate

--- a/AuthenticatorTests/TokenScannerTests.swift
+++ b/AuthenticatorTests/TokenScannerTests.swift
@@ -58,6 +58,18 @@ class TokenScannerTests: XCTestCase {
         XCTAssertTrue(tokenScanner.viewModel.isScanning)
     }
 
+    func testShowApplicationSettings() {
+        var tokenScanner = TokenScanner()
+
+        let action = TokenScanner.Action.showApplicationSettings
+        let effect = tokenScanner.update(action)
+        guard let requiredEffect = effect,
+            case .showApplicationSettings = requiredEffect else {
+                XCTFail("Expected effect .showApplicationSettings, got \(String(describing: effect))")
+                return
+        }
+    }
+
     func testScannerDecodedBadText() {
         var tokenScanner = TokenScanner()
         XCTAssertTrue(tokenScanner.viewModel.isScanning)


### PR DESCRIPTION
If the user tries to add a token after rejecting the request for camera access, instead of a showing a generic error message, show a message explaining the restriction with a link to the permission settings.

Closes #176.

<img src="https://cloud.githubusercontent.com/assets/532638/26089787/51ae2102-39ce-11e7-84ca-b0939883b41b.png" width="300px">
