### PR TITLE
Xcode 9.3 and Swift 4.1

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -39,6 +39,7 @@ opt_in_rules:
   - vertical_parameter_alignment_on_call
   - yoda_condition
 disabled_rules:
+  - identifier_name
   - line_length
   - todo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: objective-c
 xcode_workspace: Authenticator.xcworkspace
 xcode_scheme: Authenticator
 
-osx_image: xcode9
+osx_image: xcode9.3beta
 
 env:
   - RUNTIME="iOS 9.0"  DEVICE="iPhone 4s"

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -571,7 +571,7 @@
 				CLASSPREFIX = OTP;
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0800;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Matt Rubin";
 				TargetAttributes = {
 					1D6058900D05DD3D006BFB54 = {
@@ -795,6 +795,7 @@
 				);
 				GCC_DYNAMIC_NO_PIC = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;

--- a/Authenticator.xcodeproj/xcshareddata/xcschemes/Authenticator Demo.xcscheme
+++ b/Authenticator.xcodeproj/xcshareddata/xcschemes/Authenticator Demo.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Authenticator.xcodeproj/xcshareddata/xcschemes/Authenticator.xcscheme
+++ b/Authenticator.xcodeproj/xcshareddata/xcschemes/Authenticator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0800"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Authenticator.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Authenticator.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Authenticator/Source/DisplayTime.swift
+++ b/Authenticator/Source/DisplayTime.swift
@@ -26,7 +26,7 @@
 import Foundation
 
 /// A simple value representing a moment in time, stored as the number of seconds since the epoch.
-struct DisplayTime: Equatable {
+struct DisplayTime {
     let timeIntervalSince1970: TimeInterval
 
     init(date: Date) {
@@ -36,8 +36,4 @@ struct DisplayTime: Equatable {
     var date: Date {
         return Date(timeIntervalSince1970: timeIntervalSince1970)
     }
-}
-
-func == (lhs: DisplayTime, rhs: DisplayTime) -> Bool {
-    return lhs.timeIntervalSince1970 == rhs.timeIntervalSince1970
 }

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -72,7 +72,7 @@ struct TokenList: Component {
 }
 
 extension TokenList {
-    enum Action {
+    enum Action: Equatable {
         case beginAddToken
         case editPersistentToken(PersistentToken)
 
@@ -144,38 +144,6 @@ extension TokenList {
         pasteboard.setValue(password, forPasteboardType: kUTTypeUTF8PlainText as String)
         // Show an ephemeral success message.
         return .showSuccessMessage("Copied")
-    }
-}
-
-extension TokenList.Action: Equatable {}
-func == (lhs: TokenList.Action, rhs: TokenList.Action) -> Bool {
-    switch (lhs, rhs) {
-    case (.beginAddToken, .beginAddToken):
-        return true
-    case let (.editPersistentToken(l), .editPersistentToken(r)):
-        return l == r
-    case let (.updatePersistentToken(l), .updatePersistentToken(r)):
-        return l == r
-    case let (.moveToken(l), .moveToken(r)):
-        return l == r
-    case let (.deletePersistentToken(l), .deletePersistentToken(r)):
-        return l == r
-    case let (.copyPassword(l), .copyPassword(r)):
-        return l == r
-    case (.clearFilter, .clearFilter):
-        return true
-    case let (.filter(l), .filter(r)):
-        return l == r
-    case (.showBackupInfo, .showBackupInfo):
-        return true
-    case (.showInfo, .showInfo):
-        return true
-    case (.beginAddToken, _), (.editPersistentToken, _), (.updatePersistentToken, _), (.moveToken, _),
-         (.deletePersistentToken, _), (.copyPassword, _), (.filter, _), (.clearFilter, _), (.showBackupInfo, _),
-         (.showInfo, _):
-        // Using this verbose case for non-matching `Action`s instead of `default` ensures a
-        // compiler error if a new `Action` is added and not expicitly checked for equality.
-        return false
     }
 }
 

--- a/Authenticator/Source/TokenRowModel.swift
+++ b/Authenticator/Source/TokenRowModel.swift
@@ -26,7 +26,7 @@
 import Foundation
 import OneTimePassword
 
-struct TokenRowModel: Identifiable {
+struct TokenRowModel: Equatable, Identifiable {
     typealias Action = TokenList.Action
 
     let name, issuer, password: String
@@ -71,17 +71,4 @@ struct TokenRowModel: Identifiable {
         }
         return mutablePassword
     }
-}
-
-extension TokenRowModel: Equatable {}
-func == (lhs: TokenRowModel, rhs: TokenRowModel) -> Bool {
-    return (lhs.name == rhs.name)
-        && (lhs.issuer == rhs.issuer)
-        && (lhs.password == rhs.password)
-        && (lhs.showsButton == rhs.showsButton)
-        && (lhs.buttonAction == rhs.buttonAction)
-        && (lhs.selectAction == rhs.selectAction)
-        && (lhs.editAction == rhs.editAction)
-        && (lhs.deleteAction == rhs.deleteAction)
-        && (lhs.identifier == rhs.identifier)
 }

--- a/AuthenticatorTests/MockTableView.swift
+++ b/AuthenticatorTests/MockTableView.swift
@@ -26,7 +26,7 @@
 import UIKit
 
 class MockTableView: UITableView {
-    enum ChangeType {
+    enum ChangeType: Equatable {
         case beginUpdates
         case endUpdates
         case insert(indexPath: IndexPath)
@@ -77,26 +77,5 @@ class MockTableView: UITableView {
     override func scrollToRow(at indexPath: IndexPath, at scrollPosition: UITableViewScrollPosition, animated: Bool) {
         super.scrollToRow(at: indexPath, at: scrollPosition, animated: animated)
         changes.append(.scroll(indexPath: indexPath))
-    }
-}
-
-extension MockTableView.ChangeType: Equatable {}
-func == (lhs: MockTableView.ChangeType, rhs: MockTableView.ChangeType) -> Bool {
-    switch (lhs, rhs) {
-    case let (.insert(l), .insert(r)):
-        return l == r
-    case let (.remove(l), .remove(r)):
-        return l == r
-    case let (.reload(l), .reload(r)):
-        return l == r
-    case let (.move(l), .move(r)):
-        return l == r
-    case let (.scroll(l), .scroll(r)):
-        return l == r
-    case (.beginUpdates, .beginUpdates),
-         (.endUpdates, .endUpdates):
-        return true
-    case (.insert, _), (.remove, _), (.reload, _), (.move, _), (.scroll, _), (.beginUpdates, _), (.endUpdates, _):
-        return false
     }
 }

--- a/AuthenticatorTests/TokenListViewControllerTest.swift
+++ b/AuthenticatorTests/TokenListViewControllerTest.swift
@@ -119,7 +119,7 @@ class TokenListViewControllerTest: XCTestCase {
 
 func XCTAssert(_ cell: UITableViewCell, containsText expectedText: String,
                file: StaticString = #file, line: UInt = #line) {
-    let textInCellLabels = cell.contentView.subviews.flatMap({ ($0 as? UILabel)?.text })
+    let textInCellLabels = cell.contentView.subviews.compactMap({ ($0 as? UILabel)?.text })
     XCTAssert(textInCellLabels.contains(expectedText), "Expected \(textInCellLabels) to contain \"\(expectedText)\"",
               file: file, line: line)
 }

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "SVProgressHUD/SVProgressHUD" "2.2.5"
 github "jspahrsummers/xcconfigs" "0.11"
 github "mattrubin/Base32" "xcode9"
-github "mattrubin/OneTimePassword" "3.1"
+github "mattrubin/OneTimePassword" "3.1.1"
 github "shinydevelopment/SimulatorStatusMagic" "2.1"


### PR DESCRIPTION
Xcode 9.3:
 - Recommended build settings updates
 - Add the new `IDEWorkspaceChecks.plist` file

Swift 4.1:
 - Automatically synthesize `Equatable` conformance
 - Replace deprecated usage of `flatMap` with the new `compactMap`

Also:
 - Upgrade OneTimePassword to 3.1.1
 - Temporarily ignore the SwiftLint `identifier_name` rule 