### PR TITLE
Implement Steam Guard code generation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Carthage/Checkouts/OneTimePassword"]
 	path = Carthage/Checkouts/OneTimePassword
-	url = https://github.com/mattrubin/OneTimePassword.git
+	url = https://github.com/bmwalters/OneTimePassword.git
 [submodule "Carthage/Checkouts/xcconfigs"]
 	path = Carthage/Checkouts/xcconfigs
 	url = https://github.com/jspahrsummers/xcconfigs.git

--- a/Authenticator/Source/TokenFormModels.swift
+++ b/Authenticator/Source/TokenFormModels.swift
@@ -47,7 +47,7 @@ enum TokenFormRowModel<Action>: Identifiable {
 }
 
 enum TokenType {
-    case counter, timer
+    case counter, timer, steamguard
 }
 
 extension TextFieldRowViewModel {
@@ -96,6 +96,7 @@ extension SegmentedControlRowViewModel {
         let options = [
             (title: "Time Based", value: TokenType.timer),
             (title: "Counter Based", value: TokenType.counter),
+            (title: "Steam Guard", value: TokenType.steamguard),
         ]
         self.init(options: options, value: value, changeAction: changeAction)
     }

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
 # Configuration for Carthage (https://github.com/Carthage/Carthage)
 
-github "mattrubin/OneTimePassword" ~> 3.1.4
+github "bmwalters/OneTimePassword" "feature/steamguard"
 github "SVProgressHUD/SVProgressHUD" ~> 2.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "SVProgressHUD/SVProgressHUD" "2.2.5"
+github "bmwalters/OneTimePassword" "d00dd01e81d89d0dafd4770e4d50141733007584"
 github "jspahrsummers/xcconfigs" "1.0"
 github "mattrubin/Base32" "1.1.2+xcode10.2"
-github "mattrubin/OneTimePassword" "3.1.5"
 github "shinydevelopment/SimulatorStatusMagic" "2.4.1"


### PR DESCRIPTION
Refer to https://github.com/mattrubin/OneTimePassword/pull/225

## Overview
- Adds a new token type option: "Steam Guard".
- Selecting the "Steam Guard" token type hides the algorithm and digit count controls, since there is only one set of valid parameters for generating Steam Guard tokens.
- Users are expected to figure out how to obtain their Steam Guard secret on their own.