### PR TITLE
Set CFBundleVersion to 0 for all targets

### DIFF
--- a/AuthenticatorScreenshots/Info.plist
+++ b/AuthenticatorScreenshots/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0</string>
 </dict>
 </plist>

--- a/AuthenticatorTests/Info.plist
+++ b/AuthenticatorTests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0</string>
 </dict>
 </plist>


### PR DESCRIPTION
The fastlane build and release scripts will set this value to the correct build number.