### PR TITLE
Release Authenticator 2.1.2

### DIFF
--- a/Authenticator/Resources/Info.plist
+++ b/Authenticator/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/AuthenticatorScreenshots/Info.plist
+++ b/AuthenticatorScreenshots/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 </dict>

--- a/AuthenticatorTests/Info.plist
+++ b/AuthenticatorTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>CFBundleVersion</key>
 	<string>0</string>
 </dict>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the project will be documented in this file.
 [Authenticator]: https://github.com/mattrubin/Authenticator
 
 
+## [2.1.2] - 2019-05-23
+By building the app with Xcode 10.1 instead of Xcode 10.2, this update fixes a crash that could occur when trying to manually enter a token on a 32-bit device (iPhone 5 or earlier).
+
+
 ## [2.1.1] - 2019-04-25
 For users on iOS 12.2 and above, the app binary size has been reduced by more than 85%.
 ([#307](https://github.com/mattrubin/Authenticator/pull/307))
@@ -125,7 +129,8 @@ For security reasons, tokens are stored only on one device, and are not included
 ## [1.0] - 2013-11-25
 
 
-[Unreleased]: https://github.com/mattrubin/Authenticator/compare/2.1.1...HEAD
+[Unreleased]: https://github.com/mattrubin/Authenticator/compare/2.1.2...HEAD
+[2.1.2]: https://github.com/mattrubin/Authenticator/compare/2.1.1...2.1.2
 [2.1.1]: https://github.com/mattrubin/Authenticator/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/mattrubin/Authenticator/compare/2.0.5...2.1.0
 [2.0.5]: https://github.com/mattrubin/Authenticator/compare/2.0.4...2.0.5

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2018 Authenticator authors
+Copyright (c) 2013-2019 Authenticator authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/fastlane/metadata/copyright.txt
+++ b/fastlane/metadata/copyright.txt
@@ -1,1 +1,1 @@
-2013-2018 Matt Rubin
+2013-2019 Matt Rubin

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,1 +1,1 @@
-For users on iOS 12.2 and above, the app binary size has been reduced by more than 85%.
+This update fixes a crash that could occur when trying to manually enter a token on a 32-bit device (iPhone 5 or earlier).


### PR DESCRIPTION
By building the app with Xcode 10.1 instead of Xcode 10.2, this update fixes a crash that could occur when trying to manually enter a token on a 32-bit device (iPhone 5 or earlier).