### PR TITLE
Refactor progress ring to use CAShapeLayer

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -51,7 +51,7 @@
 		C9CC09551BA91D1C008C54FE /* TableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09541BA91D1C008C54FE /* TableViewModel.swift */; };
 		C9D6C83F1906BD68004F0E08 /* SegmentedControlRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C83E1906BD68004F0E08 /* SegmentedControlRow.swift */; };
 		C9D6C8461906CD54004F0E08 /* TextFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C8451906CD54004F0E08 /* TextFieldRow.swift */; };
-		C9D6C84C19075044004F0E08 /* OTPProgressRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C84B19075044004F0E08 /* OTPProgressRing.swift */; };
+		C9D6C84C19075044004F0E08 /* ProgressRingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C84B19075044004F0E08 /* ProgressRingView.swift */; };
 		C9DE02E71ED2234D00D7E01C /* InfoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DE02E61ED2234D00D7E01C /* InfoList.swift */; };
 		C9DE02E91ED227D600D7E01C /* InfoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DE02E81ED227D600D7E01C /* InfoListViewController.swift */; };
 		C9E3FB9A1E281CBC00EFA8BB /* TokenScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E3FB991E281CBC00EFA8BB /* TokenScanner.swift */; };
@@ -172,7 +172,7 @@
 		C9CC09541BA91D1C008C54FE /* TableViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewModel.swift; sourceTree = "<group>"; };
 		C9D6C83E1906BD68004F0E08 /* SegmentedControlRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControlRow.swift; sourceTree = "<group>"; };
 		C9D6C8451906CD54004F0E08 /* TextFieldRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldRow.swift; sourceTree = "<group>"; };
-		C9D6C84B19075044004F0E08 /* OTPProgressRing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OTPProgressRing.swift; sourceTree = "<group>"; };
+		C9D6C84B19075044004F0E08 /* ProgressRingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressRingView.swift; sourceTree = "<group>"; };
 		C9D844341D4C576B00D5E343 /* CONTRIBUTING.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		C9D844361D4C59D600D5E343 /* CONDUCT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONDUCT.md; sourceTree = "<group>"; };
 		C9DE02E61ED2234D00D7E01C /* InfoList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoList.swift; sourceTree = "<group>"; };
@@ -400,7 +400,7 @@
 				C9B7328E1C0A8AE60076F77E /* TokenListViewModel.swift */,
 				C92708AB19CFB0750033128B /* TokenListViewController.swift */,
 				C98C1C4517D2EDF500A07D3F /* Cells */,
-				C9D6C84B19075044004F0E08 /* OTPProgressRing.swift */,
+				C9D6C84B19075044004F0E08 /* ProgressRingView.swift */,
 				CC46C4701DB3007D00EB4605 /* SearchField.swift */,
 			);
 			name = "Token List";
@@ -669,7 +669,7 @@
 				C93BD6231C167CD100FFFB8F /* Root.swift in Sources */,
 				C97CDF2C1BEEC90100D64406 /* QRScanner.swift in Sources */,
 				C9AAB07F1B917EC3000CE547 /* TokenEditForm.swift in Sources */,
-				C9D6C84C19075044004F0E08 /* OTPProgressRing.swift in Sources */,
+				C9D6C84C19075044004F0E08 /* ProgressRingView.swift in Sources */,
 				C9A1C1A91E501D8B009E65D6 /* Info.swift in Sources */,
 				C9CC09531BA9133B008C54FE /* FocusCell.swift in Sources */,
 				C99069D1180CBAC900BAEF53 /* TokenScannerViewController.swift in Sources */,

--- a/Authenticator/Source/OTPProgressRing.swift
+++ b/Authenticator/Source/OTPProgressRing.swift
@@ -38,12 +38,19 @@ class OTPProgressRing: UIView {
     private let backgroundRingLayer = RingLayer()
     private let foregroundRingLayer = RingLayer()
 
-    required init?(coder aDecoder: NSCoder) {
-        super.init(coder: aDecoder)
-    }
+    // MARK: Initialize
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configureSublayers()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        configureSublayers()
+    }
+
+    private func configureSublayers() {
         layer.addSublayer(backgroundRingLayer)
         layer.addSublayer(foregroundRingLayer)
         updateRingColor(tintColor)

--- a/Authenticator/Source/OTPProgressRing.swift
+++ b/Authenticator/Source/OTPProgressRing.swift
@@ -53,7 +53,7 @@ class OTPProgressRing: UIView {
     private func configureSublayers() {
         layer.addSublayer(backgroundRingLayer)
         layer.addSublayer(foregroundRingLayer)
-        updateRingColor(tintColor)
+        updateWithRingColor(tintColor)
     }
 
     // MARK: Layout
@@ -71,7 +71,12 @@ class OTPProgressRing: UIView {
 
     override func tintColorDidChange() {
         super.tintColorDidChange()
-        updateRingColor(tintColor)
+        updateWithRingColor(tintColor)
+    }
+
+    private func updateWithRingColor(_ ringColor: UIColor) {
+        foregroundRingLayer.strokeColor = ringColor.cgColor
+        backgroundRingLayer.strokeColor = ringColor.withAlphaComponent(0.2).cgColor
     }
 
     func updateWithViewModel(_ viewModel: ProgressRingViewModel) {
@@ -83,11 +88,6 @@ class OTPProgressRing: UIView {
         animation.fromValue = 0
         animation.toValue = 1
         foregroundRingLayer.add(animation, forKey: path)
-    }
-
-    private func updateRingColor(_ tintColor: UIColor) {
-        foregroundRingLayer.strokeColor = tintColor.cgColor
-        backgroundRingLayer.strokeColor = tintColor.withAlphaComponent(0.2).cgColor
     }
 }
 

--- a/Authenticator/Source/OTPProgressRing.swift
+++ b/Authenticator/Source/OTPProgressRing.swift
@@ -104,6 +104,8 @@ private class RingLayer: CAShapeLayer {
 
     override func layoutSublayers() {
         super.layoutSublayers()
+
+        // Inset the ring to draw within the layer's bounds.
         let halfLineWidth = lineWidth / 2
         let ringRect = bounds.insetBy(dx: halfLineWidth, dy: halfLineWidth)
 

--- a/Authenticator/Source/OTPProgressRing.swift
+++ b/Authenticator/Source/OTPProgressRing.swift
@@ -78,9 +78,23 @@ class OTPProgressRing: UIView {
 }
 
 private class ProgressLayer: CALayer {
+    let backgroundRingLayer = RingLayer()
     @NSManaged var progress: CGFloat
     @NSManaged var ringColor: CGColor
-    @NSManaged var ringPartialColor: CGColor
+
+    override init() {
+        super.init()
+        addSublayer(backgroundRingLayer)
+    }
+
+    override init(layer: Any) {
+        super.init(layer: layer)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        addSublayer(backgroundRingLayer)
+    }
 
     private var lineWidth: CGFloat = 1.5 {
         didSet { setNeedsDisplay() }
@@ -88,7 +102,7 @@ private class ProgressLayer: CALayer {
 
     fileprivate func updateTintColor(_ tintColor: UIColor) {
         ringColor = tintColor.cgColor
-        ringPartialColor = tintColor.withAlphaComponent(0.2).cgColor
+        backgroundRingLayer.strokeColor = tintColor.withAlphaComponent(0.2).cgColor
     }
 
     override class func needsDisplay(forKey key: String) -> Bool {
@@ -104,9 +118,6 @@ private class ProgressLayer: CALayer {
 
         context.setLineWidth(lineWidth)
 
-        context.setStrokeColor(ringPartialColor)
-        context.strokeEllipse(in: ringRect)
-
         context.setStrokeColor(ringColor)
         let startAngle: CGFloat = -.pi / 2
         context.addArc(center: CGPoint(x: ringRect.midX, y: ringRect.midY),
@@ -115,5 +126,29 @@ private class ProgressLayer: CALayer {
                        endAngle: 2 * .pi * CGFloat(self.progress) + startAngle,
                        clockwise: true)
         context.strokePath()
+    }
+
+    override func layoutSublayers() {
+        super.layoutSublayers()
+        backgroundRingLayer.frame = bounds
+    }
+}
+
+private class RingLayer: CAShapeLayer {
+    override init() {
+        super.init()
+        lineWidth = 1.5
+        fillColor = nil
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    override func layoutSublayers() {
+        super.layoutSublayers()
+        let halfLineWidth = lineWidth / 2
+        let ringRect = bounds.insetBy(dx: halfLineWidth, dy: halfLineWidth)
+        self.path = CGPath(ellipseIn: ringRect, transform: nil)
     }
 }

--- a/Authenticator/Source/ProgressRingView.swift
+++ b/Authenticator/Source/ProgressRingView.swift
@@ -1,5 +1,5 @@
 //
-//  OTPProgressRing.swift
+//  ProgressRingView.swift
 //  Authenticator
 //
 //  Copyright (c) 2014-2016 Authenticator authors
@@ -34,7 +34,7 @@ struct ProgressRingViewModel {
     }
 }
 
-class OTPProgressRing: UIView {
+class ProgressRingView: UIView {
     private let backgroundRingLayer = RingLayer()
     private let foregroundRingLayer = RingLayer()
 

--- a/Authenticator/Source/SearchField.swift
+++ b/Authenticator/Source/SearchField.swift
@@ -28,7 +28,7 @@ import UIKit
 // A custom view that contains a SearchTextField displaying its placeholder centered in the
 // text field.
 //
-// Displays a OTPProgressRing as the `leftView` control.
+// Displays a ProgressRingView as the `leftView` control.
 class SearchField: UIView {
 
     override init(frame: CGRect) {
@@ -50,7 +50,7 @@ class SearchField: UIView {
         return textField.text
     }
 
-    let ring = OTPProgressRing(
+    let ring = ProgressRingView(
         frame: CGRect(origin: .zero, size: CGSize(width: 22, height: 22))
     )
 


### PR DESCRIPTION
As [suggested](https://github.com/mattrubin/Authenticator/pull/231#issuecomment-342622266) by @beaucollins, this PR refactors the progress ring view to use two `CAShapeLayer`s to draw and animate the progress ring.

By recalculating the shape layer's path only when the bounds change and animating the shape layer's `strokeStart` property, the idle CPU usage is reduced to 0%. Fixes #218.