### PR TITLE
Release Authenticator 2.0.4

### DIFF
--- a/Authenticator/Resources/Info.plist
+++ b/Authenticator/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>2.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the project will be documented in this file.
 [Authenticator]: https://github.com/mattrubin/Authenticator
 
 
+## [2.0.4] - 2018-04-29
+- Fixed a crash on launch for some users, caused by deserialization errors when loading persistent tokens from the keychain.
+([#277](https://github.com/mattrubin/Authenticator/issues/277))
+
+
 ## [2.0.3] - 2018-04-23
 - Disabled swipe-to-delete on the token list, to prevent tokens from being accidentally deleted. To delete a token, first tap "Edit" and then tap the red delete button.
 - Fixed a bug where the app might crash when adding a token from an "otpauth://" URL.
@@ -102,7 +107,8 @@ For security reasons, tokens are stored only on one device, and are not included
 ## [1.0] - 2013-11-25
 
 
-[Unreleased]: https://github.com/mattrubin/Authenticator/compare/2.0.3...HEAD
+[Unreleased]: https://github.com/mattrubin/Authenticator/compare/2.0.4...HEAD
+[2.0.4]: https://github.com/mattrubin/Authenticator/compare/2.0.3...2.0.4
 [2.0.3]: https://github.com/mattrubin/Authenticator/compare/2.0.2...2.0.3
 [2.0.2]: https://github.com/mattrubin/Authenticator/compare/2.0.1...2.0.2
 [2.0.1]: https://github.com/mattrubin/Authenticator/compare/2.0.0...2.0.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 # Configuration for Carthage (https://github.com/Carthage/Carthage)
 
-github "mattrubin/OneTimePassword" "3.1.3-hotfix"
+github "mattrubin/OneTimePassword" ~> 3.1.3
 github "SVProgressHUD/SVProgressHUD" ~> 2.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 # Configuration for Carthage (https://github.com/Carthage/Carthage)
 
-github "mattrubin/OneTimePassword" ~> 3.0
+github "mattrubin/OneTimePassword" "3.1.3-hotfix"
 github "SVProgressHUD/SVProgressHUD" ~> 2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "SVProgressHUD/SVProgressHUD" "2.2.5"
 github "jspahrsummers/xcconfigs" "0.12"
 github "mattrubin/Base32" "xcode9"
-github "mattrubin/OneTimePassword" "3.1.2"
+github "mattrubin/OneTimePassword" "3.1.3-hotfix"
 github "shinydevelopment/SimulatorStatusMagic" "2.1"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "SVProgressHUD/SVProgressHUD" "2.2.5"
 github "jspahrsummers/xcconfigs" "0.12"
 github "mattrubin/Base32" "xcode9"
-github "mattrubin/OneTimePassword" "3.1.3-hotfix"
+github "mattrubin/OneTimePassword" "3.1.3"
 github "shinydevelopment/SimulatorStatusMagic" "2.1"

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,2 +1,1 @@
-• Disabled swipe-to-delete on the token list, to prevent tokens from being accidentally deleted. To delete a token, first tap "Edit" and then tap the red delete button.
-• Fixed a bug where the app might crash when adding a token from an "otpauth://" URL.
+This release fixes an issue that was causing the app to crash on launch for some users.


### PR DESCRIPTION
This is a hotfix release to address a crash on launch affecting some users.

Fixes #276.