### PR TITLE
Update SwiftLint configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -35,7 +35,6 @@ opt_in_rules:
   - sorted_first_last
   - switch_case_on_newline
   - vertical_parameter_alignment_on_call
-  - vertical_whitespace
 disabled_rules:
   - line_length
   - todo

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,7 @@ opt_in_rules:
   - implicitly_unwrapped_optional
   - joined_default_parameter
   - let_var_whitespace
+  - literal_expression_end_indentation
   - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,6 +27,7 @@ opt_in_rules:
   - operator_usage_whitespace
   - overridden_super_call
   - override_in_extension
+  - pattern_matching_keywords
   - private_outlet
   - prohibited_super_call
   - redundant_nil_coalescing

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,22 +4,34 @@ excluded:
   - Carthage
   - fastlane
 opt_in_rules:
+  - array_init
   - attributes
   - closure_end_indentation
   - closure_spacing
   - conditional_returns_on_newline
+  - contains_over_first_not_nil
   - empty_count
+  - explicit_enum_raw_value
   - explicit_init
+  - extension_access_modifier
+  - fatal_error_message
   - file_header
   - first_where
   - force_unwrapping
+  - implicit_return
+  - implicitly_unwrapped_optional
+  - joined_default_parameter
   - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call
+  - override_in_extension
   - private_outlet
   - prohibited_super_call
   - redundant_nil_coalescing
+  - single_test_class
+  - sorted_first_last
   - switch_case_on_newline
+  - vertical_parameter_alignment_on_call
   - vertical_whitespace
 disabled_rules:
   - line_length

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,6 @@ opt_in_rules:
   - file_header
   - first_where
   - force_unwrapping
-  - missing_docs
   - nimble_operator
   - number_separator
   - operator_usage_whitespace

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -28,6 +28,9 @@ disabled_rules:
 cyclomatic_complexity:
   warning: 15
 
+function_body_length:
+  warning: 50
+
 trailing_comma:
   mandatory_comma: true
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -14,7 +14,6 @@ opt_in_rules:
   - first_where
   - force_unwrapping
   - nimble_operator
-  - number_separator
   - operator_usage_whitespace
   - overridden_super_call
   - private_outlet

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,7 +23,6 @@ opt_in_rules:
   - joined_default_parameter
   - let_var_whitespace
   - literal_expression_end_indentation
-  - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call
   - override_in_extension

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,6 +21,7 @@ opt_in_rules:
   - implicit_return
   - implicitly_unwrapped_optional
   - joined_default_parameter
+  - let_var_whitespace
   - nimble_operator
   - operator_usage_whitespace
   - overridden_super_call

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -48,7 +48,7 @@ struct Root: Component {
                 return .entryForm(form.viewModel)
             case .editForm(let form):
                 return .editForm(form.viewModel)
-            case .info(let infoList, let info):
+            case let .info(infoList, info):
                 return .info(infoList.viewModel, info?.viewModel)
             }
         }

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -160,7 +160,7 @@ extension RootViewController {
             )
             presentViewController(editController)
 
-        case .info(let infoListViewModel, let infoViewModel):
+        case let .info(infoListViewModel, infoViewModel):
             updateWithInfoViewModels(infoListViewModel, infoViewModel)
         }
         currentViewModel = viewModel

--- a/Authenticator/Source/TokenListViewController.swift
+++ b/Authenticator/Source/TokenListViewController.swift
@@ -89,7 +89,7 @@ class TokenListViewController: UITableViewController {
         let attributedMessage = NSMutableAttributedString(string: message, attributes: [
             .font: UIFont.systemFont(ofSize: 15, weight: .light),
             .paragraphStyle: paragraphStyle,
-            ])
+        ])
         attributedMessage.addAttribute(.font, value: UIFont.italicSystemFont(ofSize: 15),
                                        range: (attributedMessage.string as NSString).range(of: "not"))
         attributedMessage.addAttribute(.font, value: UIFont.boldSystemFont(ofSize: 15),

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -43,7 +43,7 @@ final class TokenScannerViewController: UIViewController, QRScannerDelegate {
         let attributedMessage = NSMutableAttributedString(string: message, attributes: [
             .font: UIFont.systemFont(ofSize: 15, weight: .light),
             .paragraphStyle: paragraphStyle,
-            ])
+        ])
         attributedMessage.addAttribute(.font, value: UIFont.boldSystemFont(ofSize: 15),
                                        range: (attributedMessage.string as NSString).range(of: linkTitle))
 

--- a/Authenticator/Source/TokenScannerViewController.swift
+++ b/Authenticator/Source/TokenScannerViewController.swift
@@ -151,7 +151,6 @@ final class TokenScannerViewController: UIViewController, QRScannerDelegate {
             // This should only ever be reached if camera restrictions are changed while the app is running, because if
             // the app is launched with restrictions already enabled, the deviceCanScan check will retrun false.
             dispatchAction(.beginManualTokenEntry)
-            break
         }
     }
 

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -55,7 +55,7 @@ class KeychainTokenStore: TokenStore {
             let indexOfB = sortedIdentifiers.index(of: $1.identifier)
 
             switch (indexOfA, indexOfB) {
-            case (.some(let iA), .some(let iB)) where iA < iB:
+            case let (.some(iA), .some(iB)) where iA < iB:
                 return true
             default:
                 return false

--- a/Authenticator/Source/TokenStore.swift
+++ b/Authenticator/Source/TokenStore.swift
@@ -28,6 +28,7 @@ import OneTimePassword
 
 protocol TokenStore {
     var persistentTokens: [PersistentToken] { get }
+
     func addToken(_ token: Token) throws
     func saveToken(_ token: Token, toPersistentToken persistentToken: PersistentToken) throws
     func updatePersistentToken(_ persistentToken: PersistentToken) throws


### PR DESCRIPTION
- Enable several new opt-in rules for SwiftLint 0.24
- Remove opt-in for several rules that are obsolete, unused, or already enabled by default
- Relax the warning threshold for function body length to 50 lines