### PR TITLE
Fix text color bugs

### DIFF
--- a/Authenticator/Source/ButtonHeaderView.swift
+++ b/Authenticator/Source/ButtonHeaderView.swift
@@ -57,7 +57,7 @@ class ButtonHeaderView<Action>: UIButton {
 
     private func configureSubviews() {
         titleLabel?.textAlignment = .center
-        titleLabel?.textColor = UIColor.otpForegroundColor
+        setTitleColor(.otpForegroundColor, for: UIControlState.normal)
         titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: UIFontWeightLight)
 
         addTarget(self, action: #selector(ButtonHeaderView.buttonWasPressed), for: .touchUpInside)

--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -34,8 +34,17 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
     let app = AppController()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        let barButtonAttributes = [NSFontAttributeName: UIFont.systemFont(ofSize: 17, weight: UIFontWeightLight)]
-        UIBarButtonItem.appearance().setTitleTextAttributes(barButtonAttributes, for: .normal)
+        let barButtonItemFont = UIFont.systemFont(ofSize: 17, weight: UIFontWeightLight)
+        let fontAttributes = [NSFontAttributeName: barButtonItemFont]
+        UIBarButtonItem.appearance().setTitleTextAttributes(fontAttributes, for: .normal)
+        UIBarButtonItem.appearance().setTitleTextAttributes(fontAttributes, for: .highlighted)
+        UIBarButtonItem.appearance().setTitleTextAttributes(fontAttributes, for: .selected)
+
+        let disabledAttributes = [
+            NSFontAttributeName: barButtonItemFont,
+            NSForegroundColorAttributeName: UIColor.otpBarForegroundColor.withAlphaComponent(0.3),
+        ]
+        UIBarButtonItem.appearance().setTitleTextAttributes(disabledAttributes, for: .disabled)
 
         // Restore white-on-black style
         SVProgressHUD.setForegroundColor(.otpLightColor)


### PR DESCRIPTION
- Set button title color using the correct method (Fixes #211)
- Explicitly set bar button item attributes for all states, fixing the color of disabled bar buttons and the font of disabled and selected bar buttons.