### PR TITLE
Refactor the Menu component

### DIFF
--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -83,7 +83,7 @@ struct Menu: Component {
     }
 
     enum Effect {
-        case done
+        case dismissMenu
         case showErrorMessage(String)
         case showSuccessMessage(String)
         case openURL(URL)
@@ -138,14 +138,14 @@ struct Menu: Component {
             return nil
 
         case .done:
-            return .done
+            return .dismissMenu
         }
     }
 
     private mutating func handleInfoEffect(_ effect: Info.Effect) -> Effect? {
         switch effect {
         case .done:
-            return .done
+            return .dismissMenu
         case let .openURL(url):
             return .openURL(url)
         }
@@ -154,7 +154,7 @@ struct Menu: Component {
     private mutating func handleDisplayOptionsEffect(_ effect: DisplayOptions.Effect) -> Effect? {
         switch effect {
         case .done:
-            return .done
+            return .dismissMenu
         case let .setDigitGroupSize(digitGroupSize):
             return .setDigitGroupSize(digitGroupSize)
         }

--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -56,6 +56,8 @@ struct Menu: Component {
         child = .info(info)
     }
 
+    // MARK: View
+
     func viewModel(digitGroupSize: Int) -> ViewModel {
         return ViewModel(infoList: infoList.viewModel, child: child.viewModel(digitGroupSize: digitGroupSize))
     }
@@ -71,7 +73,7 @@ struct Menu: Component {
         }
     }
 
-    // MARK: -
+    // MARK: Update
 
     enum Action {
         case dismissInfo
@@ -162,7 +164,7 @@ struct Menu: Component {
 
     // MARK: -
 
-    enum Error: Swift.Error {
+    private enum Error: Swift.Error {
         case badChildState
     }
 

--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -23,7 +23,7 @@
 //  SOFTWARE.
 //
 
-struct Menu {
+struct Menu: Component {
     let infoList: InfoList
     private(set) var child: Child
 
@@ -71,6 +71,25 @@ struct Menu {
 
     // MARK: -
 
+    enum Action {
+        case dismissInfo
+        case dismissDisplayOptions
+    }
+
+    typealias Effect = Never
+
+    mutating func update(with action: Action) throws -> Effect? {
+        switch action {
+        case .dismissInfo:
+            try dismissInfo()
+            return nil
+
+        case .dismissDisplayOptions:
+            try dismissDisplayOptions()
+            return nil
+        }
+    }
+
     enum Error: Swift.Error {
         case badChildState
     }
@@ -82,7 +101,7 @@ struct Menu {
         child = .info(info)
     }
 
-    mutating func dismissInfo() throws {
+    private mutating func dismissInfo() throws {
         guard case .info = child else {
             throw Error.badChildState
         }
@@ -96,7 +115,7 @@ struct Menu {
         child = .displayOptions(DisplayOptions())
     }
 
-    mutating func dismissDisplayOptions() throws {
+    private mutating func dismissDisplayOptions() throws {
         guard case .displayOptions = child else {
             throw Error.badChildState
         }

--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -114,7 +114,7 @@ struct Menu: Component {
     private mutating func handleInfoListEffect(_ effect: InfoList.Effect) throws -> Effect? {
         switch effect {
         case .showDisplayOptions:
-                try showDisplayOptions()
+            try showDisplayOptions()
             return nil
 
         case .showBackupInfo:

--- a/Authenticator/Source/Menu.swift
+++ b/Authenticator/Source/Menu.swift
@@ -26,10 +26,10 @@
 import Foundation
 
 struct Menu: Component {
-    let infoList: InfoList
-    private(set) var child: Child
+    private let infoList: InfoList
+    private var child: Child
 
-    enum Child {
+    private enum Child {
         case none
         case info(Info)
         case displayOptions(DisplayOptions)

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -90,10 +90,6 @@ extension Root {
         case tokenScannerAction(TokenScanner.Action)
         case menuAction(Menu.Action)
 
-        case infoListEffect(InfoList.Effect)
-        case infoEffect(Info.Effect)
-        case displayOptionsEffect(DisplayOptions.Effect)
-
         case addTokenFromURL(Token)
     }
 
@@ -165,15 +161,6 @@ extension Root {
                 return effect.flatMap { effect in
                     handleMenuEffect(effect)
                 }
-
-            case .infoListEffect(let effect):
-                return try handleInfoListEffect(effect)
-
-            case .infoEffect(let effect):
-                return handleInfoEffect(effect)
-
-            case .displayOptionsEffect(let effect):
-                return handleDisplayOptionsEffect(effect)
 
             case .addTokenFromURL(let token):
                 return .addToken(token,
@@ -316,67 +303,23 @@ extension Root {
         }
     }
 
-    private mutating func handleInfoListEffect(_ effect: InfoList.Effect) throws -> Effect? {
-        switch effect {
-        case .showDisplayOptions:
-            try modal.withMenu { menu in
-                try menu.showDisplayOptions()
-            }
-            return nil
-
-        case .showBackupInfo:
-            let backupInfo: Info
-            do {
-                backupInfo = try Info.backupInfo()
-            } catch {
-                return .showErrorMessage("Failed to load backup info.")
-            }
-            try modal.withMenu { menu in
-                try menu.showInfo(backupInfo)
-            }
-            return nil
-
-        case .showLicenseInfo:
-            let licenseInfo: Info
-            do {
-                licenseInfo = try Info.licenseInfo()
-            } catch {
-                return .showErrorMessage("Failed to load acknowledgements.")
-            }
-            try modal.withMenu { menu in
-                try menu.showInfo(licenseInfo)
-            }
-            return nil
-
-        case .done:
-            modal = .none
-            return nil
-
-        }
-    }
-
-    private mutating func handleInfoEffect(_ effect: Info.Effect) -> Effect? {
-        switch effect {
-        case .done:
-            modal = .none
-            return nil
-        case let .openURL(url):
-            return .openURL(url)
-        }
-    }
-
-    private mutating func handleDisplayOptionsEffect(_ effect: DisplayOptions.Effect) -> Effect? {
-        switch effect {
-        case .done:
-            modal = .none
-            return nil
-        case let .setDigitGroupSize(digitGroupSize):
-            return .setDigitGroupSize(digitGroupSize)
-        }
-    }
-
     private mutating func handleMenuEffect(_ effect: Menu.Effect) -> Effect? {
         switch effect {
+        case .done:
+            modal = .none
+            return nil
+
+        case let .showErrorMessage(message):
+            return .showErrorMessage(message)
+
+        case let .showSuccessMessage(message):
+            return .showSuccessMessage(message)
+
+        case let .openURL(url):
+            return .openURL(url)
+
+        case let .setDigitGroupSize(digitGroupSize):
+            return .setDigitGroupSize(digitGroupSize)
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -88,12 +88,11 @@ extension Root {
         case tokenEntryFormAction(TokenEntryForm.Action)
         case tokenEditFormAction(TokenEditForm.Action)
         case tokenScannerAction(TokenScanner.Action)
+        case menuAction(Menu.Action)
 
         case infoListEffect(InfoList.Effect)
         case infoEffect(Info.Effect)
         case displayOptionsEffect(DisplayOptions.Effect)
-        case dismissInfo
-        case dismissDisplayOptions
 
         case addTokenFromURL(Token)
     }
@@ -161,6 +160,12 @@ extension Root {
                     handleTokenScannerEffect(effect)
                 }
 
+            case .menuAction(let action):
+                let effect = try modal.withMenu { menu in try menu.update(with: action) }
+                return effect.flatMap { effect in
+                    handleMenuEffect(effect)
+                }
+
             case .infoListEffect(let effect):
                 return try handleInfoListEffect(effect)
 
@@ -169,18 +174,6 @@ extension Root {
 
             case .displayOptionsEffect(let effect):
                 return handleDisplayOptionsEffect(effect)
-
-            case .dismissInfo:
-                try modal.withMenu { menu in
-                    try menu.dismissInfo()
-                }
-                return nil
-
-            case .dismissDisplayOptions:
-                try modal.withMenu { menu in
-                    try menu.dismissDisplayOptions()
-                }
-                return nil
 
             case .addTokenFromURL(let token):
                 return .addToken(token,
@@ -379,6 +372,11 @@ extension Root {
             return nil
         case let .setDigitGroupSize(digitGroupSize):
             return .setDigitGroupSize(digitGroupSize)
+        }
+    }
+
+    private mutating func handleMenuEffect(_ effect: Menu.Effect) -> Effect? {
+        switch effect {
         }
     }
 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -157,7 +157,7 @@ extension Root {
                 }
 
             case .menuAction(let action):
-                let effect = try modal.withMenu { menu in try menu.update(with: action) }
+                let effect = try modal.withMenu({ menu in try menu.update(with: action) })
                 return effect.flatMap { effect in
                     handleMenuEffect(effect)
                 }

--- a/Authenticator/Source/Root.swift
+++ b/Authenticator/Source/Root.swift
@@ -305,7 +305,7 @@ extension Root {
 
     private mutating func handleMenuEffect(_ effect: Menu.Effect) -> Effect? {
         switch effect {
-        case .done:
+        case .dismissMenu:
             modal = .none
             return nil
 

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -155,23 +155,23 @@ extension RootViewController {
             case .info(let infoViewModel):
                 presentViewModels(menuViewModel.infoList,
                                   using: InfoListViewController.self,
-                                  actionTransform: Root.Action.infoListEffect,
+                                  actionTransform: compose(Menu.Action.infoListEffect, Root.Action.menuAction),
                                   and: infoViewModel,
                                   using: InfoViewController.self,
-                                  actionTransform: Root.Action.infoEffect)
+                                  actionTransform: compose(Menu.Action.infoEffect, Root.Action.menuAction))
 
             case .displayOptions(let displayOptionsViewModel):
                 presentViewModels(menuViewModel.infoList,
                                   using: InfoListViewController.self,
-                                  actionTransform: Root.Action.infoListEffect,
+                                  actionTransform: compose(Menu.Action.infoListEffect, Root.Action.menuAction),
                                   and: displayOptionsViewModel,
                                   using: DisplayOptionsViewController.self,
-                                  actionTransform: Root.Action.displayOptionsEffect)
+                                  actionTransform: compose(Menu.Action.displayOptionsEffect, Root.Action.menuAction))
 
             case .none:
                 presentViewModel(menuViewModel.infoList,
                                  using: InfoListViewController.self,
-                                 actionTransform: Root.Action.infoListEffect)
+                                 actionTransform: compose(Menu.Action.infoListEffect, Root.Action.menuAction))
             }
         }
         currentViewModel = viewModel

--- a/Authenticator/Source/RootViewController.swift
+++ b/Authenticator/Source/RootViewController.swift
@@ -216,11 +216,11 @@ extension RootViewController: UINavigationControllerDelegate {
             case .info:
                 // If the current modal state is the menu with an Info child, and the just-shown view controller is
                 // an InfoList, then the user has popped the Info view controller.
-                dispatchAction(.dismissInfo)
+                dispatchAction(.menuAction(.dismissInfo))
             case .displayOptions:
                 // If the current modal state is the menu with a DisplayOptions child, and the just-shown view
                 // controller is an InfoList, then the user has popped the DisplayOptions view controller.
-                dispatchAction(.dismissDisplayOptions)
+                dispatchAction(.menuAction(.dismissDisplayOptions))
             default:
                 break
             }

--- a/AuthenticatorTests/RootTests.swift
+++ b/AuthenticatorTests/RootTests.swift
@@ -66,7 +66,7 @@ class RootTests: XCTestCase {
         }
 
         // Hide the backup info.
-        let hideAction: Root.Action = .infoEffect(.done)
+        let hideAction: Root.Action = .menuAction(.infoEffect(.done))
         let hideEffect: Root.Effect?
         do {
             hideEffect = try root.update(with: hideAction)
@@ -113,7 +113,7 @@ class RootTests: XCTestCase {
         }
 
         // Show the license info.
-        let showAction: Root.Action = .infoListEffect(.showLicenseInfo)
+        let showAction: Root.Action = .menuAction(.infoListEffect(.showLicenseInfo))
         let showEffect: Root.Effect?
         do {
             showEffect = try root.update(with: showAction)
@@ -138,7 +138,7 @@ class RootTests: XCTestCase {
         }
 
         // Hide the license info.
-        let hideAction: Root.Action = .infoEffect(.done)
+        let hideAction: Root.Action = .menuAction(.infoEffect(.done))
         let hideEffect: Root.Effect?
         do {
             hideEffect = try root.update(with: hideAction)
@@ -164,9 +164,10 @@ class RootTests: XCTestCase {
             return
         }
 
-        let action: Root.Action = .infoEffect(.openURL(url))
+        let action: Root.Action = .menuAction(.infoEffect(.openURL(url)))
         let effect: Root.Effect?
         do {
+            XCTAssertNil(try root.update(with: .tokenListAction(.showBackupInfo)))
             effect = try root.update(with: action)
         } catch {
             XCTFail("Unexpected error: \(error)")


### PR DESCRIPTION
When the `Menu` [was added](https://github.com/mattrubin/Authenticator/pull/290), it was implemented as a simple wrapper around the mutable menu state. This PR encapsulates the menu state and actions into a true `Component`, simplifying the menu-related code in the `Root` component.