### PR TITLE
Fix a crash when opening from a URL

### DIFF
--- a/Authenticator/Source/OTPAppDelegate.swift
+++ b/Authenticator/Source/OTPAppDelegate.swift
@@ -61,7 +61,7 @@ class OTPAppDelegate: UIResponder, UIApplicationDelegate {
         app.updateView()
     }
 
-    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    func application(_ application: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
         if let token = Token(url: url) {
             let message = "Do you want to add a token for “\(token.name)”?"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the project will be documented in this file.
 [Authenticator]: https://github.com/mattrubin/Authenticator
 
 
-## [2.0.3] - 2018-04-16
+## [2.0.3] - 2018-04-23
 - Disabled swipe-to-delete on the token list, to prevent tokens from being accidentally deleted. To delete a token, first tap "Edit" and then tap the red delete button.
 - Fixed a bug where the app might crash when adding a token from an "otpauth://" URL.
 


### PR DESCRIPTION
If compiled with Xcode 9.3, the app would crash when calling the deprecated UIApplicationDelegate  open-from-url method.