### PR TITLE
Fixes errant copy actions during scroll

### DIFF
--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -252,11 +252,11 @@ extension TokenListViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let rowModel = viewModel.rowModels[indexPath.row];
+        let rowModel = viewModel.rowModels[indexPath.row]
         if isEditing {
-            dispatchAction(rowModel.editAction);
+            dispatchAction(rowModel.editAction)
         } else {
-            dispatchAction(rowModel.selectAction);
+            dispatchAction(rowModel.selectAction)
         }
     }
 }

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -250,6 +250,7 @@ extension TokenListViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 85
     }
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let rowModel = viewModel.rowModels[indexPath.row];
         if isEditing {

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -250,6 +250,14 @@ extension TokenListViewController {
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return 85
     }
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let rowModel = viewModel.rowModels[indexPath.row];
+        if isEditing {
+            dispatchAction(rowModel.editAction);
+        } else {
+            dispatchAction(rowModel.selectAction);
+        }
+    }
 }
 
 // MARK: TokenListPresenter

--- a/Authenticator/Source/TokenRowCell.swift
+++ b/Authenticator/Source/TokenRowCell.swift
@@ -140,18 +140,6 @@ class TokenRowCell: UITableViewCell {
 
     // MARK: - Actions
 
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        if selected, let rowModel = rowModel {
-            if self.isEditing {
-                dispatchAction?(rowModel.editAction)
-            } else {
-                dispatchAction?(rowModel.selectAction)
-            }
-        }
-    }
-
     func generateNextPassword() {
         if let action = rowModel?.buttonAction {
             dispatchAction?(action)


### PR DESCRIPTION
Uses the [`UITableViewControllerDelegate.tableView(_ didSelectRowAt:)`](https://developer.apple.com/documentation/uikit/uitableviewdelegate/1614877-tableview) method to dispatch row model actions.

The `UITableViewController` takes into account the scrolling interaction of the underlying `UIScrollView` to prevent firing touches that are used for scrolling. By using the delegate instead of the table view cell the actions are prevented from firing.

Fixes #210