### PR TITLE
Prepare for 2.1 beta release

### DIFF
--- a/Authenticator/Resources/Info.plist
+++ b/Authenticator/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.6</string>
+	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/AuthenticatorScreenshots/Info.plist
+++ b/AuthenticatorScreenshots/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.6</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 </dict>

--- a/AuthenticatorTests/Info.plist
+++ b/AuthenticatorTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.6</string>
+	<string>2.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 </dict>

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "fastlane", git: "https://github.com/fastlane/fastlane.git", ref: "9205800"
+gem "fastlane", "~> 2.105"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,32 @@
-GIT
-  remote: https://github.com/fastlane/fastlane.git
-  revision: 92058000312372f89072b9ebbada29cc56b8ce49
-  ref: 9205800
+GEM
+  remote: https://rubygems.org/
   specs:
-    fastlane (2.104.0)
+    CFPropertyList (3.0.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    atomos (0.1.3)
+    babosa (1.0.2)
+    claide (1.0.2)
+    colored (1.2)
+    colored2 (3.1.2)
+    commander-fastlane (4.4.6)
+      highline (~> 1.7.2)
+    declarative (0.0.10)
+    declarative-option (0.1.0)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.5.0)
+    emoji_regex (0.1.1)
+    excon (0.62.0)
+    faraday (0.15.3)
+      multipart-post (>= 1.2, < 3)
+    faraday-cookie_jar (0.0.6)
+      faraday (>= 0.7.4)
+      http-cookie (~> 1.0.0)
+    faraday_middleware (0.12.2)
+      faraday (>= 0.7.4, < 1.0)
+    fastimage (2.1.4)
+    fastlane (2.105.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -39,35 +62,6 @@ GIT
       xcodeproj (>= 1.6.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-
-GEM
-  remote: https://rubygems.org/
-  specs:
-    CFPropertyList (3.0.0)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    atomos (0.1.3)
-    babosa (1.0.2)
-    claide (1.0.2)
-    colored (1.2)
-    colored2 (3.1.2)
-    commander-fastlane (4.4.6)
-      highline (~> 1.7.2)
-    declarative (0.0.10)
-    declarative-option (0.1.0)
-    domain_name (0.5.20180417)
-      unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.5.0)
-    emoji_regex (0.1.1)
-    excon (0.62.0)
-    faraday (0.15.2)
-      multipart-post (>= 1.2, < 3)
-    faraday-cookie_jar (0.0.6)
-      faraday (>= 0.7.4)
-      http-cookie (~> 1.0.0)
-    faraday_middleware (0.12.2)
-      faraday (>= 0.7.4, < 1.0)
-    fastimage (2.1.4)
     gh_inspector (1.1.3)
     google-api-client (0.23.9)
       addressable (~> 2.5, >= 2.5.1)
@@ -111,7 +105,7 @@ GEM
     rouge (2.0.7)
     rubyzip (1.2.2)
     security (0.1.3)
-    signet (0.9.2)
+    signet (0.10.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
@@ -148,7 +142,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fastlane!
+  fastlane (~> 2.105)
 
 BUNDLED WITH
    1.16.4


### PR DESCRIPTION
Bump the version number and update the fastlane tools in anticipation of a beta release.