### PR TITLE
Remove the bar button attributes for the selected state

### DIFF
--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -38,7 +38,6 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         let fontAttributes = [NSFontAttributeName: barButtonItemFont]
         UIBarButtonItem.appearance().setTitleTextAttributes(fontAttributes, for: .normal)
         UIBarButtonItem.appearance().setTitleTextAttributes(fontAttributes, for: .highlighted)
-        UIBarButtonItem.appearance().setTitleTextAttributes(fontAttributes, for: .selected)
 
         let disabledAttributes = [
             NSFontAttributeName: barButtonItemFont,


### PR DESCRIPTION
Button items do not have a selected state, so this was being interpreted as setting the highlighted state again.