### PR TITLE
Settings screen for password digit grouping

### DIFF
--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		C9A1C1A91E501D8B009E65D6 /* Info.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A1C1A81E501D8B009E65D6 /* Info.swift */; };
 		C9A1C1AC1E5021A6009E65D6 /* BackupInfo.html in Resources */ = {isa = PBXBuildFile; fileRef = C9A1C1AA1E502195009E65D6 /* BackupInfo.html */; };
 		C9A1C1CE1E6CDBFB009E65D6 /* RootTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A1C1CD1E6CDBFB009E65D6 /* RootTests.swift */; };
+		C9A23F2E2159C28200615846 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A23F2D2159C28200615846 /* Settings.swift */; };
 		C9A262D01E170BD4004E6CEB /* AuthenticatorScreenshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A262CF1E170BD4004E6CEB /* AuthenticatorScreenshots.swift */; };
 		C9A262D81E170E3A004E6CEB /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A262D71E170E3A004E6CEB /* SnapshotHelper.swift */; };
 		C9A262DA1E176A18004E6CEB /* Demo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A262D91E176A18004E6CEB /* Demo.swift */; };
@@ -160,6 +161,7 @@
 		C9A1C1A81E501D8B009E65D6 /* Info.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Info.swift; sourceTree = "<group>"; };
 		C9A1C1AA1E502195009E65D6 /* BackupInfo.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = BackupInfo.html; sourceTree = "<group>"; };
 		C9A1C1CD1E6CDBFB009E65D6 /* RootTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootTests.swift; sourceTree = "<group>"; };
+		C9A23F2D2159C28200615846 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		C9A262CD1E170BD4004E6CEB /* AuthenticatorScreenshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AuthenticatorScreenshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9A262CF1E170BD4004E6CEB /* AuthenticatorScreenshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatorScreenshots.swift; sourceTree = "<group>"; };
 		C9A262D71E170E3A004E6CEB /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SnapshotHelper.swift; path = fastlane/SnapshotHelper.swift; sourceTree = SOURCE_ROOT; };
@@ -514,6 +516,7 @@
 			isa = PBXGroup;
 			children = (
 				C9F7A8601C4D90B50082E5AE /* TokenStore.swift */,
+				C9A23F2D2159C28200615846 /* Settings.swift */,
 			);
 			name = "Data Store";
 			sourceTree = "<group>";
@@ -668,6 +671,7 @@
 				C9CDD1D12096635300636056 /* DisplayOptionsViewController.swift in Sources */,
 				C9CDD1CF209662E100636056 /* DisplayOptions.swift in Sources */,
 				C9DE02E71ED2234D00D7E01C /* InfoList.swift in Sources */,
+				C9A23F2E2159C28200615846 /* Settings.swift in Sources */,
 				C93BD6251C16841D00FFFB8F /* RootViewController.swift in Sources */,
 				C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */,
 				C9EB44901C52AE4500ACFA87 /* AppController.swift in Sources */,

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		C9D6C84C19075044004F0E08 /* ProgressRingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C84B19075044004F0E08 /* ProgressRingView.swift */; };
 		C9DE02E71ED2234D00D7E01C /* InfoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DE02E61ED2234D00D7E01C /* InfoList.swift */; };
 		C9DE02E91ED227D600D7E01C /* InfoListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DE02E81ED227D600D7E01C /* InfoListViewController.swift */; };
+		C9E11E1121543E2A00C1AA53 /* Menu.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E11E1021543E2A00C1AA53 /* Menu.swift */; };
 		C9E3FB9A1E281CBC00EFA8BB /* TokenScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E3FB991E281CBC00EFA8BB /* TokenScanner.swift */; };
 		C9E3FB9C1E2860DD00EFA8BB /* TokenScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E3FB9B1E2860DD00EFA8BB /* TokenScannerTests.swift */; };
 		C9EB448E1C52A74200ACFA87 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9EB448D1C52A74200ACFA87 /* Component.swift */; };
@@ -179,6 +180,7 @@
 		C9D844361D4C59D600D5E343 /* CONDUCT.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONDUCT.md; sourceTree = "<group>"; };
 		C9DE02E61ED2234D00D7E01C /* InfoList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoList.swift; sourceTree = "<group>"; };
 		C9DE02E81ED227D600D7E01C /* InfoListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoListViewController.swift; sourceTree = "<group>"; };
+		C9E11E1021543E2A00C1AA53 /* Menu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menu.swift; sourceTree = "<group>"; };
 		C9E3FB991E281CBC00EFA8BB /* TokenScanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScanner.swift; sourceTree = "<group>"; };
 		C9E3FB9B1E2860DD00EFA8BB /* TokenScannerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenScannerTests.swift; sourceTree = "<group>"; };
 		C9EB448D1C52A74200ACFA87 /* Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 		C9A1C1A71E501D5F009E65D6 /* Info */ = {
 			isa = PBXGroup;
 			children = (
+				C9E11E1021543E2A00C1AA53 /* Menu.swift */,
 				C9DE02E61ED2234D00D7E01C /* InfoList.swift */,
 				C9DE02E81ED227D600D7E01C /* InfoListViewController.swift */,
 				C9A1C1A81E501D8B009E65D6 /* Info.swift */,
@@ -683,6 +686,7 @@
 				C9D6C83F1906BD68004F0E08 /* SegmentedControlRow.swift in Sources */,
 				C968D1151CB4C639004ED7BB /* DisplayTime.swift in Sources */,
 				8B0028B511EB75920092DE18 /* ScannerOverlayView.swift in Sources */,
+				C9E11E1121543E2A00C1AA53 /* Menu.swift in Sources */,
 				C9CC09551BA91D1C008C54FE /* TableViewModel.swift in Sources */,
 				C92708AC19CFB0750033128B /* TokenListViewController.swift in Sources */,
 				C9A262DA1E176A18004E6CEB /* Demo.swift in Sources */,

--- a/Authenticator.xcodeproj/project.pbxproj
+++ b/Authenticator.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		C9CC09511BA903B7008C54FE /* TokenFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09501BA903B7008C54FE /* TokenFormViewController.swift */; };
 		C9CC09531BA9133B008C54FE /* FocusCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09521BA9133B008C54FE /* FocusCell.swift */; };
 		C9CC09551BA91D1C008C54FE /* TableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CC09541BA91D1C008C54FE /* TableViewModel.swift */; };
+		C9CDD1CF209662E100636056 /* DisplayOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CDD1CE209662E100636056 /* DisplayOptions.swift */; };
+		C9CDD1D12096635300636056 /* DisplayOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CDD1D02096635300636056 /* DisplayOptionsViewController.swift */; };
 		C9D6C83F1906BD68004F0E08 /* SegmentedControlRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C83E1906BD68004F0E08 /* SegmentedControlRow.swift */; };
 		C9D6C8461906CD54004F0E08 /* TextFieldRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C8451906CD54004F0E08 /* TextFieldRow.swift */; };
 		C9D6C84C19075044004F0E08 /* ProgressRingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9D6C84B19075044004F0E08 /* ProgressRingView.swift */; };
@@ -173,6 +175,8 @@
 		C9CC09501BA903B7008C54FE /* TokenFormViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenFormViewController.swift; sourceTree = "<group>"; };
 		C9CC09521BA9133B008C54FE /* FocusCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FocusCell.swift; sourceTree = "<group>"; };
 		C9CC09541BA91D1C008C54FE /* TableViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewModel.swift; sourceTree = "<group>"; };
+		C9CDD1CE209662E100636056 /* DisplayOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayOptions.swift; sourceTree = "<group>"; };
+		C9CDD1D02096635300636056 /* DisplayOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayOptionsViewController.swift; sourceTree = "<group>"; };
 		C9D6C83E1906BD68004F0E08 /* SegmentedControlRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControlRow.swift; sourceTree = "<group>"; };
 		C9D6C8451906CD54004F0E08 /* TextFieldRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextFieldRow.swift; sourceTree = "<group>"; };
 		C9D6C84B19075044004F0E08 /* ProgressRingView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressRingView.swift; sourceTree = "<group>"; };
@@ -447,6 +451,8 @@
 				C9DE02E81ED227D600D7E01C /* InfoListViewController.swift */,
 				C9A1C1A81E501D8B009E65D6 /* Info.swift */,
 				C9A1C1A51E501CB2009E65D6 /* InfoViewController.swift */,
+				C9CDD1CE209662E100636056 /* DisplayOptions.swift */,
+				C9CDD1D02096635300636056 /* DisplayOptionsViewController.swift */,
 			);
 			name = Info;
 			sourceTree = "<group>";
@@ -659,6 +665,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				C93AD15219CD51BE007480E9 /* Colors.swift in Sources */,
+				C9CDD1D12096635300636056 /* DisplayOptionsViewController.swift in Sources */,
+				C9CDD1CF209662E100636056 /* DisplayOptions.swift in Sources */,
 				C9DE02E71ED2234D00D7E01C /* InfoList.swift in Sources */,
 				C93BD6251C16841D00FFFB8F /* RootViewController.swift in Sources */,
 				C9919CE01BA721A1006237C1 /* ButtonHeaderView.swift in Sources */,

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -174,6 +174,10 @@ class AppController {
                 // Fallback on earlier versions
                 UIApplication.shared.openURL(url)
             }
+
+        case let .setDigitGroupSize(digitGroupSize):
+            // FIXME!
+            print(digitGroupSize)
         }
     }
 

--- a/Authenticator/Source/AppController.swift
+++ b/Authenticator/Source/AppController.swift
@@ -31,6 +31,7 @@ import SVProgressHUD
 
 class AppController {
     private let store: TokenStore
+    private let settings: Settings
     private var component: Root {
         didSet {
             updateView()
@@ -38,7 +39,8 @@ class AppController {
     }
     private lazy var view: RootViewController = {
         let (currentViewModel, nextRefreshTime) = self.component.viewModel(with: self.store.persistentTokens,
-                                                                           at: .currentDisplayTime())
+                                                                           at: .currentDisplayTime(),
+                                                                           digitGroupSize: settings.digitGroupSize)
         self.setTimer(withNextRefreshTime: nextRefreshTime)
         return RootViewController(
             viewModel: currentViewModel,
@@ -68,6 +70,8 @@ class AppController {
             fatalError("Failed to load token store: \(error)")
         }
 
+        settings = Settings()
+
         // If this is a demo, show the scanner even in the simulator.
         let deviceCanScan = QRScanner.deviceCanScan || CommandLine.isDemo
         component = Root(deviceCanScan: deviceCanScan)
@@ -76,7 +80,8 @@ class AppController {
     @objc
     func updateView() {
         let (currentViewModel, nextRefreshTime) = component.viewModel(with: store.persistentTokens,
-                                                                      at: .currentDisplayTime())
+                                                                      at: .currentDisplayTime(),
+                                                                      digitGroupSize: settings.digitGroupSize)
         setTimer(withNextRefreshTime: nextRefreshTime)
         view.update(with: currentViewModel)
     }
@@ -176,8 +181,8 @@ class AppController {
             }
 
         case let .setDigitGroupSize(digitGroupSize):
-            // FIXME!
-            print(digitGroupSize)
+            settings.digitGroupSize = digitGroupSize
+            updateView()
         }
     }
 

--- a/Authenticator/Source/DisplayOptions.swift
+++ b/Authenticator/Source/DisplayOptions.swift
@@ -41,21 +41,21 @@ struct DisplayOptions: TableViewModelRepresentable {
         }
     }
 
-    var viewModel: ViewModel {
+    func viewModel(digitGroupSize: Int) -> ViewModel {
         return TableViewModel(
             title: "Display Options",
             rightBarButton: BarButtonViewModel(style: .done, action: .done),
-            sections: [[digitGroupRowModel]],
+            sections: [[digitGroupRowModel(currentValue: digitGroupSize)]],
             doneKeyAction: .done
         )
     }
 
-    private var digitGroupRowModel: RowModel {
+    private func digitGroupRowModel(currentValue: Int) -> RowModel {
         return .segmentedControlRow(
             identity: "digitGroupSize",
             viewModel: SegmentedControlRowViewModel(
                 options: [(title: "•• •• ••", value: 2), (title: "••• •••", value: 3)],
-                value: 2,
+                value: currentValue,
                 changeAction: DisplayOptions.Effect.setDigitGroupSize
             )
         )

--- a/Authenticator/Source/DisplayOptions.swift
+++ b/Authenticator/Source/DisplayOptions.swift
@@ -52,7 +52,7 @@ struct DisplayOptions: TableViewModelRepresentable {
 
     private func digitGroupRowModel(currentValue: Int) -> RowModel {
         return .segmentedControlRow(
-            identity: "digitGroupSize",
+            identity: "password.digitGroupSize",
             viewModel: SegmentedControlRowViewModel(
                 options: [(title: "•• •• ••", value: 2), (title: "••• •••", value: 3)],
                 value: currentValue,

--- a/Authenticator/Source/DisplayOptions.swift
+++ b/Authenticator/Source/DisplayOptions.swift
@@ -23,43 +23,15 @@
 //  SOFTWARE.
 //
 
-struct DisplayOptions: TableViewModelRepresentable {
+struct DisplayOptions {
     // MARK: View Model
 
-    typealias ViewModel = TableViewModel<DisplayOptions>
-
-    enum HeaderModel {}
-
-    enum RowModel: Identifiable {
-        case digitGroupingRow(identity: String, viewModel: DigitGroupingRowViewModel<Action>)
-
-        func hasSameIdentity(as other: RowModel) -> Bool {
-            switch (self, other) {
-            case let (.digitGroupingRow(rowA), .digitGroupingRow(rowB)):
-                return rowA.identity == rowB.identity
-            }
-        }
+    struct ViewModel {
+        let digitGroupSize: Int
     }
 
     func viewModel(digitGroupSize: Int) -> ViewModel {
-        return TableViewModel(
-            title: "Display Options",
-            rightBarButton: BarButtonViewModel(style: .done, action: .done),
-            sections: [[digitGroupRowModel(currentValue: digitGroupSize)]],
-            doneKeyAction: .done
-        )
-    }
-
-    private func digitGroupRowModel(currentValue: Int) -> RowModel {
-        return .digitGroupingRow(
-            identity: "password.digitGroupSize",
-            viewModel: DigitGroupingRowViewModel(
-                title: "Digit Grouping",
-                options: [(title: "•• •• ••", value: 2), (title: "••• •••", value: 3)],
-                value: currentValue,
-                changeAction: DisplayOptions.Effect.setDigitGroupSize
-            )
-        )
+        return ViewModel(digitGroupSize: digitGroupSize)
     }
 
     // MARK: Actions
@@ -68,6 +40,4 @@ struct DisplayOptions: TableViewModelRepresentable {
         case setDigitGroupSize(Int)
         case done
     }
-
-    typealias Action = Effect
 }

--- a/Authenticator/Source/DisplayOptions.swift
+++ b/Authenticator/Source/DisplayOptions.swift
@@ -23,18 +23,50 @@
 //  SOFTWARE.
 //
 
-struct DisplayOptions {
+struct DisplayOptions: TableViewModelRepresentable {
+    // MARK: View Model
+
+    typealias ViewModel = TableViewModel<DisplayOptions>
+
+    enum HeaderModel {}
+
+    enum RowModel: Identifiable {
+        case segmentedControlRow(identity: String, viewModel: SegmentedControlRowViewModel<Action>)
+
+        func hasSameIdentity(as other: RowModel) -> Bool {
+            switch (self, other) {
+            case let (.segmentedControlRow(rowA), .segmentedControlRow(rowB)):
+                return rowA.identity == rowB.identity
+            }
+        }
+    }
 
     var viewModel: ViewModel {
-        return ViewModel()
+        return TableViewModel(
+            title: "Display Options",
+            rightBarButton: BarButtonViewModel(style: .done, action: .done),
+            sections: [[digitGroupRowModel]],
+            doneKeyAction: .done
+        )
     }
 
-    struct ViewModel {
-        let title = "Display Options"
+    private var digitGroupRowModel: RowModel {
+        return .segmentedControlRow(
+            identity: "digitGroupSize",
+            viewModel: SegmentedControlRowViewModel(
+                options: [(title: "•• •• ••", value: 2), (title: "••• •••", value: 3)],
+                value: 2,
+                changeAction: DisplayOptions.Effect.setDigitGroupSize
+            )
+        )
     }
+
+    // MARK: Actions
 
     enum Effect {
         case setDigitGroupSize(Int)
         case done
     }
+
+    typealias Action = Effect
 }

--- a/Authenticator/Source/DisplayOptions.swift
+++ b/Authenticator/Source/DisplayOptions.swift
@@ -1,0 +1,40 @@
+//
+//  DisplayOptions.swift
+//  Authenticator
+//
+//  Copyright (c) 2018 Authenticator authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+struct DisplayOptions {
+
+    var viewModel: ViewModel {
+        return ViewModel()
+    }
+
+    struct ViewModel {
+        let title = "Display Options"
+    }
+
+    enum Effect {
+        case setDigitGroupSize(Int)
+        case done
+    }
+}

--- a/Authenticator/Source/DisplayOptions.swift
+++ b/Authenticator/Source/DisplayOptions.swift
@@ -31,11 +31,11 @@ struct DisplayOptions: TableViewModelRepresentable {
     enum HeaderModel {}
 
     enum RowModel: Identifiable {
-        case segmentedControlRow(identity: String, viewModel: SegmentedControlRowViewModel<Action>)
+        case digitGroupingRow(identity: String, viewModel: DigitGroupingRowViewModel<Action>)
 
         func hasSameIdentity(as other: RowModel) -> Bool {
             switch (self, other) {
-            case let (.segmentedControlRow(rowA), .segmentedControlRow(rowB)):
+            case let (.digitGroupingRow(rowA), .digitGroupingRow(rowB)):
                 return rowA.identity == rowB.identity
             }
         }
@@ -51,9 +51,10 @@ struct DisplayOptions: TableViewModelRepresentable {
     }
 
     private func digitGroupRowModel(currentValue: Int) -> RowModel {
-        return .segmentedControlRow(
+        return .digitGroupingRow(
             identity: "password.digitGroupSize",
-            viewModel: SegmentedControlRowViewModel(
+            viewModel: DigitGroupingRowViewModel(
+                title: "Digit Grouping",
                 options: [(title: "•• •• ••", value: 2), (title: "••• •••", value: 3)],
                 value: currentValue,
                 changeAction: DisplayOptions.Effect.setDigitGroupSize

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -72,16 +72,16 @@ final class DisplayOptionsViewController: UITableViewController {
 
         // Set up top bar
         title = "Display Options"
-        updateBarButtonItems()
+
+        let action = #selector(DisplayOptionsViewController.rightBarButtonAction)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: action)
     }
 
     // MARK: - Target Actions
 
     @objc
     func rightBarButtonAction() {
-        if let action = viewModel.rightBarButton?.action {
-            dispatchAction(action)
-        }
+        dispatchAction(.done)
     }
 
     // MARK: - UITableViewDataSource
@@ -117,34 +117,6 @@ final class DisplayOptionsViewController: UITableViewController {
 // MARK: - View Model Helpers
 
 extension DisplayOptionsViewController {
-    // MARK: Bar Button View Model
-
-    private func barButtonItem(for viewModel: BarButtonViewModel<DisplayOptions.Action>, target: AnyObject?, action: Selector) -> UIBarButtonItem {
-        func systemItem(for style: BarButtonStyle) -> UIBarButtonSystemItem {
-            switch style {
-            case .done:
-                return .done
-            case .cancel:
-                return .cancel
-            }
-        }
-
-        let barButtonItem = UIBarButtonItem(
-            barButtonSystemItem: systemItem(for: viewModel.style),
-            target: target,
-            action: action
-        )
-        barButtonItem.isEnabled = viewModel.enabled
-        return barButtonItem
-    }
-
-    func updateBarButtonItems() {
-        navigationItem.rightBarButtonItem = viewModel.rightBarButton.map { (viewModel) in
-            let action = #selector(DisplayOptionsViewController.rightBarButtonAction)
-            return barButtonItem(for: viewModel, target: self, action: action)
-        }
-    }
-
     // MARK: Row Model
 
     func cell(for rowModel: DisplayOptions.RowModel, in tableView: UITableView) -> UITableViewCell {
@@ -182,12 +154,9 @@ extension DisplayOptionsViewController {
 }
 
 struct DisplayOptionsTableViewModel {
-    var rightBarButton: BarButtonViewModel<DisplayOptions.Action>?
     var sections: [Section<DisplayOptions.HeaderModel, DisplayOptions.RowModel>]
 
-    init(rightBarButton: BarButtonViewModel<DisplayOptions.Action>? = nil,
-         sections: [Section<DisplayOptions.HeaderModel, DisplayOptions.RowModel>]) {
-        self.rightBarButton = rightBarButton
+    init(sections: [Section<DisplayOptions.HeaderModel, DisplayOptions.RowModel>]) {
         self.sections = sections
     }
 }
@@ -240,7 +209,6 @@ extension DisplayOptions {
 
 private func internalViewModel(for viewModel: DisplayOptions.ViewModel) -> DisplayOptionsTableViewModel {
     return DisplayOptionsTableViewModel(
-        rightBarButton: BarButtonViewModel(style: .done, action: .done),
         sections: [[digitGroupRowModel(currentValue: viewModel.digitGroupSize)]]
     )
 }
@@ -260,7 +228,6 @@ private func digitGroupRowModel(currentValue: Int) -> DisplayOptions.RowModel {
 extension DisplayOptionsViewController {
     func update(with viewModel: DisplayOptions.ViewModel) {
         self.viewModel = internalViewModel(for: viewModel)
-        updateBarButtonItems()
     }
 }
 

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -52,7 +52,7 @@ final class DisplayOptionsViewController: UITableViewController {
     init(viewModel: TableViewModel<DisplayOptions>, dispatchAction: @escaping (DisplayOptions.Action) -> Void) {
         self.viewModel = viewModel
         self.dispatchAction = dispatchAction
-        super.init(style: .grouped)
+        super.init(nibName: nil, bundle: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -27,11 +27,7 @@ import UIKit
 
 final class DisplayOptionsViewController: UITableViewController {
     fileprivate let dispatchAction: (DisplayOptions.Effect) -> Void
-    fileprivate var viewModel: DisplayOptions.ViewModel {
-        didSet {
-            digitGroupingRowCell.update(with: digitGroupingRowViewModel)
-        }
-    }
+    fileprivate var viewModel: DisplayOptions.ViewModel
 
     private let digitGroupingRowCell = DigitGroupingRowCell<DisplayOptions.Effect>()
 
@@ -112,6 +108,7 @@ final class DisplayOptionsViewController: UITableViewController {
 extension DisplayOptionsViewController {
     func update(with viewModel: DisplayOptions.ViewModel) {
         self.viewModel = viewModel
+        digitGroupingRowCell.update(with: digitGroupingRowViewModel)
     }
 
     fileprivate var digitGroupingRowViewModel: DigitGroupingRowViewModel<DisplayOptions.Effect> {

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -29,9 +29,12 @@ final class DisplayOptionsViewController: UITableViewController {
     fileprivate let dispatchAction: (DisplayOptions.Action) -> Void
     fileprivate var viewModel: DisplayOptions.ViewModel {
         didSet {
-            updateRow(at: IndexPath(row: 0, section: 0))
+            let rowModel = digitGroupRowModel(currentValue: viewModel.digitGroupSize)
+            digitGroupingCell.update(with: rowModel)
         }
     }
+
+    private let digitGroupingCell = DigitGroupingRowCell<DisplayOptions.Action>()
 
     init(viewModel: DisplayOptions.ViewModel, dispatchAction: @escaping (DisplayOptions.Action) -> Void) {
         self.viewModel = viewModel
@@ -82,13 +85,15 @@ final class DisplayOptionsViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let rowModel = modelForRow(at: indexPath) else {
+        switch (indexPath.section, indexPath.row) {
+        case (0, 0):
+            let rowModel = digitGroupRowModel(currentValue: viewModel.digitGroupSize)
+            digitGroupingCell.update(with: rowModel)
+            digitGroupingCell.dispatchAction = dispatchAction
+            return digitGroupingCell
+        default:
             return UITableViewCell()
         }
-        let cell = tableView.dequeueReusableCell(withClass: DigitGroupingRowCell<DisplayOptions.Action>.self)
-        cell.update(with: rowModel)
-        cell.dispatchAction = dispatchAction
-        return cell
     }
 
     // MARK: - UITableViewDelegate
@@ -106,30 +111,6 @@ final class DisplayOptionsViewController: UITableViewController {
 
 // MARK: - View Model Helpers
 
-extension DisplayOptionsViewController {
-    // MARK: Row Model
-
-    func updateRow(at indexPath: IndexPath) {
-        guard let cell = tableView.cellForRow(at: indexPath) else {
-            // If the given row is not visible, the table view will have no cell for it, and it
-            // doesn't need to be updated.
-            return
-        }
-        guard let rowModel = modelForRow(at: indexPath) else {
-            // If there is no row model for the given index path, just tell the table view to
-            // reload it and hope for the best.
-            tableView.reloadRows(at: [indexPath], with: .automatic)
-            return
-        }
-
-        if let cell = cell as? DigitGroupingRowCell<DisplayOptions.Action> {
-            cell.update(with: rowModel)
-        } else {
-            tableView.reloadRows(at: [indexPath], with: .automatic)
-        }
-    }
-}
-
 extension DisplayOptions {
     typealias Action = Effect
 }
@@ -146,13 +127,6 @@ private func digitGroupRowModel(currentValue: Int) -> DigitGroupingRowViewModel<
 extension DisplayOptionsViewController {
     func update(with viewModel: DisplayOptions.ViewModel) {
         self.viewModel = viewModel
-    }
-
-    func modelForRow(at indexPath: IndexPath) -> DigitGroupingRowViewModel<Action>? {
-        guard indexPath == IndexPath(row: 0, section: 0) else {
-            return nil
-        }
-        return digitGroupRowModel(currentValue: viewModel.digitGroupSize)
     }
 }
 

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -1,0 +1,106 @@
+//
+//  DisplayOptionsViewController.swift
+//  Authenticator
+//
+//  Copyright (c) 2018 Authenticator authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import UIKit
+
+final class DisplayOptionsViewController: UITableViewController {
+    private var viewModel: DisplayOptions.ViewModel
+    private let dispatchAction: (DisplayOptions.Effect) -> Void
+
+    // MARK: Initialization
+
+    init(viewModel: DisplayOptions.ViewModel, dispatchAction: @escaping (DisplayOptions.Effect) -> Void) {
+        self.viewModel = viewModel
+        self.dispatchAction = dispatchAction
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(with viewModel: DisplayOptions.ViewModel) {
+        self.viewModel = viewModel
+        applyViewModel()
+    }
+
+    private func applyViewModel() {
+        title = viewModel.title
+    }
+
+    // MARK: View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.backgroundColor = UIColor.otpBackgroundColor
+        tableView.separatorStyle = .none
+        tableView.indicatorStyle = .white
+        self.tableView.rowHeight = UITableViewAutomaticDimension
+        self.tableView.estimatedRowHeight = 44.0
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
+                                                            target: self,
+                                                            action: #selector(done))
+
+        applyViewModel()
+    }
+
+    // MARK: Target Actions
+
+    @objc
+    func done() {
+        dispatchAction(.done)
+    }
+
+    /*
+    // MARK: UITableViewDataSource
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.rowModels.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withClass: DisplayOptionsCell.self)
+        updateCell(cell, forRowAtIndexPath: indexPath)
+        return cell
+    }
+
+    fileprivate func updateCell(_ cell: DisplayOptionsCell, forRowAtIndexPath indexPath: IndexPath) {
+        let rowModel = viewModel.rowModels[indexPath.row]
+        cell.update(with: rowModel)
+    }
+
+    // MARK: UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let rowModel = viewModel.rowModels[indexPath.row]
+        dispatchAction(rowModel.action)
+    }
+*/
+}
+
+class DisplayOptionsCell: UITableViewCell {
+}

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -29,12 +29,11 @@ final class DisplayOptionsViewController: UITableViewController {
     fileprivate let dispatchAction: (DisplayOptions.Action) -> Void
     fileprivate var viewModel: DisplayOptions.ViewModel {
         didSet {
-            let rowModel = digitGroupRowModel(currentValue: viewModel.digitGroupSize)
-            digitGroupingCell.update(with: rowModel)
+            digitGroupingRowCell.update(with: digitGroupingRowViewModel)
         }
     }
 
-    private let digitGroupingCell = DigitGroupingRowCell<DisplayOptions.Action>()
+    private let digitGroupingRowCell = DigitGroupingRowCell<DisplayOptions.Action>()
 
     init(viewModel: DisplayOptions.ViewModel, dispatchAction: @escaping (DisplayOptions.Action) -> Void) {
         self.viewModel = viewModel
@@ -87,10 +86,9 @@ final class DisplayOptionsViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch (indexPath.section, indexPath.row) {
         case (0, 0):
-            let rowModel = digitGroupRowModel(currentValue: viewModel.digitGroupSize)
-            digitGroupingCell.update(with: rowModel)
-            digitGroupingCell.dispatchAction = dispatchAction
-            return digitGroupingCell
+            digitGroupingRowCell.update(with: digitGroupingRowViewModel)
+            digitGroupingRowCell.dispatchAction = dispatchAction
+            return digitGroupingRowCell
         default:
             return UITableViewCell()
         }
@@ -115,18 +113,18 @@ extension DisplayOptions {
     typealias Action = Effect
 }
 
-private func digitGroupRowModel(currentValue: Int) -> DigitGroupingRowViewModel<DisplayOptions.Action> {
-    return DigitGroupingRowViewModel(
-        title: "Digit Grouping",
-        options: [(title: "•• •• ••", value: 2), (title: "••• •••", value: 3)],
-        value: currentValue,
-        changeAction: DisplayOptions.Effect.setDigitGroupSize
-    )
-}
-
 extension DisplayOptionsViewController {
     func update(with viewModel: DisplayOptions.ViewModel) {
         self.viewModel = viewModel
+    }
+
+    fileprivate var digitGroupingRowViewModel: DigitGroupingRowViewModel<DisplayOptions.Action> {
+        return DigitGroupingRowViewModel(
+            title: "Digit Grouping",
+            options: [(title: "•• •• ••", value: 2), (title: "••• •••", value: 3)],
+            value: viewModel.digitGroupSize,
+            changeAction: DisplayOptions.Effect.setDigitGroupSize
+        )
     }
 }
 

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -26,16 +26,16 @@
 import UIKit
 
 final class DisplayOptionsViewController: UITableViewController {
-    fileprivate let dispatchAction: (DisplayOptions.Action) -> Void
+    fileprivate let dispatchAction: (DisplayOptions.Effect) -> Void
     fileprivate var viewModel: DisplayOptions.ViewModel {
         didSet {
             digitGroupingRowCell.update(with: digitGroupingRowViewModel)
         }
     }
 
-    private let digitGroupingRowCell = DigitGroupingRowCell<DisplayOptions.Action>()
+    private let digitGroupingRowCell = DigitGroupingRowCell<DisplayOptions.Effect>()
 
-    init(viewModel: DisplayOptions.ViewModel, dispatchAction: @escaping (DisplayOptions.Action) -> Void) {
+    init(viewModel: DisplayOptions.ViewModel, dispatchAction: @escaping (DisplayOptions.Effect) -> Void) {
         self.viewModel = viewModel
         self.dispatchAction = dispatchAction
         super.init(nibName: nil, bundle: nil)
@@ -109,16 +109,12 @@ final class DisplayOptionsViewController: UITableViewController {
 
 // MARK: - View Model Helpers
 
-extension DisplayOptions {
-    typealias Action = Effect
-}
-
 extension DisplayOptionsViewController {
     func update(with viewModel: DisplayOptions.ViewModel) {
         self.viewModel = viewModel
     }
 
-    fileprivate var digitGroupingRowViewModel: DigitGroupingRowViewModel<DisplayOptions.Action> {
+    fileprivate var digitGroupingRowViewModel: DigitGroupingRowViewModel<DisplayOptions.Effect> {
         return DigitGroupingRowViewModel(
             title: "Digit Grouping",
             options: [(title: "•• •• ••", value: 2), (title: "••• •••", value: 3)],

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -71,7 +71,7 @@ final class DisplayOptionsViewController: UITableViewController {
         tableView.estimatedRowHeight = 44.0
 
         // Set up top bar
-        title = viewModel.title
+        title = "Display Options"
         updateBarButtonItems()
     }
 
@@ -182,14 +182,11 @@ extension DisplayOptionsViewController {
 }
 
 struct DisplayOptionsTableViewModel {
-    var title: String
     var rightBarButton: BarButtonViewModel<DisplayOptions.Action>?
     var sections: [Section<DisplayOptions.HeaderModel, DisplayOptions.RowModel>]
 
-    init(title: String,
-         rightBarButton: BarButtonViewModel<DisplayOptions.Action>? = nil,
+    init(rightBarButton: BarButtonViewModel<DisplayOptions.Action>? = nil,
          sections: [Section<DisplayOptions.HeaderModel, DisplayOptions.RowModel>]) {
-        self.title = title
         self.rightBarButton = rightBarButton
         self.sections = sections
     }
@@ -243,7 +240,6 @@ extension DisplayOptions {
 
 private func internalViewModel(for viewModel: DisplayOptions.ViewModel) -> DisplayOptionsTableViewModel {
     return DisplayOptionsTableViewModel(
-        title: "Display Options",
         rightBarButton: BarButtonViewModel(style: .done, action: .done),
         sections: [[digitGroupRowModel(currentValue: viewModel.digitGroupSize)]]
     )

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -73,52 +73,6 @@ final class DisplayOptionsViewController: UITableViewController {
         updateBarButtonItems()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        if CommandLine.isDemo {
-            // If this is a demo, don't show the keyboard.
-            return
-        }
-
-        focusFirstField()
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        unfocus()
-    }
-
-    // MARK: Focus
-
-    @discardableResult
-    private func focusFirstField() -> Bool {
-        for cell in tableView.visibleCells {
-            if let focusCell = cell as? FocusCell {
-                return focusCell.focus()
-            }
-        }
-        return false
-    }
-
-    fileprivate func nextVisibleFocusCell(after currentIndexPath: IndexPath) -> FocusCell? {
-        if let visibleIndexPaths = tableView.indexPathsForVisibleRows {
-            for indexPath in visibleIndexPaths {
-                if currentIndexPath.compare(indexPath) == .orderedAscending {
-                    if let focusCell = tableView.cellForRow(at: indexPath) as? FocusCell {
-                        return focusCell
-                    }
-                }
-            }
-        }
-        return nil
-    }
-
-    @discardableResult
-    private func unfocus() -> Bool {
-        return view.endEditing(false)
-    }
-
     // MARK: - Target Actions
 
     @objc

--- a/Authenticator/Source/DisplayOptionsViewController.swift
+++ b/Authenticator/Source/DisplayOptionsViewController.swift
@@ -26,81 +26,259 @@
 import UIKit
 
 final class DisplayOptionsViewController: UITableViewController {
-    private var viewModel: DisplayOptions.ViewModel
-    private let dispatchAction: (DisplayOptions.Effect) -> Void
+    fileprivate let dispatchAction: (DisplayOptions.Action) -> Void
+    fileprivate var viewModel: TableViewModel<DisplayOptions> {
+        didSet {
+            guard oldValue.sections.count == viewModel.sections.count else {
+                // Automatic updates aren't implemented for changing number of sections
+                tableView.reloadData()
+                return
+            }
 
-    // MARK: Initialization
+            let changes = viewModel.sections.indices.flatMap { sectionIndex -> [Change<IndexPath>] in
+                let oldSection = oldValue.sections[sectionIndex]
+                let newSection = viewModel.sections[sectionIndex]
+                let changes = changesFrom(oldSection.rows, to: newSection.rows)
+                return changes.map({ change in
+                    change.map({ row in
+                        IndexPath(row: row, section: sectionIndex)
+                    })
+                })
+            }
+            tableView.applyChanges(changes, updateRow: updateRow(at:))
+        }
+    }
 
-    init(viewModel: DisplayOptions.ViewModel, dispatchAction: @escaping (DisplayOptions.Effect) -> Void) {
+    init(viewModel: TableViewModel<DisplayOptions>, dispatchAction: @escaping (DisplayOptions.Action) -> Void) {
         self.viewModel = viewModel
         self.dispatchAction = dispatchAction
-        super.init(nibName: nil, bundle: nil)
+        super.init(style: .grouped)
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func update(with viewModel: DisplayOptions.ViewModel) {
-        self.viewModel = viewModel
-        applyViewModel()
-    }
-
-    private func applyViewModel() {
-        title = viewModel.title
-    }
-
-    // MARK: View Lifecycle
+    // MARK: - View Lifecycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.backgroundColor = UIColor.otpBackgroundColor
+        view.backgroundColor = .otpBackgroundColor
+        view.tintColor = .otpForegroundColor
         tableView.separatorStyle = .none
-        tableView.indicatorStyle = .white
-        self.tableView.rowHeight = UITableViewAutomaticDimension
-        self.tableView.estimatedRowHeight = 44.0
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
-                                                            target: self,
-                                                            action: #selector(done))
-
-        applyViewModel()
+        // Set up top bar
+        title = viewModel.title
+        updateBarButtonItems()
     }
 
-    // MARK: Target Actions
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if CommandLine.isDemo {
+            // If this is a demo, don't show the keyboard.
+            return
+        }
+
+        focusFirstField()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        unfocus()
+    }
+
+    // MARK: Focus
+
+    @discardableResult
+    private func focusFirstField() -> Bool {
+        for cell in tableView.visibleCells {
+            if let focusCell = cell as? FocusCell {
+                return focusCell.focus()
+            }
+        }
+        return false
+    }
+
+    fileprivate func nextVisibleFocusCell(after currentIndexPath: IndexPath) -> FocusCell? {
+        if let visibleIndexPaths = tableView.indexPathsForVisibleRows {
+            for indexPath in visibleIndexPaths {
+                if currentIndexPath.compare(indexPath) == .orderedAscending {
+                    if let focusCell = tableView.cellForRow(at: indexPath) as? FocusCell {
+                        return focusCell
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    @discardableResult
+    private func unfocus() -> Bool {
+        return view.endEditing(false)
+    }
+
+    // MARK: - Target Actions
 
     @objc
-    func done() {
-        dispatchAction(.done)
+    func leftBarButtonAction() {
+        if let action = viewModel.leftBarButton?.action {
+            dispatchAction(action)
+        }
     }
 
-    /*
-    // MARK: UITableViewDataSource
+    @objc
+    func rightBarButtonAction() {
+        if let action = viewModel.rightBarButton?.action {
+            dispatchAction(action)
+        }
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return viewModel.numberOfSections
+    }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.rowModels.count
+        return viewModel.numberOfRows(inSection: section)
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withClass: DisplayOptionsCell.self)
-        updateCell(cell, forRowAtIndexPath: indexPath)
-        return cell
+        guard let rowModel = viewModel.modelForRow(at: indexPath) else {
+            return UITableViewCell()
+        }
+        return cell(for: rowModel, in: tableView)
     }
 
-    fileprivate func updateCell(_ cell: DisplayOptionsCell, forRowAtIndexPath indexPath: IndexPath) {
-        let rowModel = viewModel.rowModels[indexPath.row]
-        cell.update(with: rowModel)
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        // An apparent rendering error can occur when the table view is scrolled programmatically, causing a cell
+        // scrolled off of the screen to appear with a black background when scrolled back onto the screen. Setting the
+        // background color of the cell to the table view's background color, instead of to `.clear`, fixes the issue.
+        cell.backgroundColor = .otpBackgroundColor
+        cell.selectionStyle = .none
+
+        cell.textLabel?.textColor = .otpForegroundColor
     }
 
-    // MARK: UITableViewDelegate
-
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let rowModel = viewModel.rowModels[indexPath.row]
-        dispatchAction(rowModel.action)
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        guard let rowModel = viewModel.modelForRow(at: indexPath) else {
+            return 0
+        }
+        return heightForRow(with: rowModel)
     }
-*/
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        guard let headerModel = viewModel.modelForHeader(inSection: section) else {
+            return CGFloat.ulpOfOne
+        }
+        return heightForHeader(with: headerModel)
+    }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let headerModel = viewModel.modelForHeader(inSection: section) else {
+            return nil
+        }
+        return viewForHeader(with: headerModel)
+    }
 }
 
-class DisplayOptionsCell: UITableViewCell {
+// MARK: - View Model Helpers
+
+extension DisplayOptionsViewController {
+    // MARK: Bar Button View Model
+
+    private func barButtonItem(for viewModel: BarButtonViewModel<DisplayOptions.Action>, target: AnyObject?, action: Selector) -> UIBarButtonItem {
+        func systemItem(for style: BarButtonStyle) -> UIBarButtonSystemItem {
+            switch style {
+            case .done:
+                return .done
+            case .cancel:
+                return .cancel
+            }
+        }
+
+        let barButtonItem = UIBarButtonItem(
+            barButtonSystemItem: systemItem(for: viewModel.style),
+            target: target,
+            action: action
+        )
+        barButtonItem.isEnabled = viewModel.enabled
+        return barButtonItem
+    }
+
+    func updateBarButtonItems() {
+        navigationItem.leftBarButtonItem = viewModel.leftBarButton.map { (viewModel) in
+            let action = #selector(DisplayOptionsViewController.leftBarButtonAction)
+            return barButtonItem(for: viewModel, target: self, action: action)
+        }
+        navigationItem.rightBarButtonItem = viewModel.rightBarButton.map { (viewModel) in
+            let action = #selector(DisplayOptionsViewController.rightBarButtonAction)
+            return barButtonItem(for: viewModel, target: self, action: action)
+        }
+    }
+
+    // MARK: Row Model
+
+    func cell(for rowModel: DisplayOptions.RowModel, in tableView: UITableView) -> UITableViewCell {
+        switch rowModel {
+        case let .segmentedControlRow(row):
+            let cell = tableView.dequeueReusableCell(withClass: SegmentedControlRowCell<DisplayOptions.Action>.self)
+            cell.update(with: row.viewModel)
+            cell.dispatchAction = dispatchAction
+            return cell
+        }
+    }
+
+    func updateRow(at indexPath: IndexPath) {
+        guard let cell = tableView.cellForRow(at: indexPath) else {
+            // If the given row is not visible, the table view will have no cell for it, and it
+            // doesn't need to be updated.
+            return
+        }
+        guard let rowModel = viewModel.modelForRow(at: indexPath) else {
+            // If there is no row model for the given index path, just tell the table view to
+            // reload it and hope for the best.
+            tableView.reloadRows(at: [indexPath], with: .automatic)
+            return
+        }
+
+        switch rowModel {
+        case let .segmentedControlRow(row):
+            if let cell = cell as? SegmentedControlRowCell<DisplayOptions.Action> {
+                cell.update(with: row.viewModel)
+            } else {
+                tableView.reloadRows(at: [indexPath], with: .automatic)
+            }
+        }
+    }
+
+    func heightForRow(with rowModel: DisplayOptions.RowModel) -> CGFloat {
+        switch rowModel {
+        case let .segmentedControlRow(row):
+            return SegmentedControlRowCell<DisplayOptions.Action>.heightForRow(with: row.viewModel)
+        }
+    }
+
+    // MARK: Header Model
+
+    func viewForHeader(with headerModel: DisplayOptions.HeaderModel) -> UIView {
+        switch headerModel {
+        }
+    }
+
+    func heightForHeader(with headerModel: DisplayOptions.HeaderModel) -> CGFloat {
+        switch headerModel {
+        }
+    }
+}
+
+extension DisplayOptionsViewController {
+    func update(with viewModel: TableViewModel<DisplayOptions>) {
+        self.viewModel = viewModel
+        updateBarButtonItems()
+    }
 }

--- a/Authenticator/Source/InfoList.swift
+++ b/Authenticator/Source/InfoList.swift
@@ -2,7 +2,7 @@
 //  InfoList.swift
 //  Authenticator
 //
-//  Copyright (c) 2017 Authenticator authors
+//  Copyright (c) 2017-2018 Authenticator authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Authenticator/Source/InfoList.swift
+++ b/Authenticator/Source/InfoList.swift
@@ -45,6 +45,10 @@ struct InfoList {
         let licenseDescription = "Authenticator makes use of several third party libraries."
 
         return ViewModel(title: "Info", rowModels: [
+            RowModel(title: "Display Options",
+                     description: "The presentation of one-time passwords can be customized.",
+                     callToAction: "See Options →".replacingOccurrences(of: " ", with: "\u{00A0}"),
+                     action: .showDisplayOptions),
             RowModel(title: "Backups",
                      description: backupDescription,
                      callToAction: "Learn More →".replacingOccurrences(of: " ", with: "\u{00A0}"),
@@ -59,6 +63,7 @@ struct InfoList {
     // MARK: Update
 
     enum Effect {
+        case showDisplayOptions
         case showBackupInfo
         case showLicenseInfo
         case done

--- a/Authenticator/Source/InfoListViewController.swift
+++ b/Authenticator/Source/InfoListViewController.swift
@@ -2,7 +2,7 @@
 //  InfoListViewController.swift
 //  Authenticator
 //
-//  Copyright (c) 2017 Authenticator authors
+//  Copyright (c) 2017-2018 Authenticator authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -110,9 +110,9 @@ class InfoListCell: UITableViewCell {
         return paragraphStyle
     }()
 
-    let titleLabel = UILabel()
-    let descriptionLabel = UILabel()
-    var customConstraints: [NSLayoutConstraint]?
+    private let titleLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private var customConstraints: [NSLayoutConstraint]?
 
     // MARK: Initialization
 

--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -25,7 +25,7 @@
 
 struct Menu {
     let infoList: InfoList
-    let child: Child
+    private(set) var child: Child
 
     enum Child {
         case none
@@ -44,6 +44,16 @@ struct Menu {
         }
     }
 
+    init() {
+        infoList = InfoList()
+        child = .none
+    }
+
+    init(info: Info) {
+        infoList = InfoList()
+        child = .info(info)
+    }
+
     var viewModel: ViewModel {
         return ViewModel(infoList: infoList.viewModel, child: child.viewModel)
     }
@@ -57,5 +67,39 @@ struct Menu {
             case info(Info.ViewModel)
             case displayOptions(DisplayOptions.ViewModel)
         }
+    }
+
+    // MARK: -
+
+    enum Error: Swift.Error {
+        case badChildState
+    }
+
+    mutating func showInfo(_ info: Info) throws {
+        guard case .none = child else {
+            throw Error.badChildState
+        }
+        child = .info(info)
+    }
+
+    mutating func dismissInfo() throws {
+        guard case .info = child else {
+            throw Error.badChildState
+        }
+        child = .none
+    }
+
+    mutating func showDisplayOptions() throws {
+        guard case .none = child else {
+            throw Error.badChildState
+        }
+        child = .displayOptions(DisplayOptions())
+    }
+
+    mutating func dismissDisplayOptions() throws {
+        guard case .displayOptions = child else {
+            throw Error.badChildState
+        }
+        child = .none
     }
 }

--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -25,11 +25,12 @@
 
 struct Menu {
     let infoList: InfoList
-    var child: Child
+    let child: Child
 
     enum Child {
         case none
         case info(Info)
+        case displayOptions(DisplayOptions)
 
         var viewModel: Menu.ViewModel.Child {
             switch self {
@@ -37,6 +38,8 @@ struct Menu {
                 return .none
             case .info(let info):
                 return .info(info.viewModel)
+            case .displayOptions(let displayOptions):
+                return .displayOptions(displayOptions.viewModel)
             }
         }
     }
@@ -52,7 +55,7 @@ struct Menu {
         enum Child {
             case none
             case info(Info.ViewModel)
+            case displayOptions(DisplayOptions.ViewModel)
         }
-
     }
 }

--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -1,8 +1,8 @@
 //
-//  RootViewModel.swift
+//  Menu.swift
 //  Authenticator
 //
-//  Copyright (c) 2015-2017 Authenticator authors
+//  Copyright (c) 2018 Authenticator authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -23,15 +23,36 @@
 //  SOFTWARE.
 //
 
-struct RootViewModel {
-    let tokenList: TokenList.ViewModel
-    let modal: ModalViewModel
+struct Menu {
+    let infoList: InfoList
+    var child: Child
 
-    enum ModalViewModel {
+    enum Child {
         case none
-        case scanner(TokenScanner.ViewModel)
-        case entryForm(TokenEntryForm.ViewModel)
-        case editForm(TokenEditForm.ViewModel)
-        case menu(Menu.ViewModel)
+        case info(Info)
+
+        var viewModel: Menu.ViewModel.Child {
+            switch self {
+            case .none:
+                return .none
+            case .info(let info):
+                return .info(info.viewModel)
+            }
+        }
+    }
+
+    var viewModel: ViewModel {
+        return ViewModel(infoList: infoList.viewModel, child: child.viewModel)
+    }
+
+    struct ViewModel {
+        let infoList: InfoList.ViewModel
+        let child: Child
+
+        enum Child {
+            case none
+            case info(Info.ViewModel)
+        }
+
     }
 }

--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -32,14 +32,14 @@ struct Menu {
         case info(Info)
         case displayOptions(DisplayOptions)
 
-        var viewModel: Menu.ViewModel.Child {
+        func viewModel(digitGroupSize: Int) -> Menu.ViewModel.Child {
             switch self {
             case .none:
                 return .none
             case .info(let info):
                 return .info(info.viewModel)
             case .displayOptions(let displayOptions):
-                return .displayOptions(displayOptions.viewModel)
+                return .displayOptions(displayOptions.viewModel(digitGroupSize: digitGroupSize))
             }
         }
     }
@@ -54,8 +54,8 @@ struct Menu {
         child = .info(info)
     }
 
-    var viewModel: ViewModel {
-        return ViewModel(infoList: infoList.viewModel, child: child.viewModel)
+    func viewModel(digitGroupSize: Int) -> ViewModel {
+        return ViewModel(infoList: infoList.viewModel, child: child.viewModel(digitGroupSize: digitGroupSize))
     }
 
     struct ViewModel {

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -52,7 +52,6 @@ struct Root: Component {
                 return .menu(menu.viewModel(digitGroupSize: digitGroupSize))
             }
         }
-
     }
 
     init(deviceCanScan: Bool) {

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -38,7 +38,7 @@ struct Root: Component {
         case editForm(TokenEditForm)
         case menu(Menu)
 
-        var viewModel: RootViewModel.ModalViewModel {
+        func viewModel(digitGroupSize: Int) -> RootViewModel.ModalViewModel {
             switch self {
             case .none:
                 return .none
@@ -49,7 +49,7 @@ struct Root: Component {
             case .editForm(let form):
                 return .editForm(form.viewModel)
             case let .menu(menu):
-                return .menu(menu.viewModel)
+                return .menu(menu.viewModel(digitGroupSize: digitGroupSize))
             }
         }
 
@@ -67,11 +67,11 @@ struct Root: Component {
 extension Root {
     typealias ViewModel = RootViewModel
 
-    func viewModel(with persistentTokens: [PersistentToken], at displayTime: DisplayTime) -> (viewModel: ViewModel, nextRefreshTime: Date) {
+    func viewModel(with persistentTokens: [PersistentToken], at displayTime: DisplayTime, digitGroupSize: Int) -> (viewModel: ViewModel, nextRefreshTime: Date) {
         let (tokenListViewModel, nextRefreshTime) = tokenList.viewModel(with: persistentTokens, at: displayTime)
         let viewModel = ViewModel(
             tokenList: tokenListViewModel,
-            modal: modal.viewModel
+            modal: modal.viewModel(digitGroupSize: digitGroupSize)
         )
         return (viewModel: viewModel, nextRefreshTime: nextRefreshTime)
     }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -2,7 +2,7 @@
 //  Root.swift
 //  Authenticator
 //
-//  Copyright (c) 2015-2017 Authenticator authors
+//  Copyright (c) 2015-2018 Authenticator authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -36,7 +36,7 @@ struct Root: Component {
         case scanner(TokenScanner)
         case entryForm(TokenEntryForm)
         case editForm(TokenEditForm)
-        case info(InfoList, Info?)
+        case menu(Menu)
 
         var viewModel: RootViewModel.ModalViewModel {
             switch self {
@@ -48,10 +48,11 @@ struct Root: Component {
                 return .entryForm(form.viewModel)
             case .editForm(let form):
                 return .editForm(form.viewModel)
-            case let .info(infoList, info):
-                return .info(infoList.viewModel, info?.viewModel)
+            case let .menu(menu):
+                return .menu(menu.viewModel)
             }
         }
+
     }
 
     init(deviceCanScan: Bool) {
@@ -232,14 +233,14 @@ extension Root {
 
         case .showBackupInfo:
             do {
-                modal = .info(InfoList(), try Info.backupInfo())
+                modal = .menu(Menu(infoList: InfoList(), child: .info(try Info.backupInfo())))
                 return nil
             } catch {
                 return .showErrorMessage("Failed to load backup info.")
             }
 
         case .showInfo:
-            modal = .info(InfoList(), nil)
+            modal = .menu(Menu(infoList: InfoList(), child: .none))
             return nil
         }
     }
@@ -382,16 +383,16 @@ private extension Root.Modal {
     }
 
     mutating func setInfo(_ info: Info) throws {
-        guard case .info(let infoList, .none) = self else {
+        guard case .menu(let menu) = self, case .none = menu.child else {
             throw Error(expectedType: InfoList.self, actualState: self)
         }
-        self = .info(infoList, info)
+        self = .menu(Menu(infoList: menu.infoList, child: .info(info)))
     }
 
     mutating func dismissInfo() throws {
-        guard case .info(let infoList, .some) = self else {
+        guard case .menu(let menu) = self, case .info = menu.child else {
             throw Error(expectedType: Info.self, actualState: self)
         }
-        self = .info(infoList, nil)
+        self = .menu(Menu(infoList: menu.infoList, child: .none))
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -168,11 +168,15 @@ extension Root {
                 return handleDisplayOptionsEffect(effect)
 
             case .dismissInfo:
-                try modal.dismissInfo()
+                try modal.withMenu { menu in
+                    try menu.dismissInfo()
+                }
                 return nil
 
             case .dismissDisplayOptions:
-                try modal.dismissDisplayOptions()
+                try modal.withMenu { menu in
+                    try menu.dismissDisplayOptions()
+                }
                 return nil
 
             case .addTokenFromURL(let token):
@@ -319,7 +323,9 @@ extension Root {
     private mutating func handleInfoListEffect(_ effect: InfoList.Effect) throws -> Effect? {
         switch effect {
         case .showDisplayOptions:
-            try modal.showDisplayOptions()
+            try modal.withMenu { menu in
+                try menu.showDisplayOptions()
+            }
             return nil
 
         case .showBackupInfo:
@@ -329,7 +335,9 @@ extension Root {
             } catch {
                 return .showErrorMessage("Failed to load backup info.")
             }
-            try modal.showInfo(backupInfo)
+            try modal.withMenu { menu in
+                try menu.showInfo(backupInfo)
+            }
             return nil
 
         case .showLicenseInfo:
@@ -339,7 +347,9 @@ extension Root {
             } catch {
                 return .showErrorMessage("Failed to load acknowledgements.")
             }
-            try modal.showInfo(licenseInfo)
+            try modal.withMenu { menu in
+                try menu.showInfo(licenseInfo)
+            }
             return nil
 
         case .done:
@@ -403,35 +413,12 @@ private extension Root.Modal {
         return result
     }
 
-    mutating func showInfo(_ info: Info) throws {
+    mutating func withMenu<ResultType>(_ body: (inout Menu) throws -> ResultType) throws -> ResultType {
         guard case .menu(var menu) = self else {
             throw Error(expectedType: Menu.self, actualState: self)
         }
-        try menu.showInfo(info)
+        let result = try body(&menu)
         self = .menu(menu)
-    }
-
-    mutating func dismissInfo() throws {
-        guard case .menu(var menu) = self else {
-            throw Error(expectedType: Menu.self, actualState: self)
-        }
-        try menu.dismissInfo()
-        self = .menu(menu)
-    }
-
-    mutating func showDisplayOptions() throws {
-        guard case .menu(var menu) = self else {
-            throw Error(expectedType: Menu.self, actualState: self)
-        }
-        try menu.showDisplayOptions()
-        self = .menu(menu)
-    }
-
-    mutating func dismissDisplayOptions() throws {
-        guard case .menu(var menu) = self else {
-            throw Error(expectedType: Menu.self, actualState: self)
-        }
-        try menu.dismissDisplayOptions()
-        self = .menu(menu)
+        return result
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -243,14 +243,14 @@ extension Root {
 
         case .showBackupInfo:
             do {
-                modal = .menu(Menu(infoList: InfoList(), child: .info(try Info.backupInfo())))
+                modal = .menu(Menu(info: try Info.backupInfo()))
                 return nil
             } catch {
                 return .showErrorMessage("Failed to load backup info.")
             }
 
         case .showInfo:
-            modal = .menu(Menu(infoList: InfoList(), child: .none))
+            modal = .menu(Menu())
             return nil
         }
     }
@@ -319,7 +319,7 @@ extension Root {
     private mutating func handleInfoListEffect(_ effect: InfoList.Effect) throws -> Effect? {
         switch effect {
         case .showDisplayOptions:
-            try modal.setDisplayOptions(DisplayOptions())
+            try modal.showDisplayOptions()
             return nil
 
         case .showBackupInfo:
@@ -329,7 +329,7 @@ extension Root {
             } catch {
                 return .showErrorMessage("Failed to load backup info.")
             }
-            try modal.setInfo(backupInfo)
+            try modal.showInfo(backupInfo)
             return nil
 
         case .showLicenseInfo:
@@ -339,7 +339,7 @@ extension Root {
             } catch {
                 return .showErrorMessage("Failed to load acknowledgements.")
             }
-            try modal.setInfo(licenseInfo)
+            try modal.showInfo(licenseInfo)
             return nil
 
         case .done:
@@ -403,31 +403,35 @@ private extension Root.Modal {
         return result
     }
 
-    mutating func setInfo(_ info: Info) throws {
-        guard case .menu(let menu) = self, case .none = menu.child else {
-            throw Error(expectedType: InfoList.self, actualState: self)
+    mutating func showInfo(_ info: Info) throws {
+        guard case .menu(var menu) = self else {
+            throw Error(expectedType: Menu.self, actualState: self)
         }
-        self = .menu(Menu(infoList: menu.infoList, child: .info(info)))
+        try menu.showInfo(info)
+        self = .menu(menu)
     }
 
     mutating func dismissInfo() throws {
-        guard case .menu(let menu) = self, case .info = menu.child else {
-            throw Error(expectedType: Info.self, actualState: self)
+        guard case .menu(var menu) = self else {
+            throw Error(expectedType: Menu.self, actualState: self)
         }
-        self = .menu(Menu(infoList: menu.infoList, child: .none))
+        try menu.dismissInfo()
+        self = .menu(menu)
     }
 
-    mutating func setDisplayOptions(_ displayOptions: DisplayOptions) throws {
-        guard case .menu(let menu) = self, case .none = menu.child else {
-            throw Error(expectedType: InfoList.self, actualState: self)
+    mutating func showDisplayOptions() throws {
+        guard case .menu(var menu) = self else {
+            throw Error(expectedType: Menu.self, actualState: self)
         }
-        self = .menu(Menu(infoList: menu.infoList, child: .displayOptions(displayOptions)))
+        try menu.showDisplayOptions()
+        self = .menu(menu)
     }
 
     mutating func dismissDisplayOptions() throws {
-        guard case .menu(let menu) = self, case .displayOptions = menu.child else {
-            throw Error(expectedType: DisplayOptions.self, actualState: self)
+        guard case .menu(var menu) = self else {
+            throw Error(expectedType: Menu.self, actualState: self)
         }
-        self = .menu(Menu(infoList: menu.infoList, child: .none))
+        try menu.dismissDisplayOptions()
+        self = .menu(menu)
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -68,7 +68,11 @@ extension Root {
     typealias ViewModel = RootViewModel
 
     func viewModel(with persistentTokens: [PersistentToken], at displayTime: DisplayTime, digitGroupSize: Int) -> (viewModel: ViewModel, nextRefreshTime: Date) {
-        let (tokenListViewModel, nextRefreshTime) = tokenList.viewModel(with: persistentTokens, at: displayTime)
+        let (tokenListViewModel, nextRefreshTime) = tokenList.viewModel(
+            with: persistentTokens,
+            at: displayTime,
+            digitGroupSize: digitGroupSize
+        )
         let viewModel = ViewModel(
             tokenList: tokenListViewModel,
             modal: modal.viewModel(digitGroupSize: digitGroupSize)

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -307,6 +307,9 @@ extension Root {
 
     private mutating func handleInfoListEffect(_ effect: InfoList.Effect) throws -> Effect? {
         switch effect {
+        case .showDisplayOptions:
+            return nil
+
         case .showBackupInfo:
             let backupInfo: Info
             do {

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -213,10 +213,12 @@ extension RootViewController: UINavigationControllerDelegate {
             viewController is InfoListViewController {
             switch menu.child {
             case .info:
-                // If the view model modal state has an Info.ViewModel and the just-shown view controller is an info list,
-                // then the user has popped the info view controller.
+                // If the current modal state is the menu with an Info child, and the just-shown view controller is
+                // an InfoList, then the user has popped the Info view controller.
                 dispatchAction(.dismissInfo)
             case .displayOptions:
+                // If the current modal state is the menu with a DisplayOptions child, and the just-shown view
+                // controller is an InfoList, then the user has popped the DisplayOptions view controller.
                 dispatchAction(.dismissDisplayOptions)
             default:
                 break

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -111,6 +111,7 @@ extension TokenScannerViewController: ModelBased {}
 extension TokenFormViewController: ModelBased {}
 extension InfoListViewController: ModelBased {}
 extension InfoViewController: ModelBased {}
+extension DisplayOptionsViewController: ModelBased {}
 
 private func reify<ViewController: ModelBasedViewController>(_ existingViewController: UIViewController?, viewModel: ViewController.ViewModel, dispatchAction: @escaping (ViewController.Action) -> Void) -> ViewController {
     if let viewController = existingViewController as? ViewController {
@@ -158,6 +159,14 @@ extension RootViewController {
                                   using: InfoViewController.self,
                                   actionTransform: Root.Action.infoEffect)
 
+            case .displayOptions(let displayOptionsViewModel):
+                presentViewModels(menuViewModel.infoList,
+                                  using: InfoListViewController.self,
+                                  actionTransform: Root.Action.infoListEffect,
+                                  and: displayOptionsViewModel,
+                                  using: DisplayOptionsViewController.self,
+                                  actionTransform: Root.Action.displayOptionsEffect)
+
             case .none:
                 presentViewModel(menuViewModel.infoList,
                                  using: InfoListViewController.self,
@@ -201,11 +210,17 @@ private func compose<A, B, C>(_ transform: @escaping (A) -> B, _ handler: @escap
 extension RootViewController: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if case .menu(let menu) = currentViewModel.modal,
-            case .info = menu.child,
             viewController is InfoListViewController {
-            // If the view model modal state has an Info.ViewModel and the just-shown view controller is an info list,
-            // then the user has popped the info view controller.
-            dispatchAction(.dismissInfo)
+            switch menu.child {
+            case .info:
+                // If the view model modal state has an Info.ViewModel and the just-shown view controller is an info list,
+                // then the user has popped the info view controller.
+                dispatchAction(.dismissInfo)
+            case .displayOptions:
+                dispatchAction(.dismissDisplayOptions)
+            default:
+                break
+            }
         }
     }
 }

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -148,17 +148,18 @@ extension RootViewController {
                              using: TokenFormViewController.self,
                              actionTransform: Root.Action.tokenEditFormAction)
 
-        case let .info(infoListViewModel, infoViewModel):
-            if let infoViewModel = infoViewModel {
-                presentViewModels(infoListViewModel,
+        case let .menu(menuViewModel):
+            switch menuViewModel.child {
+            case .info(let infoViewModel):
+                presentViewModels(menuViewModel.infoList,
                                   using: InfoListViewController.self,
                                   actionTransform: Root.Action.infoListEffect,
                                   and: infoViewModel,
                                   using: InfoViewController.self,
                                   actionTransform: Root.Action.infoEffect)
 
-            } else {
-                presentViewModel(infoListViewModel,
+            case .none:
+                presentViewModel(menuViewModel.infoList,
                                  using: InfoListViewController.self,
                                  actionTransform: Root.Action.infoListEffect)
             }
@@ -199,7 +200,8 @@ private func compose<A, B, C>(_ transform: @escaping (A) -> B, _ handler: @escap
 
 extension RootViewController: UINavigationControllerDelegate {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
-        if case .info(_, .some) = currentViewModel.modal,
+        if case .menu(let menu) = currentViewModel.modal,
+            case .info = menu.child,
             viewController is InfoListViewController {
             // If the view model modal state has an Info.ViewModel and the just-shown view controller is an info list,
             // then the user has popped the info view controller.

--- a/Authenticator/Source/RootViewModel.swift
+++ b/Authenticator/Source/RootViewModel.swift
@@ -2,7 +2,7 @@
 //  RootViewModel.swift
 //  Authenticator
 //
-//  Copyright (c) 2015-2017 Authenticator authors
+//  Copyright (c) 2015-2018 Authenticator authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Authenticator/Source/Settings.swift
+++ b/Authenticator/Source/Settings.swift
@@ -1,0 +1,29 @@
+//
+//  Settings.swift
+//  Authenticator
+//
+//  Copyright (c) 2018 Authenticator authors
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+final class Settings {
+    // TODO: Load from persistent storage.
+    var digitGroupSize = 2
+}

--- a/Authenticator/Source/Settings.swift
+++ b/Authenticator/Source/Settings.swift
@@ -23,7 +23,23 @@
 //  SOFTWARE.
 //
 
+import Foundation
+
+private let digitGroupSizeKey = "password.digitGroupSize"
+private let defaultDigitGroupSize = 2
+
 final class Settings {
-    // TODO: Load from persistent storage.
-    var digitGroupSize = 2
+    let userDefaults = UserDefaults.standard
+
+    var digitGroupSize: Int {
+        get {
+            guard userDefaults.object(forKey: digitGroupSizeKey) != nil else {
+                return defaultDigitGroupSize
+            }
+            return userDefaults.integer(forKey: digitGroupSizeKey)
+        }
+        set {
+            userDefaults.set(newValue, forKey: digitGroupSizeKey)
+        }
+    }
 }

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -2,7 +2,7 @@
 //  TokenFormViewController.swift
 //  Authenticator
 //
-//  Copyright (c) 2015-2017 Authenticator authors
+//  Copyright (c) 2015-2018 Authenticator authors
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal

--- a/Authenticator/Source/TokenFormViewController.swift
+++ b/Authenticator/Source/TokenFormViewController.swift
@@ -155,9 +155,9 @@ final class TokenFormViewController<Form: TableViewModelRepresentable>: UITableV
     // MARK: - UITableViewDelegate
 
     override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        // An apparent rendering error can occur when the form is scrolled programaticallty, causing a cell scrolled off
-        // of the screen to appear with a black background when scrolled back onto the screen. Setting the background
-        // color of the cell to the table view's background color, instead of to clearColor(), fixes the issue.
+        // An apparent rendering error can occur when the table view is scrolled programmatically, causing a cell
+        // scrolled off of the screen to appear with a black background when scrolled back onto the screen. Setting the
+        // background color of the cell to the table view's background color, instead of to `.clear`, fixes the issue.
         cell.backgroundColor = .otpBackgroundColor
         cell.selectionStyle = .none
 

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -35,10 +35,10 @@ struct TokenList: Component {
 
     typealias ViewModel = TokenListViewModel
 
-    func viewModel(with persistentTokens: [PersistentToken], at displayTime: DisplayTime) -> (viewModel: TokenListViewModel, nextRefreshTime: Date) {
+    func viewModel(with persistentTokens: [PersistentToken], at displayTime: DisplayTime, digitGroupSize: Int) -> (viewModel: TokenListViewModel, nextRefreshTime: Date) {
         let isFiltering = !(filter ?? "").isEmpty
         let rowModels = filteredTokens(from: persistentTokens).map({
-            TokenRowModel(persistentToken: $0, displayTime: displayTime, canReorder: !isFiltering)
+            TokenRowModel(persistentToken: $0, displayTime: displayTime, digitGroupSize: digitGroupSize, canReorder: !isFiltering)
         })
 
         let lastRefreshTime = persistentTokens.reduce(.distantPast) { (lastRefreshTime, persistentToken) in

--- a/Authenticator/Source/TokenList.swift
+++ b/Authenticator/Source/TokenList.swift
@@ -38,7 +38,10 @@ struct TokenList: Component {
     func viewModel(with persistentTokens: [PersistentToken], at displayTime: DisplayTime, digitGroupSize: Int) -> (viewModel: TokenListViewModel, nextRefreshTime: Date) {
         let isFiltering = !(filter ?? "").isEmpty
         let rowModels = filteredTokens(from: persistentTokens).map({
-            TokenRowModel(persistentToken: $0, displayTime: displayTime, digitGroupSize: digitGroupSize, canReorder: !isFiltering)
+            TokenRowModel(persistentToken: $0,
+                          displayTime: displayTime,
+                          digitGroupSize: digitGroupSize,
+                          canReorder: !isFiltering)
         })
 
         let lastRefreshTime = persistentTokens.reduce(.distantPast) { (lastRefreshTime, persistentToken) in

--- a/Authenticator/Source/TokenRowModel.swift
+++ b/Authenticator/Source/TokenRowModel.swift
@@ -39,12 +39,12 @@ struct TokenRowModel: Equatable, Identifiable {
 
     fileprivate let identifier: Data
 
-    init(persistentToken: PersistentToken, displayTime: DisplayTime, canReorder reorderable: Bool = true) {
+    init(persistentToken: PersistentToken, displayTime: DisplayTime, digitGroupSize: Int, canReorder reorderable: Bool = true) {
         let rawPassword = (try? persistentToken.token.generator.password(at: displayTime.date)) ?? ""
 
         name = persistentToken.token.name
         issuer = persistentToken.token.issuer
-        password = TokenRowModel.chunkPassword(rawPassword)
+        password = TokenRowModel.chunkPassword(rawPassword, chunkSize: digitGroupSize)
         if case .counter = persistentToken.token.generator.factor {
             showsButton = true
         } else {
@@ -63,9 +63,8 @@ struct TokenRowModel: Equatable, Identifiable {
     }
 
     // Group the password into chunks of two digits, separated by spaces.
-    private static func chunkPassword(_ password: String) -> String {
+    private static func chunkPassword(_ password: String, chunkSize: Int) -> String {
         var mutablePassword = password
-        let chunkSize = 2
         for i in stride(from: chunkSize, to: mutablePassword.count, by: chunkSize).reversed() {
             mutablePassword.insert(" ", at: mutablePassword.index(mutablePassword.startIndex, offsetBy: i))
         }

--- a/AuthenticatorTests/RootTests.swift
+++ b/AuthenticatorTests/RootTests.swift
@@ -204,8 +204,12 @@ class RootTests: XCTestCase {
     func testEventTokenFormSucceeded() {
         var root = Root(deviceCanScan: false)
 
+        func modalViewModel(from root: Root) -> RootViewModel.ModalViewModel {
+            return root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize).viewModel.modal
+        }
+
         // Ensure the initial view model has no modal.
-        guard case .none = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize).viewModel.modal else {
+        guard case .none = modalViewModel(from: root) else {
             XCTFail("The initial view model should have no modal.")
             return
         }
@@ -219,7 +223,7 @@ class RootTests: XCTestCase {
         }
 
         // Ensure the view model now has a modal entry form.
-        guard case .entryForm = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize).viewModel.modal else {
+        guard case .entryForm = modalViewModel(from: root) else {
             XCTFail("The view model should have a modal entry form.")
             return
         }
@@ -229,7 +233,7 @@ class RootTests: XCTestCase {
         XCTAssertNil(effect)
 
         // Ensure the token entry form hides on success.
-        guard case .none = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize).viewModel.modal else {
+        guard case .none = modalViewModel(from: root) else {
             XCTFail("The final view model should have no modal.")
             return
         }

--- a/AuthenticatorTests/RootTests.swift
+++ b/AuthenticatorTests/RootTests.swift
@@ -27,13 +27,14 @@ import XCTest
 @testable import Authenticator
 
 class RootTests: XCTestCase {
+    private let defaultDigitGroupSize = 2
     let displayTime = DisplayTime(date: Date())
 
     func testShowBackupInfo() {
         var root = Root(deviceCanScan: false)
 
         // Ensure there is no modal visible.
-        let (firstViewModel, _) = root.viewModel(with: [], at: displayTime)
+        let (firstViewModel, _) = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize)
         guard case .none = firstViewModel.modal else {
             XCTFail("Expected .none, got \(firstViewModel.modal)")
             return
@@ -51,12 +52,17 @@ class RootTests: XCTestCase {
         XCTAssertNil(showEffect)
 
         // Ensure the backup info modal is visible.
-        let (secondViewModel, _) = root.viewModel(with: [], at: displayTime)
+        let (secondViewModel, _) = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize)
         switch secondViewModel.modal {
-        case .info(_, .some(let infoViewModel)):
-            XCTAssert(infoViewModel.title == "Backups")
+        case .menu(let menu):
+            switch menu.child {
+            case .info(let infoViewModel):
+                XCTAssert(infoViewModel.title == "Backups")
+            default:
+                XCTFail("Expected Backups .info, got \(menu.child)")
+            }
         default:
-            XCTFail("Expected Backups .info, got \(secondViewModel.modal)")
+            XCTFail("Expected .menu, got \(secondViewModel.modal)")
         }
 
         // Hide the backup info.
@@ -71,7 +77,7 @@ class RootTests: XCTestCase {
         XCTAssertNil(hideEffect)
 
         // Ensure the backup info modal no longer visible.
-        let (thirdViewModel, _) = root.viewModel(with: [], at: displayTime)
+        let (thirdViewModel, _) = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize)
         guard case .none = thirdViewModel.modal else {
             XCTFail("Expected .none, got \(thirdViewModel.modal)")
             return
@@ -82,7 +88,7 @@ class RootTests: XCTestCase {
         var root = Root(deviceCanScan: false)
 
         // Ensure there is no modal visible.
-        let (firstViewModel, _) = root.viewModel(with: [], at: displayTime)
+        let (firstViewModel, _) = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize)
         guard case .none = firstViewModel.modal else {
             XCTFail("Expected .none, got \(firstViewModel.modal)")
             return
@@ -100,8 +106,8 @@ class RootTests: XCTestCase {
         XCTAssertNil(showInfoEffect)
 
         // Ensure the info list modal is visible.
-        let (nextViewModel, _) = root.viewModel(with: [], at: displayTime)
-        guard case .info(_, .none) = nextViewModel.modal else {
+        let (nextViewModel, _) = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize)
+        guard case .menu(let menu) = nextViewModel.modal, case .none = menu.child else {
             XCTFail("Expected .info list, got \(nextViewModel.modal)")
             return
         }
@@ -118,12 +124,17 @@ class RootTests: XCTestCase {
         XCTAssertNil(showEffect)
 
         // Ensure the license info modal is visible.
-        let (secondViewModel, _) = root.viewModel(with: [], at: displayTime)
+        let (secondViewModel, _) = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize)
         switch secondViewModel.modal {
-        case .info(_, .some(let infoViewModel)):
-            XCTAssert(infoViewModel.title == "Acknowledgements")
+        case .menu(let menu):
+            switch menu.child {
+            case .info(let infoViewModel):
+                XCTAssert(infoViewModel.title == "Acknowledgements")
+            default:
+                XCTFail("Expected Acknowledgements .info, got \(menu.child)")
+            }
         default:
-            XCTFail("Expected Acknowledgements .info, got \(secondViewModel.modal)")
+            XCTFail("Expected .menu, got \(secondViewModel.modal)")
         }
 
         // Hide the license info.
@@ -138,7 +149,7 @@ class RootTests: XCTestCase {
         XCTAssertNil(hideEffect)
 
         // Ensure the license info modal no longer visible.
-        let (thirdViewModel, _) = root.viewModel(with: [], at: displayTime)
+        let (thirdViewModel, _) = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize)
         guard case .none = thirdViewModel.modal else {
             XCTFail("Expected .none, got \(thirdViewModel.modal)")
             return
@@ -194,7 +205,7 @@ class RootTests: XCTestCase {
         var root = Root(deviceCanScan: false)
 
         // Ensure the initial view model has no modal.
-        guard case .none = root.viewModel(with: [], at: displayTime).viewModel.modal else {
+        guard case .none = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize).viewModel.modal else {
             XCTFail("The initial view model should have no modal.")
             return
         }
@@ -208,7 +219,7 @@ class RootTests: XCTestCase {
         }
 
         // Ensure the view model now has a modal entry form.
-        guard case .entryForm = root.viewModel(with: [], at: displayTime).viewModel.modal else {
+        guard case .entryForm = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize).viewModel.modal else {
             XCTFail("The view model should have a modal entry form.")
             return
         }
@@ -218,7 +229,7 @@ class RootTests: XCTestCase {
         XCTAssertNil(effect)
 
         // Ensure the token entry form hides on success.
-        guard case .none = root.viewModel(with: [], at: displayTime).viewModel.modal else {
+        guard case .none = root.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize).viewModel.modal else {
             XCTFail("The final view model should have no modal.")
             return
         }

--- a/AuthenticatorTests/TableDiffTests.swift
+++ b/AuthenticatorTests/TableDiffTests.swift
@@ -28,6 +28,8 @@ import XCTest
 @testable import Authenticator
 
 class TableDiffTests: XCTestCase {
+    private let defaultDigitGroupSize = 2
+
     func testNoChanges() {
         // swiftlint:disable force_unwrapping
         let generator = Generator(factor: .timer(period: 60),
@@ -44,13 +46,15 @@ class TableDiffTests: XCTestCase {
         let before = [
             TokenRowModel(
                 persistentToken: persistentToken,
-                displayTime: DisplayTime(date: date)
+                displayTime: DisplayTime(date: date),
+                digitGroupSize: defaultDigitGroupSize
             ),
         ]
         let after = [
             TokenRowModel(
                 persistentToken: persistentToken,
-                displayTime: DisplayTime(date: date)
+                displayTime: DisplayTime(date: date),
+                digitGroupSize: defaultDigitGroupSize
             ),
         ]
 

--- a/AuthenticatorTests/TokenListTests.swift
+++ b/AuthenticatorTests/TokenListTests.swift
@@ -28,6 +28,7 @@ import XCTest
 @testable import Authenticator
 
 class TokenListTests: XCTestCase {
+    private let defaultDigitGroupSize = 2
     let displayTime = DisplayTime(date: Date())
 
     func testFilterByIssuerAndName() {
@@ -39,7 +40,7 @@ class TokenListTests: XCTestCase {
         ])
         let effect = tokenList.update(with: .filter("goo"))
 
-        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime)
+        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime, digitGroupSize: defaultDigitGroupSize)
         let filteredIssuers = viewModel.rowModels.map { $0.issuer }
 
         XCTAssertNil(effect)
@@ -56,7 +57,7 @@ class TokenListTests: XCTestCase {
             ("Service", "username"),
         ])
         let effect = tokenList.update(with: .filter("Service"))
-        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime)
+        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime, digitGroupSize: defaultDigitGroupSize)
 
         XCTAssertNil(effect)
         XCTAssertTrue(viewModel.isFiltering)

--- a/AuthenticatorTests/TokenListTests.swift
+++ b/AuthenticatorTests/TokenListTests.swift
@@ -40,7 +40,9 @@ class TokenListTests: XCTestCase {
         ])
         let effect = tokenList.update(with: .filter("goo"))
 
-        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime, digitGroupSize: defaultDigitGroupSize)
+        let (viewModel, _) = tokenList.viewModel(with: persistentTokens,
+                                                 at: displayTime,
+                                                 digitGroupSize: defaultDigitGroupSize)
         let filteredIssuers = viewModel.rowModels.map { $0.issuer }
 
         XCTAssertNil(effect)
@@ -57,7 +59,9 @@ class TokenListTests: XCTestCase {
             ("Service", "username"),
         ])
         let effect = tokenList.update(with: .filter("Service"))
-        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime, digitGroupSize: defaultDigitGroupSize)
+        let (viewModel, _) = tokenList.viewModel(with: persistentTokens,
+                                                 at: displayTime,
+                                                 digitGroupSize: defaultDigitGroupSize)
 
         XCTAssertNil(effect)
         XCTAssertTrue(viewModel.isFiltering)

--- a/AuthenticatorTests/TokenListViewControllerTest.swift
+++ b/AuthenticatorTests/TokenListViewControllerTest.swift
@@ -28,6 +28,8 @@ import OneTimePassword
 @testable import Authenticator
 
 class TokenListViewControllerTest: XCTestCase {
+    private let defaultDigitGroupSize = 2
+
     let tokenList = TokenList()
     let displayTime = DisplayTime(date: Date())
 
@@ -38,7 +40,7 @@ class TokenListViewControllerTest: XCTestCase {
     }()
 
     func emptyListViewModel() -> TokenList.ViewModel {
-        return tokenList.viewModel(with: [], at: displayTime).viewModel
+        return tokenList.viewModel(with: [], at: displayTime, digitGroupSize: defaultDigitGroupSize).viewModel
     }
 
     // Test that inserting a new token will produce the expected changes to the table view.
@@ -53,7 +55,7 @@ class TokenListViewControllerTest: XCTestCase {
         let persistentTokens = mockPersistentTokens([
             ("Service", "email@example.com"),
         ])
-        let (updatedViewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime)
+        let (updatedViewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime, digitGroupSize: defaultDigitGroupSize)
         controller.update(with: updatedViewModel)
 
         // Check the table view.
@@ -70,7 +72,7 @@ class TokenListViewControllerTest: XCTestCase {
     func testUpdatesExistingToken() {
         // Set up a view controller with a mock table view.
         let initialPersistentToken = mockPersistentToken(name: "account@example.com", issuer: "Issuer")
-        let (initialTokenListViewModel, _) = tokenList.viewModel(with: [initialPersistentToken], at: displayTime)
+        let (initialTokenListViewModel, _) = tokenList.viewModel(with: [initialPersistentToken], at: displayTime, digitGroupSize: defaultDigitGroupSize)
         let controller = TokenListViewController(viewModel: initialTokenListViewModel, dispatchAction: { _ in })
         let tableView = MockTableView()
         controller.tableView = tableView
@@ -80,7 +82,7 @@ class TokenListViewControllerTest: XCTestCase {
 
         // Update the view controller.
         let updatedPersistentToken = initialPersistentToken.updated(with: mockToken(name: "name", issuer: "issuer"))
-        let (updatedTokenListViewModel, _) = tokenList.viewModel(with: [updatedPersistentToken], at: displayTime)
+        let (updatedTokenListViewModel, _) = tokenList.viewModel(with: [updatedPersistentToken], at: displayTime, digitGroupSize: defaultDigitGroupSize)
         controller.update(with: updatedTokenListViewModel)
 
         // Check the changes to the table view.
@@ -102,7 +104,7 @@ class TokenListViewControllerTest: XCTestCase {
             ("Service", "example@google.com"),
             ("Service", "username"),
         ])
-        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime)
+        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime, digitGroupSize: defaultDigitGroupSize)
         let controller = TokenListViewController(viewModel: viewModel, dispatchAction: { _ in })
 
         // Check that the table view contains the expected cells.

--- a/AuthenticatorTests/TokenListViewControllerTest.swift
+++ b/AuthenticatorTests/TokenListViewControllerTest.swift
@@ -55,7 +55,9 @@ class TokenListViewControllerTest: XCTestCase {
         let persistentTokens = mockPersistentTokens([
             ("Service", "email@example.com"),
         ])
-        let (updatedViewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime, digitGroupSize: defaultDigitGroupSize)
+        let (updatedViewModel, _) = tokenList.viewModel(with: persistentTokens,
+                                                        at: displayTime,
+                                                        digitGroupSize: defaultDigitGroupSize)
         controller.update(with: updatedViewModel)
 
         // Check the table view.
@@ -72,7 +74,9 @@ class TokenListViewControllerTest: XCTestCase {
     func testUpdatesExistingToken() {
         // Set up a view controller with a mock table view.
         let initialPersistentToken = mockPersistentToken(name: "account@example.com", issuer: "Issuer")
-        let (initialTokenListViewModel, _) = tokenList.viewModel(with: [initialPersistentToken], at: displayTime, digitGroupSize: defaultDigitGroupSize)
+        let (initialTokenListViewModel, _) = tokenList.viewModel(with: [initialPersistentToken],
+                                                                 at: displayTime,
+                                                                 digitGroupSize: defaultDigitGroupSize)
         let controller = TokenListViewController(viewModel: initialTokenListViewModel, dispatchAction: { _ in })
         let tableView = MockTableView()
         controller.tableView = tableView
@@ -82,7 +86,9 @@ class TokenListViewControllerTest: XCTestCase {
 
         // Update the view controller.
         let updatedPersistentToken = initialPersistentToken.updated(with: mockToken(name: "name", issuer: "issuer"))
-        let (updatedTokenListViewModel, _) = tokenList.viewModel(with: [updatedPersistentToken], at: displayTime, digitGroupSize: defaultDigitGroupSize)
+        let (updatedTokenListViewModel, _) = tokenList.viewModel(with: [updatedPersistentToken],
+                                                                 at: displayTime,
+                                                                 digitGroupSize: defaultDigitGroupSize)
         controller.update(with: updatedTokenListViewModel)
 
         // Check the changes to the table view.
@@ -104,7 +110,9 @@ class TokenListViewControllerTest: XCTestCase {
             ("Service", "example@google.com"),
             ("Service", "username"),
         ])
-        let (viewModel, _) = tokenList.viewModel(with: persistentTokens, at: displayTime, digitGroupSize: defaultDigitGroupSize)
+        let (viewModel, _) = tokenList.viewModel(with: persistentTokens,
+                                                 at: displayTime,
+                                                 digitGroupSize: defaultDigitGroupSize)
         let controller = TokenListViewController(viewModel: viewModel, dispatchAction: { _ in })
 
         // Check that the table view contains the expected cells.


### PR DESCRIPTION
**TL;DR:** This PR adds a settings screen that allows the user to choose whether they prefer passwords rendered in groups of two digits or groups of three.

----- 

This PR is the result of two separate issues I've been thinking about for a long time:
1. [Version 2.0](https://github.com/mattrubin/Authenticator/releases/tag/2.0.0) of the app changed how passwords are displayed: instead of showing the whole password as a single string of digits, the passwords are [chunked](https://en.wikipedia.org/wiki/Chunking_(psychology)) into two-digit groups to make them easier to read and remember. Since then, several users of the app [have reported](https://github.com/mattrubin/Authenticator/issues/214) that they have an easier time remembering six-digit passwords when they are chunked into groups of three digits. A [pull request](https://github.com/mattrubin/Authenticator/pull/216) from @beaucollins proposed to change the chunk size dynamically based on the length of the password, but despite the cleverness of this approach, it never quite felt like the right solution to me.
   I avoided making any changes on this for almost a year, for a very simple reason – I personally find it much easier to read and remember passwords chunked into groups of two, and the handful of users I had originally asked for input felt the same way. (At least one user wrote in an App Store review that the two-digit grouping is _the_ specific reason they use Authenticator over other two-factor apps.) I have been reluctant to make any changes when the current two-digit chunking strategy has been working for (anecdotally) most users.
2. As long as I have been developing Authenticator, I have tried to keep the app as simple as possible. I want the app to be clear and straightforward for users, and I didn't want to add a settings screen with a bunch of potentially-confusing options. In addition to complexity for users, adding user settings increases the number of different states in which the app operates, and can make testing and debugging significantly more complicated. For these reasons, I've avoided adding a settings screen to the app.

After thinking over the best way to present passwords that are readable and memorable for all users, I've concluded that the solution is to overcome my reluctance to add a settings screen to the app, and to add a toggle allowing the user to pick how they prefer for passwords to be grouped. Currently, the options are groups of two digits or groups of three digits. If I receive further user feedback on the issue, I will consider adding more options, but for now I want to keep things as simple as possible. While I think [the approach](https://github.com/mattrubin/Authenticator/pull/216) of changing the chunk size based on password length is aesthetically pleasing, I have found in my conversations with users that preferred chunk size for ease of memorization seems constant for a given person, regardless of password length.

I would love to hear what people think of this approach, and in particular to know whether this is is a satisfactory solution for those who prefer passwords in groups of three digits.


<img alt="Screenshot with passwords in groups of two digits" src="https://user-images.githubusercontent.com/532638/46041685-62a5ae80-c0e1-11e8-8ef4-dc9089facaf7.png" width="30%"> <img alt="Screenshot of settings screen with toggle for password grouping size" src="https://user-images.githubusercontent.com/532638/46041690-6802f900-c0e1-11e8-9b67-4df55f2b8d2c.png" width="30%"> <img alt="Screenshot with passwords in groups of three digits" src="https://user-images.githubusercontent.com/532638/46041698-6afde980-c0e1-11e8-8f79-f507cfabccee.png" width="30%">