### PR TITLE
Improve button accessibility

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -74,6 +74,9 @@ class TokenListViewController: UITableViewController {
         self.noTokensLabel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         button.addSubview(self.noTokensLabel)
 
+        button.accessibilityLabel = "No Tokens"
+        button.accessibilityHint = "Double-tap to add a new token."
+
         return button
     }()
 
@@ -107,6 +110,9 @@ class TokenListViewController: UITableViewController {
         self.backupWarningLabel.frame = button.bounds
         self.backupWarningLabel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         button.addSubview(self.backupWarningLabel)
+
+        button.accessibilityLabel = "For security reasons, tokens will be stored only on this \(UIDevice.current.model), and will not be included in iCloud or unencrypted backups."
+        button.accessibilityHint = "Double-tap to learn more."
 
         return button
     }()

--- a/Authenticator/Source/TokenRowCell.swift
+++ b/Authenticator/Source/TokenRowCell.swift
@@ -68,6 +68,8 @@ class TokenRowCell: UITableViewCell {
 
         nextPasswordButton.tintColor = .otpForegroundColor
         nextPasswordButton.addTarget(self, action: #selector(TokenRowCell.generateNextPassword), for: .touchUpInside)
+        nextPasswordButton.accessibilityLabel = "Increment token"
+        nextPasswordButton.accessibilityHint = "Double-tap to generate a new password."
         contentView.addSubview(nextPasswordButton)
     }
 

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -64,6 +64,9 @@ final class TokenScannerViewController: UIViewController, QRScannerDelegate {
         self.permissionLabel.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         button.addSubview(self.permissionLabel)
 
+        button.accessibilityLabel = "To add a new token via QR code, Authenticator needs permission to access the camera."
+        button.accessibilityHint = "Double-tap to go to Settings."
+
         return button
     }()
 


### PR DESCRIPTION
Add accessibility labels and hints to custom buttons. Closes #190.

There are further accessibility refinements that can be made, but these changes begin by making all elements in the app compatible with VoiceOver.