### PR TITLE
Prevent haptic overload

### DIFF
--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -166,11 +166,11 @@ class AppController {
 
         case let .showErrorMessage(message):
             SVProgressHUD.showError(withStatus: message)
-            generateFeedback(for: .error)
+            generateHapticFeedback(for: .error)
 
         case let .showSuccessMessage(message):
             SVProgressHUD.showSuccess(withStatus: message)
-            generateFeedback(for: .success)
+            generateHapticFeedback(for: .success)
 
         case .showApplicationSettings:
             guard let applicationSettingsURL = URL(string: UIApplicationOpenSettingsURLString) else {
@@ -198,8 +198,7 @@ class AppController {
         return topViewController(presentedFrom: presentedViewController)
     }
 
-    // Provide haptic feedback to accompany success and error messages
-    private func generateFeedback(for notificationFeedbackType: UINotificationFeedbackType) {
+    private func generateHapticFeedback(for notificationFeedbackType: UINotificationFeedbackType) {
         if #available(iOS 10.0, *) {
             let feedbackGenerator = UINotificationFeedbackGenerator()
             feedbackGenerator.notificationOccurred(notificationFeedbackType)

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -53,7 +53,6 @@ class AppController {
             dispatchAction: self.handleAction
         )
     }()
-    private var lastHapticFeedback = Date(timeIntervalSince1970: 0)
 
     init() {
         do {
@@ -202,12 +201,8 @@ class AppController {
     // Provide haptic feedback to accompany success and error messages
     private func generateFeedback(for notificationFeedbackType: UINotificationFeedbackType) {
         if #available(iOS 10.0, *) {
-            let now = Date()
-            if now.timeIntervalSince(lastHapticFeedback) > 1 {
-                lastHapticFeedback = now
-                let feedbackGenerator = UINotificationFeedbackGenerator()
-                feedbackGenerator.notificationOccurred(notificationFeedbackType)
-            }
+            let feedbackGenerator = UINotificationFeedbackGenerator()
+            feedbackGenerator.notificationOccurred(notificationFeedbackType)
         }
     }
 

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -53,6 +53,7 @@ class AppController {
             dispatchAction: self.handleAction
         )
     }()
+    private var lastHapticFeedback = Date(timeIntervalSince1970: 0)
 
     init() {
         do {
@@ -166,21 +167,11 @@ class AppController {
 
         case let .showErrorMessage(message):
             SVProgressHUD.showError(withStatus: message)
-
-            // Provide haptic feedback
-            if #available(iOS 10.0, *) {
-                let feedbackGenerator = UINotificationFeedbackGenerator()
-                feedbackGenerator.notificationOccurred(.error)
-            }
+            generateFeedback(for: .error)
 
         case let .showSuccessMessage(message):
             SVProgressHUD.showSuccess(withStatus: message)
-
-            // Provide haptic feedback
-            if #available(iOS 10.0, *) {
-                let feedbackGenerator = UINotificationFeedbackGenerator()
-                feedbackGenerator.notificationOccurred(.success)
-            }
+            generateFeedback(for: .success)
 
         case .showApplicationSettings:
             guard let applicationSettingsURL = URL(string: UIApplicationOpenSettingsURLString) else {
@@ -206,6 +197,18 @@ class AppController {
             return viewController
         }
         return topViewController(presentedFrom: presentedViewController)
+    }
+
+    // Provide haptic feedback to accompany success and error messages
+    private func generateFeedback(for notificationFeedbackType: UINotificationFeedbackType) {
+        if #available(iOS 10.0, *) {
+            let now = Date()
+            if now.timeIntervalSince(lastHapticFeedback) > 1 {
+                lastHapticFeedback = now
+                let feedbackGenerator = UINotificationFeedbackGenerator()
+                feedbackGenerator.notificationOccurred(notificationFeedbackType)
+            }
+        }
     }
 
     // MARK: - Public

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -184,10 +184,18 @@ final class TokenScannerViewController: UIViewController, QRScannerDelegate {
 
     // MARK: QRScannerDelegate
 
+    private var lastScanTime = Date(timeIntervalSince1970: 0)
+    private let minimumScanInterval: TimeInterval = 1
+
     func handleDecodedText(_ text: String) {
         guard viewModel.isScanning else {
             return
         }
-        dispatchAction(.scannerDecodedText(text))
+
+        let now = Date()
+        if now.timeIntervalSince(lastScanTime) > minimumScanInterval {
+            lastScanTime = now
+            dispatchAction(.scannerDecodedText(text))
+        }
     }
 }


### PR DESCRIPTION
Only process one result per second from the token scanner, to avoid excessive feedback for invalid QR codes. Fixes #197.