### PR TITLE
Refactor AVCaptureSession creation

### DIFF
--- a/Authenticator/Source/QRScanner.swift
+++ b/Authenticator/Source/QRScanner.swift
@@ -27,7 +27,6 @@ import AVFoundation
 
 protocol QRScannerDelegate: class {
     func handleDecodedText(_ text: String)
-    func handleError(_ error: Error)
 }
 
 class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
@@ -35,7 +34,7 @@ class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     private let serialQueue = DispatchQueue(label: "QRScanner serial queue")
     private var captureSession: AVCaptureSession?
 
-    func start(_ completion: @escaping (AVCaptureSession) -> Void) {
+    func start(success: @escaping (AVCaptureSession) -> Void, failure: @escaping (Error) -> Void) {
         serialQueue.async {
             do {
                 let captureSession = try self.captureSession ?? QRScanner.createCaptureSessionWithDelegate(self)
@@ -43,12 +42,12 @@ class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
 
                 self.captureSession = captureSession
                 DispatchQueue.main.async {
-                    completion(captureSession)
+                    success(captureSession)
                 }
             } catch {
                 self.captureSession = nil
                 DispatchQueue.main.async {
-                    self.delegate?.handleError(error)
+                    failure(error)
                 }
             }
         }

--- a/Authenticator/Source/QRScanner.swift
+++ b/Authenticator/Source/QRScanner.swift
@@ -35,13 +35,13 @@ class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
     private let serialQueue = DispatchQueue(label: "QRScanner serial queue")
     private var captureSession: AVCaptureSession?
 
-    func start(_ completion: @escaping (AVCaptureSession?) -> Void) {
+    func start(_ completion: @escaping (AVCaptureSession) -> Void) {
         serialQueue.async {
             do {
-                self.captureSession = try QRScanner.createCaptureSessionWithDelegate(self)
-                self.captureSession?.startRunning()
+                let captureSession = try self.captureSession ?? QRScanner.createCaptureSessionWithDelegate(self)
+                captureSession.startRunning()
                 DispatchQueue.main.async {
-                    completion(self.captureSession)
+                    completion(captureSession)
                 }
             } catch {
                 self.captureSession = nil

--- a/Authenticator/Source/QRScanner.swift
+++ b/Authenticator/Source/QRScanner.swift
@@ -40,6 +40,8 @@ class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
             do {
                 let captureSession = try self.captureSession ?? QRScanner.createCaptureSessionWithDelegate(self)
                 captureSession.startRunning()
+
+                self.captureSession = captureSession
                 DispatchQueue.main.async {
                     completion(captureSession)
                 }

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -152,9 +152,11 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
 
     private func startScanning() {
         scanner.delegate = self
-        scanner.start { captureSession in
+        scanner.start(success: { captureSession in
             self.videoLayer.session = captureSession
-        }
+        }, failure: { error in
+            self.dispatchAction(.scannerError(error))
+        })
     }
 
     private func showMissingAccessMessage() {
@@ -187,9 +189,5 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
             return
         }
         dispatchAction(.scannerDecodedText(text))
-    }
-
-    func handleError(_ error: Error) {
-        dispatchAction(.scannerError(error))
     }
 }

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -152,10 +152,10 @@ class TokenScannerViewController: UIViewController, QRScannerDelegate {
 
     private func startScanning() {
         scanner.delegate = self
-        scanner.start(success: { captureSession in
-            self.videoLayer.session = captureSession
-        }, failure: { error in
-            self.dispatchAction(.scannerError(error))
+        scanner.start(success: { [weak self] captureSession in
+            self?.videoLayer.session = captureSession
+        }, failure: { [weak self] error in
+            self?.dispatchAction(.scannerError(error))
         })
     }
 


### PR DESCRIPTION
In cases where camera permissions were denied, the lazily-created capture session was (correctly) never started, but then would be instantiated when we tried to stop it, throwing an error. This new approach only creates a new capture session when it is told to start.

Also, refactor the handling of success and failure for `QRScanner.start(…)`.