### PR TITLE
Generic helper method for modal view controllers

### DIFF
--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -71,10 +71,6 @@ class RootViewController: OpaqueNavigationController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    fileprivate func presentViewController(_ viewController: UIViewController) {
-        presentViewControllers([viewController])
-    }
-
     fileprivate func presentViewControllers(_ viewControllersToPresent: [UIViewController]) {
         // If there is currently no modal, create one.
         guard let navController = modalNavController else {
@@ -176,7 +172,7 @@ extension RootViewController {
             viewModel: viewModel,
             dispatchAction: compose(actionTransform, dispatchAction)
         )
-        presentViewController(viewController)
+        presentViewControllers([viewController])
     }
 
     // swiftlint:disable:next function_parameter_count

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -140,25 +140,19 @@ extension RootViewController {
             dismissViewController()
 
         case .scanner(let scannerViewModel):
-            let scannerViewController: TokenScannerViewController = reify(
-                viewModel: scannerViewModel,
-                dispatchAction: compose(Root.Action.tokenScannerAction, dispatchAction)
-            )
-            presentViewController(scannerViewController)
+            presentViewModel(scannerViewModel,
+                             using: TokenScannerViewController.self,
+                             actionTransform: Root.Action.tokenScannerAction)
 
         case .entryForm(let formViewModel):
-            let formController: TokenFormViewController = reify(
-                viewModel: formViewModel,
-                dispatchAction: compose(Root.Action.tokenEntryFormAction, dispatchAction)
-            )
-            presentViewController(formController)
+            presentViewModel(formViewModel,
+                             using: TokenFormViewController.self,
+                             actionTransform: Root.Action.tokenEntryFormAction)
 
         case .editForm(let formViewModel):
-            let editController: TokenFormViewController = reify(
-                viewModel: formViewModel,
-                dispatchAction: compose(Root.Action.tokenEditFormAction, dispatchAction)
-            )
-            presentViewController(editController)
+            presentViewModel(formViewModel,
+                             using: TokenFormViewController.self,
+                             actionTransform: Root.Action.tokenEditFormAction)
 
         case let .info(infoListViewModel, infoViewModel):
             updateWithInfoViewModels(infoListViewModel, infoViewModel)
@@ -166,13 +160,19 @@ extension RootViewController {
         currentViewModel = viewModel
     }
 
+    private func presentViewModel<ViewController: UIViewController & ModelBasedViewController>(_ viewModel: ViewController.ViewModel, using _: ViewController.Type, actionTransform: @escaping ((ViewController.Action) -> Root.Action)) {
+        let viewController: ViewController = reify(
+            viewModel: viewModel,
+            dispatchAction: compose(actionTransform, dispatchAction)
+        )
+        presentViewController(viewController)
+    }
+
     private func updateWithInfoViewModels(_ infoListViewModel: InfoList.ViewModel, _ infoViewModel: Info.ViewModel?) {
         guard let infoViewModel = infoViewModel else {
-            let infoListViewController: InfoListViewController = reify(
-                viewModel: infoListViewModel,
-                dispatchAction: compose(Root.Action.infoListEffect, dispatchAction)
-            )
-            presentViewController(infoListViewController)
+            presentViewModel(infoListViewModel,
+                             using: InfoListViewController.self,
+                             actionTransform: Root.Action.infoListEffect)
             return
         }
 

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -112,20 +112,20 @@ extension TokenFormViewController: ModelBased {}
 extension InfoListViewController: ModelBased {}
 extension InfoViewController: ModelBased {}
 
-extension RootViewController {
-    private func reify<ViewController: ModelBasedViewController>(_ existingViewController: UIViewController?, viewModel: ViewController.ViewModel, dispatchAction: @escaping (ViewController.Action) -> Void) -> ViewController {
-        if let viewController = existingViewController as? ViewController {
-            viewController.update(with: viewModel)
-            return viewController
-        } else {
-            let viewController = ViewController(
-                viewModel: viewModel,
-                dispatchAction: dispatchAction
-            )
-            return viewController
-        }
+private func reify<ViewController: ModelBasedViewController>(_ existingViewController: UIViewController?, viewModel: ViewController.ViewModel, dispatchAction: @escaping (ViewController.Action) -> Void) -> ViewController {
+    if let viewController = existingViewController as? ViewController {
+        viewController.update(with: viewModel)
+        return viewController
+    } else {
+        let viewController = ViewController(
+            viewModel: viewModel,
+            dispatchAction: dispatchAction
+        )
+        return viewController
     }
+}
 
+extension RootViewController {
     func update(with viewModel: Root.ViewModel) {
         tokenListViewController.update(with: viewModel.tokenList)
 

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -151,7 +151,19 @@ extension RootViewController {
                              actionTransform: Root.Action.tokenEditFormAction)
 
         case let .info(infoListViewModel, infoViewModel):
-            updateWithInfoViewModels(infoListViewModel, infoViewModel)
+            if let infoViewModel = infoViewModel {
+                presentViewModels(infoListViewModel,
+                                  using: InfoListViewController.self,
+                                  actionTransform: Root.Action.infoListEffect,
+                                  and: infoViewModel,
+                                  using: InfoViewController.self,
+                                  actionTransform: Root.Action.infoEffect)
+
+            } else {
+                presentViewModel(infoListViewModel,
+                                 using: InfoListViewController.self,
+                                 actionTransform: Root.Action.infoListEffect)
+            }
         }
         currentViewModel = viewModel
     }
@@ -180,22 +192,6 @@ extension RootViewController {
             dispatchAction: compose(actionTransformB, dispatchAction)
         )
         presentViewControllers([viewControllerA, viewControllerB])
-    }
-
-    private func updateWithInfoViewModels(_ infoListViewModel: InfoList.ViewModel, _ infoViewModel: Info.ViewModel?) {
-        guard let infoViewModel = infoViewModel else {
-            presentViewModel(infoListViewModel,
-                             using: InfoListViewController.self,
-                             actionTransform: Root.Action.infoListEffect)
-            return
-        }
-
-        presentViewModels(infoListViewModel,
-                          using: InfoListViewController.self,
-                          actionTransform: Root.Action.infoListEffect,
-                          and: infoViewModel,
-                          using: InfoViewController.self,
-                          actionTransform: Root.Action.infoEffect)
     }
 }
 

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -101,7 +101,7 @@ class RootViewController: OpaqueNavigationController {
     }
 }
 
-protocol ModelBasedViewController {
+protocol ModelBased {
     associatedtype ViewModel
     associatedtype Action
 
@@ -109,10 +109,12 @@ protocol ModelBasedViewController {
     func update(with viewModel: ViewModel)
 }
 
-extension TokenScannerViewController: ModelBasedViewController {}
-extension TokenFormViewController: ModelBasedViewController {}
-extension InfoListViewController: ModelBasedViewController {}
-extension InfoViewController: ModelBasedViewController {}
+typealias ModelBasedViewController = UIViewController & ModelBased
+
+extension TokenScannerViewController: ModelBased {}
+extension TokenFormViewController: ModelBased {}
+extension InfoListViewController: ModelBased {}
+extension InfoViewController: ModelBased {}
 
 extension RootViewController {
     private func reify<ViewController: ModelBasedViewController>(_ existingViewController: UIViewController?, viewModel: ViewController.ViewModel, dispatchAction: @escaping (ViewController.Action) -> Void) -> ViewController {
@@ -168,7 +170,7 @@ extension RootViewController {
         currentViewModel = viewModel
     }
 
-    private func presentViewModel<ViewController: UIViewController & ModelBasedViewController>(_ viewModel: ViewController.ViewModel, using _: ViewController.Type, actionTransform: @escaping ((ViewController.Action) -> Root.Action)) {
+    private func presentViewModel<ViewController: ModelBasedViewController>(_ viewModel: ViewController.ViewModel, using _: ViewController.Type, actionTransform: @escaping ((ViewController.Action) -> Root.Action)) {
         let viewController: ViewController = reify(
             modalNavController?.topViewController,
             viewModel: viewModel,
@@ -178,7 +180,7 @@ extension RootViewController {
     }
 
     // swiftlint:disable:next function_parameter_count
-    private func presentViewModels<A: UIViewController & ModelBasedViewController, B: UIViewController & ModelBasedViewController>(
+    private func presentViewModels<A: ModelBasedViewController, B: ModelBasedViewController>(
         _ viewModelA: A.ViewModel, using _: A.Type, actionTransform actionTransformA: @escaping ((A.Action) -> Root.Action),
         and viewModelB: B.ViewModel, using _: B.Type, actionTransform actionTransformB: @escaping ((B.Action) -> Root.Action)) {
         let viewControllerA: A = reify(

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -115,10 +115,6 @@ extension InfoListViewController: ModelBasedViewController {}
 extension InfoViewController: ModelBasedViewController {}
 
 extension RootViewController {
-    private func reify<ViewController: ModelBasedViewController>(viewModel: ViewController.ViewModel, dispatchAction: @escaping (ViewController.Action) -> Void) -> ViewController {
-        return reify(modalNavController?.topViewController, viewModel: viewModel, dispatchAction: dispatchAction)
-    }
-
     private func reify<ViewController: ModelBasedViewController>(_ existingViewController: UIViewController?, viewModel: ViewController.ViewModel, dispatchAction: @escaping (ViewController.Action) -> Void) -> ViewController {
         if let viewController = existingViewController as? ViewController {
             viewController.update(with: viewModel)
@@ -162,6 +158,7 @@ extension RootViewController {
 
     private func presentViewModel<ViewController: UIViewController & ModelBasedViewController>(_ viewModel: ViewController.ViewModel, using _: ViewController.Type, actionTransform: @escaping ((ViewController.Action) -> Root.Action)) {
         let viewController: ViewController = reify(
+            modalNavController?.topViewController,
             viewModel: viewModel,
             dispatchAction: compose(actionTransform, dispatchAction)
         )
@@ -178,6 +175,7 @@ extension RootViewController {
             dispatchAction: compose(actionTransformA, dispatchAction)
         )
         let viewControllerB: B = reify(
+            modalNavController?.topViewController,
             viewModel: viewModelB,
             dispatchAction: compose(actionTransformB, dispatchAction)
         )

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -168,6 +168,22 @@ extension RootViewController {
         presentViewController(viewController)
     }
 
+    // swiftlint:disable:next function_parameter_count
+    private func presentViewModels<A: UIViewController & ModelBasedViewController, B: UIViewController & ModelBasedViewController>(
+        _ viewModelA: A.ViewModel, using _: A.Type, actionTransform actionTransformA: @escaping ((A.Action) -> Root.Action),
+        and viewModelB: B.ViewModel, using _: B.Type, actionTransform actionTransformB: @escaping ((B.Action) -> Root.Action)) {
+        let viewControllerA: A = reify(
+            modalNavController?.viewControllers.first,
+            viewModel: viewModelA,
+            dispatchAction: compose(actionTransformA, dispatchAction)
+        )
+        let viewControllerB: B = reify(
+            viewModel: viewModelB,
+            dispatchAction: compose(actionTransformB, dispatchAction)
+        )
+        presentViewControllers([viewControllerA, viewControllerB])
+    }
+
     private func updateWithInfoViewModels(_ infoListViewModel: InfoList.ViewModel, _ infoViewModel: Info.ViewModel?) {
         guard let infoViewModel = infoViewModel else {
             presentViewModel(infoListViewModel,
@@ -176,16 +192,12 @@ extension RootViewController {
             return
         }
 
-        let infoListViewController: InfoListViewController = reify(
-            modalNavController?.viewControllers.first,
-            viewModel: infoListViewModel,
-            dispatchAction: compose(Root.Action.infoListEffect, dispatchAction)
-        )
-        let infoViewController: InfoViewController = reify(
-            viewModel: infoViewModel,
-            dispatchAction: compose(Root.Action.infoEffect, dispatchAction)
-        )
-        presentViewControllers([infoListViewController, infoViewController])
+        presentViewModels(infoListViewModel,
+                          using: InfoListViewController.self,
+                          actionTransform: Root.Action.infoListEffect,
+                          and: infoViewModel,
+                          using: InfoViewController.self,
+                          actionTransform: Root.Action.infoEffect)
     }
 }
 


### PR DESCRIPTION
Refactor the initialization and presentation of modal view controllers to use generic helper methods. These new generic methods will significantly reduce the amount and complexity of code necessary to introduce new modal views – especially new modal navigation stacks with multiple levels.