### PR TITLE
Dispatch AVCaptureDevice.requestAccess completion to the main queue

### DIFF
--- a/Authenticator/Source/QRScanner.swift
+++ b/Authenticator/Source/QRScanner.swift
@@ -99,7 +99,11 @@ class QRScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         guard !CommandLine.isDemo else {
             return
         }
-        AVCaptureDevice.requestAccess(for: .video, completionHandler: completionHandler)
+        AVCaptureDevice.requestAccess(for: .video) { accessGranted in
+            DispatchQueue.main.async {
+                completionHandler(accessGranted)
+            }
+        }
     }
 
     // MARK: AVCaptureMetadataOutputObjectsDelegate


### PR DESCRIPTION
This fixes a bug where the "needs permission" message would not appear correctly on the camera view immediately after the user denied access to the camera.

From the AVCaptureDevice.requestAccess documentation: 
> The completion handler is called on an arbitrary dispatch queue. It is the client's responsibility to ensure that any UIKit-related updates are called on the main queue or main thread as a result.